### PR TITLE
add support for use of ~ in globs.

### DIFF
--- a/internal/glob/glob.go
+++ b/internal/glob/glob.go
@@ -54,6 +54,11 @@ func constructGlobMessages(globMessages []models.Message) []models.Message {
 }
 
 func parseGlob(glob string) ([]models.Message, error) {
+	home, err := os.UserHomeDir()
+	if err != nil && strings.Contains(glob, "~/") { // only fail if glob contains ~/ and home dir is not found
+		return nil, fmt.Errorf("failed to get home dir: %w", err)
+	}
+	glob = strings.Replace(glob, "~", home, 1)
 	files, err := filepath.Glob(glob)
 	ret := make([]models.Message, 0, len(files))
 	if err != nil {
@@ -64,9 +69,6 @@ func parseGlob(glob string) ([]models.Message, error) {
 	}
 
 	if len(files) == 0 {
-		if strings.Contains(glob, "~/") {
-			ancli.PrintWarn("found '~/', which wont work. Use absolute path '/home/<user>/'. Maybe I fix this some day, we'll see.\n")
-		}
 		return nil, fmt.Errorf("no files found")
 	}
 

--- a/internal/glob/glob_test.go
+++ b/internal/glob/glob_test.go
@@ -25,8 +25,13 @@ func TestParseGlob(t *testing.T) {
 		{"two files", fmt.Sprintf("%v/*.txt", tmpDir), 2, false},
 		{"no match", "*.log", 0, true},
 		{"invalid pattern", "[", 0, true},
+		{"home directory", "~/*.txt", 2, false}, // This test case will fail on windows and plan9
 	}
-
+	oldHome := os.Getenv("HOME")
+	_ = os.Setenv("HOME", tmpDir)
+	defer func() {
+		_ = os.Setenv("HOME", oldHome)
+	}()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := parseGlob(tt.glob)


### PR DESCRIPTION
wrt to error handling.

os.GetHomeDir() might fail but I only propagate this up if a tilde is found. No need to fail if we're not gonna use the result. 

This could have all been find inside an if, but I like to keep things shallow.