### PR TITLE
Feature/pipeline releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,3 +10,7 @@ jobs:
     uses: baalimago/simple-go-pipeline/.github/workflows/release.yml@releases
     with:
       go-version: '1.22'
+      owner: baalimago
+      project-name: clai
+      repository: clai
+      branch: master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-workflow:
-    uses: baalimago/simple-go-pipeline/.github/workflows/release.yml@v0.2.4
+    uses: baalimago/simple-go-pipeline/.github/workflows/release.yml@v0.2.5
     with:
       go-version: '1.22'
       project-name: clai

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,10 @@ on:
 
 jobs:
   call-workflow:
-    uses: baalimago/simple-go-pipeline/.github/workflows/release.yml@v0.2.3
+    uses: baalimago/simple-go-pipeline/.github/workflows/release.yml@v0.2.4
     with:
       go-version: '1.22'
       project-name: clai
       branch: main
+      version-var: "github.com/baalimago/clai/internal.BUILD_VERSION"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-workflow:
-    uses: baalimago/simple-go-pipeline/.github/workflows/release.yml@v0.2.2
+    uses: baalimago/simple-go-pipeline/.github/workflows/release.yml@v0.2.3
     with:
       go-version: '1.22'
       project-name: clai

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,5 +11,5 @@ jobs:
     with:
       go-version: '1.22'
       project-name: clai
-      branch: master
+      branch: main
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-workflow:
-    uses: baalimago/simple-go-pipeline/.github/workflows/release.yml@releases
+    uses: baalimago/simple-go-pipeline/.github/workflows/release.yml@v0.2.0
     with:
       go-version: '1.22'
       project-name: clai

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ jobs:
     uses: baalimago/simple-go-pipeline/.github/workflows/release.yml@releases
     with:
       go-version: '1.22'
-      owner: baalimago
       project-name: clai
-      repository: clai
       branch: master
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-workflow:
-    uses: baalimago/simple-go-pipeline/.github/workflows/release.yml@v0.2.0
+    uses: baalimago/simple-go-pipeline/.github/workflows/release.yml@v0.2.2
     with:
       go-version: '1.22'
       project-name: clai

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,12 @@
+name: Simple Go Pipeline - relesae
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  call-workflow:
+    uses: baalimago/simple-go-pipeline/.github/workflows/release.yml@releases
+    with:
+      go-version: '1.22'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: Simple Go Pipeline
+name: Simple Go Pipeline - validate
 
 on:
   push:
@@ -8,6 +8,6 @@ on:
 
 jobs:
   call-workflow:
-    uses: baalimago/simple-go-pipeline/.github/workflows/go.yml@main
+    uses: baalimago/simple-go-pipeline/.github/workflows/validate.yml@main
     with:
       go-version: '1.22'

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Most text and photo based models within the respective vendors are supported, se
 go install github.com/baalimago/clai@latest
 ```
 
+You may also use the setup script:
+```bash
+<LINK> | sh
+```
+
 Either look at `clai help` or the [examples](./EXAMPLES.md) for how to use `clai`.
 
 ## Honorable mentions

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ go install github.com/baalimago/clai@latest
 
 You may also use the setup script:
 ```bash
-<LINK> | sh
+curl -fsSL https://raw.githubusercontent.com/baalimago/clai/main/setup.sh | sh
 ```
 
 Either look at `clai help` or the [examples](./EXAMPLES.md) for how to use `clai`.

--- a/internal/setup.go
+++ b/internal/setup.go
@@ -176,7 +176,15 @@ func Setup(usage string) (models.Querier, error) {
 		if !ok {
 			return nil, errors.New("failed to read build info")
 		}
-		fmt.Printf("version: %v, go version: %v, checksum: %v\n", bi.Main.Version, bi.GoVersion, bi.Main.Sum)
+		version := bi.Main.Version
+		checksum := bi.Main.Sum
+		if version == "" || version == "(devel)" {
+			version = BUILD_VERSION
+		}
+		if checksum == "" {
+			checksum = BUILD_CHECKSUM
+		}
+		fmt.Printf("version: %v, go version: %v, checksum: %v\n", version, bi.GoVersion, checksum)
 		os.Exit(0)
 	case SETUP:
 		err := setup.Run()

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,5 +1,7 @@
 package internal
 
 // Set with buildflag if built in pipeline and not using go install
-var BUILD_VERSION = ""
-var BUILD_CHECKSUM = ""
+var (
+	BUILD_VERSION  = ""
+	BUILD_CHECKSUM = ""
+)

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,0 +1,5 @@
+package internal
+
+// Set with buildflag if built in pipeline and not using go install
+var BUILD_VERSION = ""
+var BUILD_CHECKSUM = ""

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Function to get the latest release download URL for the specified OS and architecture
 get_latest_release_url() {
@@ -16,14 +16,18 @@ get_latest_release_url() {
 }
 
 # Detect the OS
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-  os="linux"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-  os="darwin"
-else
-  echo "Unsupported OS: $OSTYPE"
-  exit 1
-fi
+case "$(uname)" in
+  Linux*)
+    os="linux"
+    ;;
+  Darwin*)
+    os="darwin"
+    ;;
+  *)
+    echo "Unsupported OS: $(uname)"
+    exit 1
+    ;;
+esac
 
 # Detect the architecture
 arch=$(uname -m)
@@ -46,7 +50,7 @@ case "$arch" in
     ;;
 esac
 
-printf "detected os: '$os', arch: '$arch'\n"
+printf "detected os: '%s', arch: '%s'\n" "$os" "$arch"
 
 # Get the download URL for the latest release
 printf "finding asset url..."

--- a/setup.sh
+++ b/setup.sh
@@ -38,7 +38,7 @@ case "$arch" in
   armv7*)
     arch="arm"
     ;;
-  aarch64)
+  aarch64|arm64)
     arch="arm64"
     ;;
   i?86)

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Function to get the latest release download URL for the specified OS and architecture
+get_latest_release_url() {
+  repo="baalimago/clai"
+  os="$1"
+  arch="$2"
+
+  # Fetch the latest release data from GitHub API
+  release_data=$(curl -s "https://api.github.com/repos/$repo/releases/latest")
+
+  # Extract the asset URL for the specified OS and architecture
+  download_url=$(echo "$release_data" | grep "browser_download_url" | grep "$os" | grep "$arch" | cut -d '"' -f 4)
+
+  echo "$download_url"
+}
+
+# Detect the OS
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  os="linux"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  os="darwin"
+else
+  echo "Unsupported OS: $OSTYPE"
+  exit 1
+fi
+
+# Detect the architecture
+arch=$(uname -m)
+case "$arch" in
+  x86_64)
+    arch="amd64"
+    ;;
+  armv7*)
+    arch="arm"
+    ;;
+  aarch64)
+    arch="arm64"
+    ;;
+  i?86)
+    arch="386"
+    ;;
+  *)
+    echo "Unsupported architecture: $arch"
+    exit 1
+    ;;
+esac
+
+printf "detected os: '$os', arch: '$arch'\n"
+
+# Get the download URL for the latest release
+printf "finding asset url..."
+download_url=$(get_latest_release_url "$os" "$arch")
+printf "OK!\n"
+
+# Download the binary
+tmp_file=$(mktemp)
+
+printf "downloading binary..."
+if ! curl -s -L -o "$tmp_file" "$download_url"; then
+  echo
+  echo "Failed to download the binary."
+  exit 1
+fi
+printf "OK!\n"
+
+printf "setting file executable file permissions..."
+# Make the binary executable
+
+if ! chmod +x "$tmp_file"; then
+  echo
+  echo "Failed to make the binary executable. Try running the script with sudo."
+  exit 1
+fi
+printf "OK!\n"
+
+# Move the binary to /usr/local/bin and handle permission errors
+if ! mv "$tmp_file" /usr/local/bin/clai; then
+  echo "Failed to move the binary to /usr/local/bin/clai, see error above. Try running the script with sudo, or run 'mv $tmp_file <desired-position>'."
+  exit 1
+fi
+
+echo "clai installed successfully in /usr/local/bin, try it out with 'clai h'"


### PR DESCRIPTION
* Introduced releases via pipeline
  * This is based on a new version of simple-go-pipeline
* `setup.sh` script which finds OS -> arch and finds release -> installs
* Updated `clai v/version` command to also print version set with ld flags