### PR TITLE
Bug/paralell calls chatgpt

### DIFF
--- a/internal/text/generic/stream_completer.go
+++ b/internal/text/generic/stream_completer.go
@@ -18,7 +18,7 @@ import (
 
 var dataPrefix = []byte("data: ")
 
-// // streamCompletions taking the messages as prompt conversation. Returns the messages from the chat model.
+// streamCompletions taking the messages as prompt conversation. Returns the messages from the chat model.
 func (s *StreamCompleter) StreamCompletions(ctx context.Context, chat models.Chat) (chan models.CompletionEvent, error) {
 	if s.Clean != nil {
 		cpy := make([]models.Message, len(chat.Messages))
@@ -56,6 +56,8 @@ func (s *StreamCompleter) createRequest(ctx context.Context, chat models.Chat) (
 		ResponseFormat:   responseFormat{Type: "text"},
 		Messages:         chat.Messages,
 		Stream:           true,
+		// No support for this yet since it's limited usecase and high complexity
+		ParalellToolCalls: false,
 	}
 	if len(s.tools) > 0 {
 		reqData.Tools = s.tools

--- a/internal/text/generic/stream_completer_models.go
+++ b/internal/text/generic/stream_completer_models.go
@@ -78,15 +78,16 @@ type responseFormat struct {
 }
 
 type req struct {
-	Model            string           `json:"model,omitempty"`
-	ResponseFormat   responseFormat   `json:"response_format,omitempty"`
-	Messages         []models.Message `json:"messages,omitempty"`
-	Stream           bool             `json:"stream,omitempty"`
-	FrequencyPenalty *float64         `json:"frequency_penalty,omitempty"`
-	MaxTokens        *int             `json:"max_tokens,omitempty"`
-	PresencePenalty  *float64         `json:"presence_penalty,omitempty"`
-	Temperature      *float64         `json:"temperature,omitempty"`
-	TopP             *float64         `json:"top_p,omitempty"`
-	ToolChoice       *string          `json:"tool_choice,omitempty"`
-	Tools            []ToolSuper      `json:"tools,omitempty"`
+	Model             string           `json:"model,omitempty"`
+	ResponseFormat    responseFormat   `json:"response_format,omitempty"`
+	Messages          []models.Message `json:"messages,omitempty"`
+	Stream            bool             `json:"stream,omitempty"`
+	FrequencyPenalty  *float64         `json:"frequency_penalty,omitempty"`
+	MaxTokens         *int             `json:"max_tokens,omitempty"`
+	PresencePenalty   *float64         `json:"presence_penalty,omitempty"`
+	Temperature       *float64         `json:"temperature,omitempty"`
+	TopP              *float64         `json:"top_p,omitempty"`
+	ToolChoice        *string          `json:"tool_choice,omitempty"`
+	Tools             []ToolSuper      `json:"tools,omitempty"`
+	ParalellToolCalls bool             `json:"parallel_tools_call,omitempty"`
 }

--- a/internal/text/querier.go
+++ b/internal/text/querier.go
@@ -222,6 +222,9 @@ func (q *Querier[C]) handleFunctionCall(ctx context.Context, call tools.Call) er
 		call.Type = "function"
 	}
 	if call.Function.Name == "" {
+		if call.Name == "" {
+			call.Name = "EMPTY-STRING"
+		}
 		call.Function.Name = call.Name
 	}
 	if call.Function.Arguments == "" {

--- a/internal/text/querier.go
+++ b/internal/text/querier.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/baalimago/clai/internal/models"
 	"github.com/baalimago/clai/internal/reply"
@@ -278,11 +279,16 @@ func (q *Querier[C]) handleFunctionCall(ctx context.Context, call tools.Call) er
 // shortenedOutput returns a shortened version of the output
 func shortenedOutput(out string) string {
 	maxTokens := 20
+	maxRunes := 100
 	outSplit := strings.Split(out, " ")
 	outNewlineSplit := strings.Split(out, "\n")
 	firstTokens := utils.GetFirstTokens(outSplit, maxTokens)
-	if len(firstTokens) < 20 && len(outNewlineSplit) < MAX_SHORTENED_NEWLINES {
+	amRunes := utf8.RuneCountInString(out)
+	if len(firstTokens) < maxTokens && len(outNewlineSplit) < MAX_SHORTENED_NEWLINES && amRunes < maxRunes {
 		return out
+	}
+	if amRunes > maxRunes {
+		return fmt.Sprintf("%v... and %v more runes", out[:maxRunes], amRunes-maxRunes)
 	}
 	firstTokensStr := strings.Join(firstTokens, " ")
 	amLeft := len(outSplit) - maxTokens

--- a/internal/text/querier_test.go
+++ b/internal/text/querier_test.go
@@ -349,9 +349,9 @@ func Test_ChatQuerier(t *testing.T) {
 func Test_shortenedOutput(t *testing.T) {
 	t.Run("it should shorten line with a lot of newlines", func(t *testing.T) {
 		given := ""
-		amNewlines := 1000
+		amNewlines := 90
 		for range amNewlines {
-			given += "word\n"
+			given += "\n"
 		}
 		gotStr := shortenedOutput(given)
 		got := strings.Count(gotStr, "\n")


### PR DESCRIPTION
Chatgpt sometimes attempted to do parallel calls, since it started having this turned on by default (fräscht). Fix is to disable it. Also some other minor fixes when it comes to function calling.