### PR TITLE
Reset functionJson after its been used once

### DIFF
--- a/internal/vendors/anthropic/claude_stream_block_events.go
+++ b/internal/vendors/anthropic/claude_stream_block_events.go
@@ -64,6 +64,7 @@ func (c *Claude) handleContentBlockStop(blockStop string) models.CompletionEvent
 		if err := json.Unmarshal([]byte(c.functionJson), &inputs); err != nil {
 			return fmt.Errorf("failed to unmarshal functionJson: %v, error is: %w", c.functionJson, err)
 		}
+		c.functionJson = ""
 		return tools.Call{
 			Name:   c.functionName,
 			Inputs: inputs,


### PR DESCRIPTION
Fixed an issue where multiple function calls in a row using streaming wouldn't work on claude