### PR TITLE
Bug - cmd with quotes doesnt work

### DIFF
--- a/internal/text/querier_cmd_mode.go
+++ b/internal/text/querier_cmd_mode.go
@@ -11,6 +11,9 @@ import (
 	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
 )
 
+var errFormat = "code: %v, stderr: '%v', stdout: '%v'\n"
+var okFormat = "stdout on new line:\n%v\n"
+
 func (q *Querier[C]) handleCmdMode() error {
 	// Tokens stream end without endline
 	fmt.Println()
@@ -23,27 +26,33 @@ func (q *Querier[C]) handleCmdMode() error {
 		case "q":
 			return nil
 		case "e":
-			return q.executeAiCmd()
+			out, err := q.executeAiCmd()
+			if err == nil {
+				ancli.PrintOK(fmt.Sprintf("%v\n", out))
+				return nil
+			} else {
+				return fmt.Errorf("failed to execute cmd: %v", err)
+			}
 		default:
 			ancli.PrintWarn(fmt.Sprintf("unrecognized command: %v, please try again\n", input))
 		}
 	}
 }
 
-func (q *Querier[C]) executeAiCmd() error {
+func (q *Querier[C]) executeAiCmd() (string, error) {
 	fullMsg, err := utils.ReplaceTildeWithHome(q.fullMsg)
 	if err != nil {
-		return fmt.Errorf("parseGlob, ReplaceTildeWithHome: %w", err)
+		return "", fmt.Errorf("parseGlob, ReplaceTildeWithHome: %w", err)
 	}
 	split := strings.Split(fullMsg, " ")
 	if len(split) < 1 {
-		return errors.New("Querier.executeAiCmd: too few tokens in q.fullMsg")
+		return "", errors.New("Querier.executeAiCmd: too few tokens in q.fullMsg")
 	}
 	cmd := split[0]
 	args := split[1:]
 
 	if len(cmd) == 0 {
-		return errors.New("Querier.executeAiCmd: command is empty")
+		return "", errors.New("Querier.executeAiCmd: command is empty")
 	}
 
 	command := exec.Command(cmd, args...)
@@ -58,13 +67,11 @@ func (q *Querier[C]) executeAiCmd() error {
 	if err != nil {
 		cast := &exec.ExitError{}
 		if errors.As(err, &cast) {
-			ancli.PrintErr(fmt.Sprintf("code: %v, stderr: '%v', stdout: '%v'\n", cast.ExitCode(), errStr, outStr))
-			return nil
+			return "", fmt.Errorf(errFormat, cast.ExitCode(), errStr, outStr)
 		} else {
-			return fmt.Errorf("Querier.executeAiCmd - run error: %w", err)
+			return "", fmt.Errorf("Querier.executeAiCmd - run error: %w", err)
 		}
 	}
 
-	ancli.PrintOK(fmt.Sprintf("stdout on new line:\n%v\n", outStr))
-	return nil
+	return fmt.Sprintf(okFormat, outStr), nil
 }

--- a/internal/text/querier_cmd_mode.go
+++ b/internal/text/querier_cmd_mode.go
@@ -45,6 +45,7 @@ func (q *Querier[C]) executeAiCmd() (string, error) {
 		return "", fmt.Errorf("parseGlob, ReplaceTildeWithHome: %w", err)
 	}
 	split := strings.Split(fullMsg, " ")
+	fmt.Println(split)
 	if len(split) < 1 {
 		return "", errors.New("Querier.executeAiCmd: too few tokens in q.fullMsg")
 	}

--- a/internal/text/querier_cmd_mode.go
+++ b/internal/text/querier_cmd_mode.go
@@ -26,7 +26,7 @@ func (q *Querier[C]) handleCmdMode() error {
 		case "q":
 			return nil
 		case "e":
-			out, err := q.executeAiCmd()
+			out, err := q.executeLlmCmd()
 			if err == nil {
 				ancli.PrintOK(fmt.Sprintf("%v\n", out))
 				return nil
@@ -39,13 +39,18 @@ func (q *Querier[C]) handleCmdMode() error {
 	}
 }
 
-func (q *Querier[C]) executeAiCmd() (string, error) {
+func (q *Querier[C]) executeLlmCmd() (string, error) {
 	fullMsg, err := utils.ReplaceTildeWithHome(q.fullMsg)
 	if err != nil {
 		return "", fmt.Errorf("parseGlob, ReplaceTildeWithHome: %w", err)
 	}
+	// Quotes are, in 99% of the time, expanded by the shell in
+	// different ways and then passed into the shell. So when LLM
+	// suggests a command, executeAiCmd needs to act the same (meaning)
+	// remove/expand the quotes
+	fullMsg = strings.ReplaceAll(fullMsg, "\"", "")
+	fullMsg = strings.ReplaceAll(fullMsg, "'", "")
 	split := strings.Split(fullMsg, " ")
-	fmt.Println(split)
 	if len(split) < 1 {
 		return "", errors.New("Querier.executeAiCmd: too few tokens in q.fullMsg")
 	}

--- a/internal/text/querier_cmd_mode.go
+++ b/internal/text/querier_cmd_mode.go
@@ -11,8 +11,10 @@ import (
 	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
 )
 
-var errFormat = "code: %v, stderr: '%v', stdout: '%v'\n"
-var okFormat = "stdout on new line:\n%v\n"
+var (
+	errFormat = "code: %v, stderr: '%v', stdout: '%v'\n"
+	okFormat  = "stdout on new line:\n%v\n"
+)
 
 func (q *Querier[C]) handleCmdMode() error {
 	// Tokens stream end without endline

--- a/internal/text/querier_cmd_mode_test.go
+++ b/internal/text/querier_cmd_mode_test.go
@@ -45,6 +45,16 @@ func Test_executeAiCmd(t *testing.T) {
 			want:    fmt.Sprintf(okFormat, "./testfile\n"),
 			wantErr: nil,
 		},
+		{
+			description: "it should work without quotes",
+			setup: func(t *testing.T) {
+				t.Helper()
+				os.Chdir(filepath.Dir(testboil.CreateTestFile(t, "testfile").Name()))
+			},
+			given:   "find ./ -name testfile",
+			want:    fmt.Sprintf(okFormat, "./testfile\n"),
+			wantErr: nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/text/querier_cmd_mode_test.go
+++ b/internal/text/querier_cmd_mode_test.go
@@ -32,7 +32,7 @@ func Test_executeAiCmd(t *testing.T) {
 		{
 			description: "it should run shell cmd",
 			given:       "printf 'test'",
-			want:        fmt.Sprintf(okFormat, "'test'"),
+			want:        fmt.Sprintf(okFormat, "test"),
 			wantErr:     nil,
 		},
 		{
@@ -64,7 +64,7 @@ func Test_executeAiCmd(t *testing.T) {
 				tc.setup(t)
 			}
 			q.fullMsg = tc.given
-			gotFormated, gotErr := q.executeAiCmd()
+			gotFormated, gotErr := q.executeLlmCmd()
 
 			if gotFormated != tc.want {
 				t.Fatalf("expected: %v, got: %v", tc.want, gotFormated)

--- a/internal/text/querier_cmd_mode_test.go
+++ b/internal/text/querier_cmd_mode_test.go
@@ -1,0 +1,68 @@
+package text
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/baalimago/clai/internal/models"
+	"github.com/baalimago/go_away_boilerplate/pkg/testboil"
+)
+
+type mockCompleter struct{}
+
+func (m mockCompleter) Setup() error {
+	return nil
+}
+
+func (m mockCompleter) StreamCompletions(ctx context.Context, c models.Chat) (chan models.CompletionEvent, error) {
+	return nil, nil
+}
+
+func Test_executeAiCmd(t *testing.T) {
+	testCases := []struct {
+		description string
+		setup       func(t *testing.T)
+		given       string
+		want        string
+		wantErr     error
+	}{
+		{
+			description: "it should run shell cmd",
+			given:       "printf 'test'",
+			want:        fmt.Sprintf(okFormat, "'test'"),
+			wantErr:     nil,
+		},
+		{
+			description: "it should work with quotes",
+			setup: func(t *testing.T) {
+				t.Helper()
+				os.Chdir(filepath.Dir(testboil.CreateTestFile(t, "testfile").Name()))
+			},
+			given:   "find ./ -name \"testfile\"",
+			want:    fmt.Sprintf(okFormat, "./testfile\n"),
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			q := Querier[mockCompleter]{}
+			if tc.setup != nil {
+				tc.setup(t)
+			}
+			q.fullMsg = tc.given
+			gotFormated, gotErr := q.executeAiCmd()
+
+			if gotFormated != tc.want {
+				t.Fatalf("expected: %v, got: %v", tc.want, gotFormated)
+			}
+
+			if gotErr != tc.wantErr {
+				t.Fatalf("expected error: %v, got: %v", tc.wantErr, gotErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The LLMs sometimes suggested commands which required [shell quoting](https://www.gnu.org/software/bash/manual/html_node/Quoting.html), which got escaped into commands that didn't act as the llm expected. 

Example:
LLM suggested: `find ./ -name "testfile"`, which will be executed as `find ./ -name \"testfile\"` since the quotes becomes escaped. 