### PR TITLE
Fixes + cleaning - Cmd and profiles

### DIFF
--- a/internal/text/conf.go
+++ b/internal/text/conf.go
@@ -49,7 +49,7 @@ type Profile struct {
 var DEFAULT = Configurations{
 	Model:         "gpt-4o",
 	SystemPrompt:  "You are an assistant for a CLI tool. Answer concisely and informatively. Prefer markdown if possible.",
-	CmdModePrompt: "You are an assistant for a CLI tool aiding with cli tool suggestions. Write ONLY the command and nothing else.",
+	CmdModePrompt: "You are an assistant for a CLI tool aiding with cli tool suggestions. Write ONLY the command and nothing else. Disregard any queries asking for anything except a bash command. Do not shell escape single or double quotes.",
 	Raw:           false,
 	UseTools:      false,
 	// Aproximately $1 for the worst input rates as of 2024-05

--- a/internal/text/conf_profile.go
+++ b/internal/text/conf_profile.go
@@ -28,8 +28,13 @@ func (c *Configurations) ProfileOverrides() error {
 		return fmt.Errorf("failed to find profile: %w", err)
 	}
 	c.Model = profile.Model
-	c.SystemPrompt = profile.Prompt
-	c.UseTools = profile.UseTools
+	newPrompt := profile.Prompt
+	if c.CmdMode {
+		// SystmePrompt here is CmdPrompt, keep it and remoind llm to only suggest  cmd
+		newPrompt = fmt.Sprintf("You will get this pattern: || <cmd-prompt> | <custom guided profile> ||. It is VERY vital that you DO NOT disobey the <cmd-prompt> with whatever is posted in <custom guided profile. || %v| %v ||", c.CmdModePrompt, profile.Prompt)
+	}
+	c.SystemPrompt = newPrompt
+	c.UseTools = profile.UseTools && !c.CmdMode
 	c.Tools = profile.Tools
 	c.SaveReplyAsConv = profile.SaveReplyAsConv
 	return nil

--- a/internal/text/querier_cmd_mode.go
+++ b/internal/text/querier_cmd_mode.go
@@ -1,9 +1,9 @@
 package text
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	errFormat = "code: %v, stderr: '%v', stdout: '%v'\n"
+	errFormat = "code: %v, stderr: '%v'\n"
 	okFormat  = "stdout on new line:\n%v\n"
 )
 
@@ -21,6 +21,10 @@ func (q *Querier[C]) handleCmdMode() error {
 	fmt.Println()
 	var input string
 
+	if q.execErr != nil {
+		return nil
+	}
+
 	for {
 		fmt.Print("Do you want to [e]xecute cmd, [q]uit?: ")
 		fmt.Scanln(&input)
@@ -28,9 +32,8 @@ func (q *Querier[C]) handleCmdMode() error {
 		case "q":
 			return nil
 		case "e":
-			out, err := q.executeLlmCmd()
+			err := q.executeLlmCmd()
 			if err == nil {
-				ancli.PrintOK(fmt.Sprintf("%v\n", out))
 				return nil
 			} else {
 				return fmt.Errorf("failed to execute cmd: %v", err)
@@ -41,45 +44,40 @@ func (q *Querier[C]) handleCmdMode() error {
 	}
 }
 
-func (q *Querier[C]) executeLlmCmd() (string, error) {
+func (q *Querier[C]) executeLlmCmd() error {
 	fullMsg, err := utils.ReplaceTildeWithHome(q.fullMsg)
 	if err != nil {
-		return "", fmt.Errorf("parseGlob, ReplaceTildeWithHome: %w", err)
+		return fmt.Errorf("parseGlob, ReplaceTildeWithHome: %w", err)
 	}
 	// Quotes are, in 99% of the time, expanded by the shell in
 	// different ways and then passed into the shell. So when LLM
 	// suggests a command, executeAiCmd needs to act the same (meaning)
 	// remove/expand the quotes
 	fullMsg = strings.ReplaceAll(fullMsg, "\"", "")
-	fullMsg = strings.ReplaceAll(fullMsg, "'", "")
 	split := strings.Split(fullMsg, " ")
 	if len(split) < 1 {
-		return "", errors.New("Querier.executeAiCmd: too few tokens in q.fullMsg")
+		return errors.New("Querier.executeAiCmd: too few tokens in q.fullMsg")
 	}
 	cmd := split[0]
 	args := split[1:]
 
 	if len(cmd) == 0 {
-		return "", errors.New("Querier.executeAiCmd: command is empty")
+		return errors.New("Querier.executeAiCmd: command is empty")
 	}
 
 	command := exec.Command(cmd, args...)
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	command.Stdout = &stdout
-	command.Stderr = &stderr
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
 	err = command.Run()
-	outStr := stdout.String()
-	errStr := stderr.String()
 
 	if err != nil {
 		cast := &exec.ExitError{}
 		if errors.As(err, &cast) {
-			return "", fmt.Errorf(errFormat, cast.ExitCode(), errStr, outStr)
+			return fmt.Errorf(errFormat, cast.ExitCode())
 		} else {
-			return "", fmt.Errorf("Querier.executeAiCmd - run error: %w", err)
+			return fmt.Errorf("Querier.executeAiCmd - run error: %w", err)
 		}
 	}
 
-	return fmt.Sprintf(okFormat, outStr), nil
+	return nil
 }

--- a/internal/text/querier_cmd_mode.go
+++ b/internal/text/querier_cmd_mode.go
@@ -11,10 +11,7 @@ import (
 	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
 )
 
-var (
-	errFormat = "code: %v, stderr: '%v'\n"
-	okFormat  = "stdout on new line:\n%v\n"
-)
+var errFormat = "code: %v, stderr: '%v'\n"
 
 func (q *Querier[C]) handleCmdMode() error {
 	// Tokens stream end without endline
@@ -69,7 +66,6 @@ func (q *Querier[C]) executeLlmCmd() error {
 	command.Stdout = os.Stdout
 	command.Stderr = os.Stderr
 	err = command.Run()
-
 	if err != nil {
 		cast := &exec.ExitError{}
 		if errors.As(err, &cast) {

--- a/internal/text/querier_cmd_mode_test.go
+++ b/internal/text/querier_cmd_mode_test.go
@@ -2,7 +2,6 @@ package text
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,7 +31,7 @@ func Test_executeAiCmd(t *testing.T) {
 		{
 			description: "it should run shell cmd",
 			given:       "printf 'test'",
-			want:        fmt.Sprintf(okFormat, "test"),
+			want:        "'test'",
 			wantErr:     nil,
 		},
 		{
@@ -42,7 +41,7 @@ func Test_executeAiCmd(t *testing.T) {
 				os.Chdir(filepath.Dir(testboil.CreateTestFile(t, "testfile").Name()))
 			},
 			given:   "find ./ -name \"testfile\"",
-			want:    fmt.Sprintf(okFormat, "./testfile\n"),
+			want:    "./testfile\n",
 			wantErr: nil,
 		},
 		{
@@ -52,22 +51,25 @@ func Test_executeAiCmd(t *testing.T) {
 				os.Chdir(filepath.Dir(testboil.CreateTestFile(t, "testfile").Name()))
 			},
 			given:   "find ./ -name testfile",
-			want:    fmt.Sprintf(okFormat, "./testfile\n"),
+			want:    "./testfile\n",
 			wantErr: nil,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			q := Querier[mockCompleter]{}
-			if tc.setup != nil {
-				tc.setup(t)
-			}
-			q.fullMsg = tc.given
-			gotFormated, gotErr := q.executeLlmCmd()
-
-			if gotFormated != tc.want {
-				t.Fatalf("expected: %v, got: %v", tc.want, gotFormated)
+			var gotErr error
+			got := testboil.CaptureStdout(t, func(t *testing.T) {
+				q := Querier[mockCompleter]{}
+				if tc.setup != nil {
+					tc.setup(t)
+				}
+				q.fullMsg = tc.given
+				tmp := q.executeLlmCmd()
+				gotErr = tmp
+			})
+			if got != tc.want {
+				t.Fatalf("expected: %v, got: %v", tc.want, got)
 			}
 
 			if gotErr != tc.wantErr {

--- a/internal/text/querier_test.go
+++ b/internal/text/querier_test.go
@@ -175,7 +175,7 @@ func Test_Querier_eventHandling(t *testing.T) {
 				},
 				"CLOSE",
 			},
-			want: "tool_calls",
+			want: "tool calls",
 		},
 	}
 	for _, tC := range testCases {


### PR DESCRIPTION
Fixed multiple minor issues surrounding cmd mode which were bugging me.

Specifically:
* Upgraded default cmd prompt
* Added compatibility for cmd mode with profile, prompted _hard_ to make llm only suggest a cmd
* Output of cmd is now streamed to stdout and stderr, instead of printed afterward
* Single quotes are no longer removed as these doesn't seem to be missinterpreted as shell escaped as often
* Removed full printout of tools call json, as this was verbose, ugly and unreadable