### PR TITLE
Improved row clearing to avoid the first raw row staying

### DIFF
--- a/internal/utils/print.go
+++ b/internal/utils/print.go
@@ -34,20 +34,24 @@ func countNewLines(msg string, termWidth int) int {
 // UpdateMessageTerminalMetadata updates the terminal metadata. Meaning the lineCount, to eventually
 // clear the terminal
 func UpdateMessageTerminalMetadata(msg string, line *string, lineCount *int, termWidth int) {
-	msgSplit := strings.Split(*line+msg, "\n")
+	newlineSplit := strings.Split(*line+msg, "\n")
 	amNewlines := 0
-	for _, line := range msgSplit {
+	for _, line := range newlineSplit {
 		amNewlines += countNewLines(line, termWidth)
 	}
-	if amNewlines == 0 {
-		amNewlines = 1
-	}
-	amNewlines += len(msgSplit) - 1
 
-	*lineCount += amNewlines
-	lastToken := msgSplit[len(msgSplit)-1]
-	if len(lastToken) > termWidth {
-		lastTokenWords := strings.Split(lastToken, " ")
+	amNewlineChars := len(newlineSplit)
+	if amNewlineChars == 1 {
+		amNewlineChars = 0
+	}
+
+	*lineCount += amNewlines + amNewlineChars
+	if *lineCount == 0 {
+		*lineCount = 1
+	}
+	lastNewline := newlineSplit[len(newlineSplit)-1]
+	if len(lastNewline) > termWidth {
+		lastTokenWords := strings.Split(lastNewline, " ")
 		lastWord := lastTokenWords[len(lastTokenWords)-1]
 		if len(lastWord) > termWidth {
 			trimmedWord := lastWord[termWidth:]
@@ -56,7 +60,7 @@ func UpdateMessageTerminalMetadata(msg string, line *string, lineCount *int, ter
 			*line = lastWord
 		}
 	} else {
-		*line = lastToken
+		*line = lastNewline
 	}
 }
 

--- a/internal/utils/print_test.go
+++ b/internal/utils/print_test.go
@@ -49,13 +49,31 @@ func TestUpdateMessageTerminalMetadata(t *testing.T) {
 			expectedLineCount: 1,
 		},
 		{
-			name:              "It should handle very large blocks of text lines",
-			msg:               "One oneone two twotwo threethree. Four four five five six\nSeven",
+			name:              "It should handle multiple termwidth overflows",
+			msg:               "1111 2222 3333 4444",
 			line:              "",
 			lineCount:         0,
-			termWidth:         10,
-			expectedLine:      "Seven",
-			expectedLineCount: 6,
+			termWidth:         5,
+			expectedLine:      "4444",
+			expectedLineCount: 3,
+		},
+		{
+			name:              "It should handle multiple termwidth overflows + newlines",
+			msg:               "1111 22\n3333 4444",
+			line:              "",
+			lineCount:         0,
+			termWidth:         5,
+			expectedLine:      "4444",
+			expectedLineCount: 4,
+		},
+		{
+			name:              "It should handle multiple termwidth overflows + newlines",
+			msg:               "11 22 33 44 55 66",
+			line:              "",
+			lineCount:         0,
+			termWidth:         3,
+			expectedLine:      "66",
+			expectedLineCount: 5,
 		},
 	}
 
@@ -72,6 +90,71 @@ func TestUpdateMessageTerminalMetadata(t *testing.T) {
 
 			if lineCount != tc.expectedLineCount {
 				t.Errorf("Expected lineCount: %d, got: %d", tc.expectedLineCount, lineCount)
+			}
+		})
+	}
+}
+
+func Test_countNewLines(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		given struct {
+			msg       string
+			termWidth int
+		}
+		want int
+	}{
+		{
+			desc: "it should count spaces when splitting into new lines",
+			given: struct {
+				msg       string
+				termWidth int
+			}{
+				msg:       "          ",
+				termWidth: 5,
+			},
+			want: 2,
+		},
+		{
+			desc: "it should count spaces when splitting into new lines, test 2",
+			given: struct {
+				msg       string
+				termWidth int
+			}{
+				msg:       "1 2 3 ",
+				termWidth: 2,
+			},
+			want: 3,
+		},
+		{
+			desc: "it should count spaces when splitting into new lines, test 3",
+			given: struct {
+				msg       string
+				termWidth int
+			}{
+				msg:       "1 2 3 4",
+				termWidth: 2,
+			},
+			want: 3,
+		},
+		{
+			desc: "it should sometimes treat space as newline, maybe",
+			given: struct {
+				msg       string
+				termWidth int
+			}{
+				msg:       "Hello World",
+				termWidth: 5,
+			},
+			want: 2,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			got := countNewLines(tC.given.msg, tC.given.termWidth)
+			want := tC.want
+			if got != want {
+				t.Fatalf("expected: %v, got: %v", want, got)
 			}
 		})
 	}


### PR DESCRIPTION
There was an annoying issue where the first row of raw content
sometimes would stick around. It's not perfect, and I'm too low
on brainjuice to figure out exactly what the issue is, but it should
be significantly better now.

 Changes:
* Implemented tests to more carefully detect the issue
* Fixed the issue