### PR TITLE
Stdin now appends as suffix even if no input flag

### DIFF
--- a/internal/utils/prompt.go
+++ b/internal/utils/prompt.go
@@ -51,6 +51,11 @@ func Prompt(stdinReplace string, args []string) (string, error) {
 		args = append(args, strings.Split(pipeIn, " ")...)
 	}
 
+	if stdinReplace == "" && hasPipe {
+		stdinReplace = "{}"
+		args = append(args, "{}")
+	}
+
 	// Replace all occurrence of stdinReplaceSignal with pipeIn
 	if stdinReplace != "" {
 		if debug {

--- a/internal/utils/prompt.go
+++ b/internal/utils/prompt.go
@@ -49,9 +49,7 @@ func Prompt(stdinReplace string, args []string) (string, error) {
 	// Add the pipeIn to the args if there are no args
 	if len(args) == 0 {
 		args = append(args, strings.Split(pipeIn, " ")...)
-	}
-
-	if stdinReplace == "" && hasPipe {
+	} else if stdinReplace == "" && hasPipe {
 		stdinReplace = "{}"
 		args = append(args, "{}")
 	}

--- a/internal/utils/prompt_test.go
+++ b/internal/utils/prompt_test.go
@@ -54,6 +54,14 @@ func TestPrompt(t *testing.T) {
 			expectedPrompt: "prefix input from stdin suffix",
 			expectedError:  false,
 		},
+		{
+			name:           "Arguments with stdinReplace",
+			stdinReplace:   "",
+			args:           []string{"cmd", "prefix", "suffix"},
+			stdin:          "input from stdin",
+			expectedPrompt: "prefix suffix input from stdin",
+			expectedError:  false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
I've aliased a lot of my clai commands behind profiles. For example: `alias pask="clai -p python-god query"` so 
that I can run `pask how do i do X` to quickly query a preprompted llm. But, I can't add an input flag in
these aliases, which is annoying. 

As there very rarely is a case where I add input to stdin which I _don't_ want to be used in the query,
this new system simply appends the stdin to the end of the query. Also works with conversations... sort of
use on your own risk.