### PR TITLE
Added support for editing config files with $EDITOR

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -24,6 +24,7 @@ const (
 	conf
 	del
 	newaction
+	confWithEditor
 )
 
 var ErrUserExit = errors.New("user exit")
@@ -38,6 +39,8 @@ func (a action) String() string {
 		return "[d]el"
 	case newaction:
 		return "create [n]ew"
+	case confWithEditor:
+		return "configure with [e]ditor"
 	default:
 		return "unset"
 	}
@@ -75,11 +78,11 @@ func Run() error {
 			return fmt.Errorf("failed to get configs files: %w", err)
 		}
 		configs = t
-		action, err := queryForAction([]action{conf, del})
+		qAct, err := queryForAction([]action{conf, del, confWithEditor})
 		if err != nil {
 			return fmt.Errorf("failed to find action: %w", err)
 		}
-		a = action
+		a = qAct
 	case "2":
 		profilesDir := filepath.Join(claiDir, "profiles")
 		t, err := getConfigs(filepath.Join(profilesDir, "*.json"), []string{})
@@ -87,11 +90,11 @@ func Run() error {
 			return fmt.Errorf("failed to get configs files: %w", err)
 		}
 		configs = t
-		action, err := queryForAction([]action{conf, del, newaction})
+		qAct, err := queryForAction([]action{conf, del, newaction, confWithEditor})
 		if err != nil {
 			return fmt.Errorf("failed to find action: %w", err)
 		}
-		a = action
+		a = qAct
 		if a == newaction {
 			c, err := createProFile(profilesDir)
 			if err != nil {


### PR DESCRIPTION
Although I applaud my own json editing skills, I found myself not reconfiguring
stuff since it was too tedious to do. I like vim, and don't want to use some adhoc solution.

So, now I've enabled typing `e` or `configureWithEditor` to reconfigure any config file with `$EDITOR`, along with 
the preexisting configurator.

Try it out with `clai s` -> `0/1/2` -> `e`