### PR TITLE
Fixed issue where lineclear sometimes would leave a line of raw text

### DIFF
--- a/internal/utils/print.go
+++ b/internal/utils/print.go
@@ -39,6 +39,9 @@ func UpdateMessageTerminalMetadata(msg string, line *string, lineCount *int, ter
 	for _, line := range newlineSplit {
 		amNewlines += countNewLines(line, termWidth)
 	}
+	if amNewlines == 1 {
+		amNewlines = 2
+	}
 
 	amNewlineChars := len(newlineSplit)
 	if amNewlineChars == 1 {

--- a/internal/utils/print_test.go
+++ b/internal/utils/print_test.go
@@ -75,6 +75,15 @@ func TestUpdateMessageTerminalMetadata(t *testing.T) {
 			expectedLine:      "66",
 			expectedLineCount: 5,
 		},
+		{
+			name: "it should not fail on this edge case that I found",
+			msg:  "Debugging involves systematically finding and resolving issues within your code or software. Start by identifying the problem, replicate the error, and use tools like breakpoints or logging to trace the source. Testing changes iteratively helps ensure the fix is successful and doesn't cause new issues.",
+			// This is not correct, but that's fine, the last line functionality isn't used anywhere anyways
+			expectedLine:      "issues.",
+			lineCount:         0,
+			termWidth:         223,
+			expectedLineCount: 2,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
The calculations for one-line output longer than the terminal width was not being calculated correctly when there was only one line of output.

The whole algorithm is ugly as hell also, silvertejp galore. But it works, and it's so annoying to debug it's good enough.