### PR TITLE
Pagination + input upgrades

### DIFF
--- a/internal/chat/chat.go
+++ b/internal/chat/chat.go
@@ -42,11 +42,11 @@ func Save(saveAt string, chat models.Chat) error {
 	return os.WriteFile(fileName, b, 0o644)
 }
 
-func IdFromPrompt(prompt string) string {
+func IDFromPrompt(prompt string) string {
 	id := strings.Join(utils.GetFirstTokens(strings.Split(prompt, " "), 5), "_")
 	// Slashes messes up the save path pretty bad
-	id = strings.Replace(id, "/", ".", -1)
+	id = strings.ReplaceAll(id, "/", ".")
 	// You're welcome, windows users. You're also weird.
-	id = strings.Replace(id, "\\", ".", -1)
+	id = strings.ReplaceAll(id, "\\", ".")
 	return id
 }

--- a/internal/reply/reply.go
+++ b/internal/reply/reply.go
@@ -29,7 +29,7 @@ func SaveAsPreviousQuery(claiConfDir string, msgs []models.Message) error {
 		}
 		convChat := models.Chat{
 			Created:  time.Now(),
-			ID:       chat.IdFromPrompt(firstUserMsg.Content),
+			ID:       chat.IDFromPrompt(firstUserMsg.Content),
 			Messages: msgs,
 		}
 		err = chat.Save(path.Join(claiConfDir, "conversations"), convChat)

--- a/internal/setup.go
+++ b/internal/setup.go
@@ -231,18 +231,14 @@ func Setup(usage string) (models.Querier, error) {
 	case SETUP:
 		err := setup.Run()
 		if err != nil {
-			if errors.Is(err, setup.ErrUserExit) {
-				ancli.PrintOK("user exit\n")
-				os.Exit(0)
-			}
-			return nil, fmt.Errorf("failed to run setup: %v", err)
+			return nil, fmt.Errorf("failed to run setup: %w", err)
 		}
 		os.Exit(0)
 		return nil, nil
 	case REPLAY:
 		err := reply.Replay(flagSet.PrintRaw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to replay previous reply: %v", err)
+			return nil, fmt.Errorf("failed to replay previous reply: %w", err)
 		}
 		os.Exit(0)
 	default:

--- a/internal/text/conf.go
+++ b/internal/text/conf.go
@@ -118,7 +118,7 @@ func (c *Configurations) SetupPrompts(args []string) error {
 	}
 	c.PostProccessedPrompt = prompt
 	if c.InitialPrompt.ID == "" {
-		c.InitialPrompt.ID = chat.IdFromPrompt(prompt)
+		c.InitialPrompt.ID = chat.IDFromPrompt(prompt)
 	}
 	return nil
 }

--- a/internal/text/querier_cmd_mode.go
+++ b/internal/text/querier_cmd_mode.go
@@ -16,7 +16,6 @@ var errFormat = "code: %v, stderr: '%v'\n"
 func (q *Querier[C]) handleCmdMode() error {
 	// Tokens stream end without endline
 	fmt.Println()
-	var input string
 
 	if q.execErr != nil {
 		return nil
@@ -24,7 +23,10 @@ func (q *Querier[C]) handleCmdMode() error {
 
 	for {
 		fmt.Print("Do you want to [e]xecute cmd, [q]uit?: ")
-		fmt.Scanln(&input)
+		input, err := utils.ReadUserInput()
+		if err != nil {
+			return err
+		}
 		switch strings.ToLower(input) {
 		case "q":
 			return nil

--- a/internal/utils/errors.go
+++ b/internal/utils/errors.go
@@ -1,0 +1,5 @@
+package utils
+
+import "errors"
+
+var ErrUserInitiatedExit = errors.New("user exit")

--- a/internal/utils/input.go
+++ b/internal/utils/input.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"slices"
+	"strings"
+)
+
+// ReadUserInput and return on interrupt channel
+func ReadUserInput() (string, error) {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	defer signal.Stop(sigChan)
+	inputChan := make(chan string)
+	errChan := make(chan error)
+
+	go func() {
+		reader := bufio.NewReader(os.Stdin)
+		userInput, err := reader.ReadString('\n')
+		if err != nil {
+			errChan <- err
+			return
+		}
+		inputChan <- userInput
+	}()
+
+	select {
+	case <-sigChan:
+		return "", ErrUserInitiatedExit
+	case err := <-errChan:
+		return "", fmt.Errorf("failed to read user input: %w", err)
+	case userInput, open := <-inputChan:
+		if open {
+			trimmedInput := strings.TrimSpace(userInput)
+			quitters := []string{"q", "quit", "e", "exit"}
+			if slices.Contains(quitters, trimmedInput) {
+				return "", ErrUserInitiatedExit
+			}
+			return trimmedInput, nil
+		} else {
+			return "", errors.New("user input channel closed. Not sure how we ended up here🤔")
+		}
+	}
+}


### PR DESCRIPTION
Although I'm a big fan of never looking back, it's sometimes necessary to retrospect.

You can now enter `p` or `prev` to go to the previous page, and thus paginate backwards and 
forth in the chat list.

Try it out with `clai chat list` -> `<enter>/n` -> `p/prev`

Changes + cleaning:
* Added amount of messages to chat list table
* Standardized user input in all places (I think)
* Misc cleaning wherever my lsp whined at me