### PR TITLE
feat: Added sed and rows_between tools

### DIFF
--- a/internal/tools/handler.go
+++ b/internal/tools/handler.go
@@ -13,6 +13,8 @@ var Tools = map[string]AiTool{
 	"go":               Go,
 	"write_file":       WriteFile,
 	"freetext_command": FreetextCmd,
+	"sed":              Sed,
+	"rows_between":     RowsBetween,
 }
 
 // Invoke the call, and gather both error and output in the same string

--- a/internal/tools/programming_tool_rows_between.go
+++ b/internal/tools/programming_tool_rows_between.go
@@ -1,0 +1,92 @@
+package tools
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type RowsBetweenTool UserFunction
+
+var RowsBetween = RowsBetweenTool{
+	Name:        "rows_between",
+	Description: "Fetch the lines between two line numbers (inclusive) from a file.",
+	Inputs: &InputSchema{
+		Type: "object",
+		Properties: map[string]ParameterObject{
+			"file_path": {
+				Type:        "string",
+				Description: "The path to the file to read.",
+			},
+			"start_line": {
+				Type:        "integer",
+				Description: "First line to include (1-based, inclusive).",
+			},
+			"end_line": {
+				Type:        "integer",
+				Description: "Last line to include (1-based, inclusive).",
+			},
+		},
+		Required: []string{"file_path", "start_line", "end_line"},
+	},
+}
+
+func (r RowsBetweenTool) Call(input Input) (string, error) {
+	filePath, ok := input["file_path"].(string)
+	if !ok {
+		return "", fmt.Errorf("file_path must be a string")
+	}
+	startLine, ok := input["start_line"].(int)
+	if !ok {
+		// Accept float64 (from JSON decoding)
+		if f, ok := input["start_line"].(float64); ok {
+			startLine = int(f)
+		} else if s, ok := input["start_line"].(string); ok {
+			startLine, _ = strconv.Atoi(s)
+		} else {
+			return "", fmt.Errorf("start_line must be an integer")
+		}
+	}
+	endLine, ok := input["end_line"].(int)
+	if !ok {
+		if f, ok := input["end_line"].(float64); ok {
+			endLine = int(f)
+		} else if s, ok := input["end_line"].(string); ok {
+			endLine, _ = strconv.Atoi(s)
+		} else {
+			return "", fmt.Errorf("end_line must be an integer")
+		}
+	}
+
+	if startLine <= 0 || endLine < startLine {
+		return "", fmt.Errorf("invalid line range")
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	for i := 1; scanner.Scan(); i++ {
+		if i >= startLine && i <= endLine {
+			lines = append(lines, scanner.Text())
+		}
+		if i > endLine {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("failed to scan file: %w", err)
+	}
+
+	return strings.Join(lines, "\n"), nil
+}
+
+func (r RowsBetweenTool) UserFunction() UserFunction {
+	return UserFunction(RowsBetween)
+}

--- a/internal/tools/programming_tool_rows_between_test.go
+++ b/internal/tools/programming_tool_rows_between_test.go
@@ -1,0 +1,60 @@
+package tools
+
+import (
+	"os"
+	"testing"
+)
+
+func TestRowsBetweenTool_Call(t *testing.T) {
+	const fileName = "test_rows_between.txt"
+	initial := "one\ntwo\nthree\nfour\nfive\n"
+	err := os.WriteFile(fileName, []byte(initial), 0o644)
+	if err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+	defer os.Remove(fileName)
+
+	cases := []struct {
+		start, end int
+		expected   string
+	}{
+		{1, 3, "one\ntwo\nthree"},
+		{2, 4, "two\nthree\nfour"},
+		{4, 5, "four\nfive"},
+		{3, 3, "three"},
+	}
+
+	for _, tc := range cases {
+		got, err := RowsBetween.Call(Input{
+			"file_path":  fileName,
+			"start_line": tc.start,
+			"end_line":   tc.end,
+		})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if got != tc.expected {
+			t.Errorf("unexpected output: got %q want %q (start=%d, end=%d)", got, tc.expected, tc.start, tc.end)
+		}
+	}
+}
+
+func TestRowsBetweenTool_BadInputs(t *testing.T) {
+	_, err := RowsBetween.Call(Input{"file_path": "nonexistent.txt", "start_line": 1, "end_line": 3})
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+
+	_, err = RowsBetween.Call(Input{"file_path": "", "start_line": 1, "end_line": 3})
+	if err == nil {
+		t.Error("expected error for missing file_path")
+	}
+	_, err = RowsBetween.Call(Input{"file_path": "test_rows_between.txt", "start_line": -2, "end_line": 3})
+	if err == nil {
+		t.Error("expected error for bad start_line")
+	}
+	_, err = RowsBetween.Call(Input{"file_path": "test_rows_between.txt", "start_line": 4, "end_line": 2})
+	if err == nil {
+		t.Error("expected error for inverted lines")
+	}
+}

--- a/internal/tools/programming_tool_sed.go
+++ b/internal/tools/programming_tool_sed.go
@@ -1,0 +1,111 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type SedTool UserFunction
+
+var Sed = SedTool{
+	Name:        "sed",
+	Description: "Perform a basic regex substitution on each line or within a specific line range of a file (like 'sed s/pattern/repl/g'). Overwrites the file.",
+	Inputs: &InputSchema{
+		Type: "object",
+		Properties: map[string]ParameterObject{
+			"file_path": {
+				Type:        "string",
+				Description: "The path to the file to modify.",
+			},
+			"pattern": {
+				Type:        "string",
+				Description: "The regex pattern to search for.",
+			},
+			"repl": {
+				Type:        "string",
+				Description: "The replacement string.",
+			},
+			"start_line": {
+				Type:        "integer",
+				Description: "Optional. First line to modify (1-based, inclusive).",
+			},
+			"end_line": {
+				Type:        "integer",
+				Description: "Optional. Last line to modify (1-based, inclusive).",
+			},
+		},
+		Required: []string{"file_path", "pattern", "repl"},
+	},
+}
+
+func (s SedTool) Call(input Input) (string, error) {
+	filePath, ok := input["file_path"].(string)
+	if !ok {
+		return "", fmt.Errorf("file_path must be a string")
+	}
+	pattern, ok := input["pattern"].(string)
+	if !ok {
+		return "", fmt.Errorf("pattern must be a string")
+	}
+	repl, ok := input["repl"].(string)
+	if !ok {
+		return "", fmt.Errorf("repl must be a string")
+	}
+
+	var startLine, endLine int
+	if v, ok := input["start_line"]; ok {
+		switch n := v.(type) {
+		case float64:
+			startLine = int(n)
+		case int:
+			startLine = n
+		case string:
+			startLine, _ = strconv.Atoi(n)
+		}
+	}
+	if v, ok := input["end_line"]; ok {
+		switch n := v.(type) {
+		case float64:
+			endLine = int(n)
+		case int:
+			endLine = n
+		case string:
+			endLine, _ = strconv.Atoi(n)
+		}
+	}
+
+	raw, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file: %w", err)
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", fmt.Errorf("invalid regex: %w", err)
+	}
+
+	lines := strings.Split(string(raw), "\n")
+	for i := range lines {
+		lineNum := i + 1
+		if (startLine == 0 && endLine == 0) ||
+			(startLine > 0 && endLine > 0 && lineNum >= startLine && lineNum <= endLine) ||
+			(startLine > 0 && endLine == 0 && lineNum >= startLine) ||
+			(startLine == 0 && endLine > 0 && lineNum <= endLine) {
+			lines[i] = re.ReplaceAllString(lines[i], repl)
+		}
+	}
+
+	out := strings.Join(lines, "\n")
+	err = os.WriteFile(filePath, []byte(out), 0o644)
+	if err != nil {
+		return "", fmt.Errorf("failed to write file: %w", err)
+	}
+	return fmt.Sprintf("sed: replaced occurrences of %q with %q in %s (%d-%d)", pattern, repl, filePath, startLine, endLine), nil
+}
+
+func (s SedTool) UserFunction() UserFunction {
+	return UserFunction(Sed)
+}

--- a/internal/tools/programming_tool_sed_test.go
+++ b/internal/tools/programming_tool_sed_test.go
@@ -1,0 +1,66 @@
+package tools
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSedTool_Call(t *testing.T) {
+	const fileName = "test_sed.txt"
+	initial := "apple\nbanana\napple pie\n"
+	err := os.WriteFile(fileName, []byte(initial), 0o644)
+	if err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+	defer os.Remove(fileName)
+
+	_, err = Sed.Call(Input{
+		"file_path": fileName,
+		"pattern":   "apple",
+		"repl":      "orange",
+	})
+	if err != nil {
+		t.Fatalf("sed failed: %v", err)
+	}
+
+	result, err := os.ReadFile(fileName)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+
+	expected := "orange\nbanana\norange pie\n"
+	if string(result) != expected {
+		t.Errorf("unexpected output: got\n%q\nwant\n%q", string(result), expected)
+	}
+}
+
+func TestSedTool_Range(t *testing.T) {
+	const fileName = "test_sed_range.txt"
+	initial := "foo\nfoo\nfoo\nfoo\n"
+	err := os.WriteFile(fileName, []byte(initial), 0o644)
+	if err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+	defer os.Remove(fileName)
+
+	_, err = Sed.Call(Input{
+		"file_path":  fileName,
+		"pattern":    "foo",
+		"repl":       "bar",
+		"start_line": 2,
+		"end_line":   3,
+	})
+	if err != nil {
+		t.Fatalf("sed with range failed: %v", err)
+	}
+
+	result, err := os.ReadFile(fileName)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+
+	expected := "foo\nbar\nbar\nfoo\n"
+	if string(result) != expected {
+		t.Errorf("unexpected output: got\n%q\nwant\n%q", string(result), expected)
+	}
+}


### PR DESCRIPTION
With these the llms should be able to be more specific changes at lower costs, especially in big files. Will mesh well with LSP based tooling that specify the rows of some specific function, for instance

These were entirely written by gpt 4.1 using `write_file` tool and `go` tool to test the behaviour. The new tools themselves
were tested e2e by running:

`go run . -re -p gopher q Alright youre now running the code. Try the new sed and rows between tools out by modifying the readme at row 50, read the change, then revert the change`

and checking inspecting the changes.