### PR TITLE
feat: Add line_count tool

### DIFF
--- a/internal/tools/handler.go
+++ b/internal/tools/handler.go
@@ -15,6 +15,7 @@ var Tools = map[string]AiTool{
 	"freetext_command": FreetextCmd,
 	"sed":              Sed,
 	"rows_between":     RowsBetween,
+	"line_count":       LineCount,
 }
 
 // Invoke the call, and gather both error and output in the same string

--- a/internal/tools/programming_tool_line_count.go
+++ b/internal/tools/programming_tool_line_count.go
@@ -1,0 +1,50 @@
+package tools
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+type LineCountTool UserFunction
+
+var LineCount = LineCountTool{
+	Name:        "line_count",
+	Description: "Count the number of lines in a file.",
+	Inputs: &InputSchema{
+		Type: "object",
+		Properties: map[string]ParameterObject{
+			"file_path": {
+				Type:        "string",
+				Description: "The path to the file to count lines of.",
+			},
+		},
+		Required: []string{"file_path"},
+	},
+}
+
+func (l LineCountTool) Call(input Input) (string, error) {
+	filePath, ok := input["file_path"].(string)
+	if !ok {
+		return "", fmt.Errorf("file_path must be a string")
+	}
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	count := 0
+	for scanner.Scan() {
+		count++
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("failed to read file: %w", err)
+	}
+	return fmt.Sprintf("%d", count), nil
+}
+
+func (l LineCountTool) UserFunction() UserFunction {
+	return UserFunction(LineCount)
+}

--- a/internal/tools/programming_tool_line_count_test.go
+++ b/internal/tools/programming_tool_line_count_test.go
@@ -1,0 +1,32 @@
+package tools
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLineCountTool_Call(t *testing.T) {
+	const fileName = "test_line_count.txt"
+	content := "one\ntwo\nthree\n"
+	if err := os.WriteFile(fileName, []byte(content), 0o644); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+	defer os.Remove(fileName)
+
+	out, err := LineCount.Call(Input{"file_path": fileName})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "3" {
+		t.Errorf("unexpected output: got %q want \"3\"", out)
+	}
+}
+
+func TestLineCountTool_BadInputs(t *testing.T) {
+	if _, err := LineCount.Call(Input{"file_path": 123}); err == nil {
+		t.Error("expected error for bad file_path type")
+	}
+	if _, err := LineCount.Call(Input{"file_path": "no_such_file.txt"}); err == nil {
+		t.Error("expected error for missing file")
+	}
+}


### PR DESCRIPTION
A simple tool which counts the amount of lines in a file. The usecase for this is to instruct the llm to first
check how large a file is before running `cat`, since if it attempts to send a very large file it'll both be 
costly and eat up the context