### PR TITLE
feat: Add output size limit and disclaimer

### DIFF
--- a/internal/text/conf.go
+++ b/internal/text/conf.go
@@ -16,23 +16,26 @@ import (
 
 // Configurations used to setup the requirements of text models
 type Configurations struct {
-	Model           string      `json:"model"`
-	SystemPrompt    string      `json:"system-prompt"`
-	CmdModePrompt   string      `json:"cmd-mode-prompt"`
-	Raw             bool        `json:"raw"`
-	UseTools        bool        `json:"use-tools"`
-	TokenWarnLimit  int         `json:"token-warn-limit"`
-	SaveReplyAsConv bool        `json:"save-reply-as-prompt"`
-	ConfigDir       string      `json:"-"`
-	StdinReplace    string      `json:"-"`
-	Stream          bool        `json:"-"`
-	ReplyMode       bool        `json:"-"`
-	ChatMode        bool        `json:"-"`
-	CmdMode         bool        `json:"-"`
-	Glob            string      `json:"-"`
-	InitialPrompt   models.Chat `json:"-"`
-	UseProfile      string      `json:"-"`
-	Tools           []string    `json:"-"`
+	Model          string `json:"model"`
+	SystemPrompt   string `json:"system-prompt"`
+	CmdModePrompt  string `json:"cmd-mode-prompt"`
+	Raw            bool   `json:"raw"`
+	UseTools       bool   `json:"use-tools"`
+	TokenWarnLimit int    `json:"token-warn-limit"`
+	// ToolOutputRuneLimit limits the amount of runes a tool may return
+	// before clai truncates the output. Zero means no limit.
+	ToolOutputRuneLimit int         `json:"tool-output-rune-limit"`
+	SaveReplyAsConv     bool        `json:"save-reply-as-prompt"`
+	ConfigDir           string      `json:"-"`
+	StdinReplace        string      `json:"-"`
+	Stream              bool        `json:"-"`
+	ReplyMode           bool        `json:"-"`
+	ChatMode            bool        `json:"-"`
+	CmdMode             bool        `json:"-"`
+	Glob                string      `json:"-"`
+	InitialPrompt       models.Chat `json:"-"`
+	UseProfile          string      `json:"-"`
+	Tools               []string    `json:"-"`
 	// PostProccessedPrompt which has had it's strings replaced etc
 	PostProccessedPrompt string `json:"-"`
 }
@@ -54,8 +57,9 @@ var DEFAULT = Configurations{
 	Raw:           false,
 	UseTools:      false,
 	// Aproximately $1 for the worst input rates as of 2024-05
-	TokenWarnLimit:  17000,
-	SaveReplyAsConv: true,
+	TokenWarnLimit:      17000,
+	ToolOutputRuneLimit: 21600,
+	SaveReplyAsConv:     true,
 }
 
 var DEFAULT_PROFILE = Profile{

--- a/internal/text/querier.go
+++ b/internal/text/querier.go
@@ -22,6 +22,7 @@ import (
 const (
 	TOKEN_COUNT_FACTOR     = 1.1
 	MAX_SHORTENED_NEWLINES = 5
+	TOOL_OUTPUT_DISCLAIMER = "\n\noutput too large, concentrate your tool call"
 )
 
 type Querier[C models.StreamCompleter] struct {
@@ -40,6 +41,7 @@ type Querier[C models.StreamCompleter] struct {
 	hasPrinted              bool
 	Model                   C
 	tokenWarnLimit          int
+	toolOutputRuneLimit     int
 	cmdMode                 bool
 	execErr                 error
 }
@@ -302,6 +304,7 @@ func (q *Querier[C]) handleFunctionCall(ctx context.Context, call tools.Call) er
 	q.chat.Messages = append(q.chat.Messages, assistantToolsCall)
 
 	out := tools.Invoke(call)
+	out = limitToolOutput(out, q.toolOutputRuneLimit)
 	// Chatgpt doesn't like responses which yield no output, even if they're valid (ls on empty dir)
 	if out == "" {
 		out = "<EMPTY-RESPONSE>"
@@ -363,6 +366,17 @@ func shortenedOutput(out string) string {
 		abbreviationType = "lines"
 	}
 	return fmt.Sprintf("%v\n...[and %v more %v]", firstTokensStr, amLeft, abbreviationType)
+}
+
+func limitToolOutput(out string, limit int) string {
+	if limit <= 0 {
+		return out
+	}
+	r := []rune(out)
+	if len(r) <= limit {
+		return out
+	}
+	return string(r[:limit]) + TOOL_OUTPUT_DISCLAIMER
 }
 
 func (q *Querier[C]) handleToken(token string) {

--- a/internal/text/querier.go
+++ b/internal/text/querier.go
@@ -20,9 +20,8 @@ import (
 )
 
 const (
-	TOKEN_COUNT_FACTOR     = 1.1
-	MAX_SHORTENED_NEWLINES = 5
-	TOOL_OUTPUT_DISCLAIMER = "\n\noutput too large, concentrate your tool call"
+	TokenCountFactor     = 1.1
+	MaxShortenedNewlines = 5
 )
 
 type Querier[C models.StreamCompleter] struct {
@@ -130,7 +129,7 @@ func (q *Querier[C]) countTokens() int {
 	for _, msg := range q.chat.Messages {
 		ret += len(strings.Split(msg.Content, " "))
 	}
-	return int(float64(ret) * TOKEN_COUNT_FACTOR)
+	return int(float64(ret) * TokenCountFactor)
 }
 
 func (q *Querier[C]) postProcess() {
@@ -351,7 +350,7 @@ func shortenedOutput(out string) string {
 	outNewlineSplit := strings.Split(out, "\n")
 	firstTokens := utils.GetFirstTokens(outSplit, maxTokens)
 	amRunes := utf8.RuneCountInString(out)
-	if len(firstTokens) < maxTokens && len(outNewlineSplit) < MAX_SHORTENED_NEWLINES && amRunes < maxRunes {
+	if len(firstTokens) < maxTokens && len(outNewlineSplit) < MaxShortenedNewlines && amRunes < maxRunes {
 		return out
 	}
 	if amRunes > maxRunes {
@@ -360,9 +359,9 @@ func shortenedOutput(out string) string {
 	firstTokensStr := strings.Join(firstTokens, " ")
 	amLeft := len(outSplit) - maxTokens
 	abbreviationType := "tokens"
-	if len(outNewlineSplit) > MAX_SHORTENED_NEWLINES {
-		firstTokensStr = strings.Join(utils.GetFirstTokens(outNewlineSplit, MAX_SHORTENED_NEWLINES), "\n")
-		amLeft = len(outNewlineSplit) - MAX_SHORTENED_NEWLINES
+	if len(outNewlineSplit) > MaxShortenedNewlines {
+		firstTokensStr = strings.Join(utils.GetFirstTokens(outNewlineSplit, MaxShortenedNewlines), "\n")
+		amLeft = len(outNewlineSplit) - MaxShortenedNewlines
 		abbreviationType = "lines"
 	}
 	return fmt.Sprintf("%v\n...[and %v more %v]", firstTokensStr, amLeft, abbreviationType)
@@ -372,11 +371,13 @@ func limitToolOutput(out string, limit int) string {
 	if limit <= 0 {
 		return out
 	}
-	r := []rune(out)
-	if len(r) <= limit {
+	amRunes := utf8.RuneCountInString(out)
+	if amRunes <= limit {
 		return out
 	}
-	return string(r[:limit]) + TOOL_OUTPUT_DISCLAIMER
+	return fmt.Sprintf(
+		"%v... and %v more characters. The tool's output has been restricted as it's too long. Please concentrate your tool calls to reduce the amount of tokens used!",
+		out[:limit], amRunes-limit)
 }
 
 func (q *Querier[C]) handleToken(token string) {

--- a/internal/text/querier_setup.go
+++ b/internal/text/querier_setup.go
@@ -147,5 +147,6 @@ func NewQuerier[C models.StreamCompleter](userConf Configurations, dfault C) (Qu
 	querier.cmdMode = userConf.CmdMode
 	querier.shouldSaveReply = !userConf.ChatMode && userConf.SaveReplyAsConv
 	querier.tokenWarnLimit = userConf.TokenWarnLimit
+	querier.toolOutputRuneLimit = userConf.ToolOutputRuneLimit
 	return querier, nil
 }

--- a/internal/text/querier_test.go
+++ b/internal/text/querier_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/baalimago/clai/internal/reply"
 	"github.com/baalimago/clai/internal/tools"
 	"github.com/baalimago/go_away_boilerplate/pkg/testboil"
+	"unicode/utf8"
 )
 
 type MockQuerier struct {
@@ -358,6 +359,28 @@ func Test_shortenedOutput(t *testing.T) {
 		want := MAX_SHORTENED_NEWLINES + 1
 		if got >= want {
 			t.Fatalf("expected: %v, got: %v", want, got)
+		}
+	})
+}
+
+func Test_limitToolOutput(t *testing.T) {
+	t.Run("should append disclaimer when exceeding limit", func(t *testing.T) {
+		given := "abcdefghijklmnopqrstuvwxyz"
+		got := limitToolOutput(given, 10)
+		if !strings.Contains(got, TOOL_OUTPUT_DISCLAIMER) {
+			t.Fatalf("expected disclaimer in output, got: %v", got)
+		}
+		runeLen := utf8.RuneCountInString(got)
+		if runeLen <= 10 {
+			t.Fatalf("expected output to be longer than limit due to disclaimer, got %v runes", runeLen)
+		}
+	})
+
+	t.Run("should return same string when within limit", func(t *testing.T) {
+		given := "short"
+		got := limitToolOutput(given, 10)
+		if got != given {
+			t.Fatalf("expected %v, got %v", given, got)
 		}
 	})
 }

--- a/internal/text/querier_test.go
+++ b/internal/text/querier_test.go
@@ -12,12 +12,12 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/baalimago/clai/internal/models"
 	"github.com/baalimago/clai/internal/reply"
 	"github.com/baalimago/clai/internal/tools"
 	"github.com/baalimago/go_away_boilerplate/pkg/testboil"
-	"unicode/utf8"
 )
 
 type MockQuerier struct {

--- a/internal/text/querier_test.go
+++ b/internal/text/querier_test.go
@@ -356,7 +356,7 @@ func Test_shortenedOutput(t *testing.T) {
 		}
 		gotStr := shortenedOutput(given)
 		got := strings.Count(gotStr, "\n")
-		want := MAX_SHORTENED_NEWLINES + 1
+		want := MaxShortenedNewlines + 1
 		if got >= want {
 			t.Fatalf("expected: %v, got: %v", want, got)
 		}
@@ -367,7 +367,7 @@ func Test_limitToolOutput(t *testing.T) {
 	t.Run("should append disclaimer when exceeding limit", func(t *testing.T) {
 		given := "abcdefghijklmnopqrstuvwxyz"
 		got := limitToolOutput(given, 10)
-		if !strings.Contains(got, TOOL_OUTPUT_DISCLAIMER) {
+		if !strings.Contains(got, "The tool's output has been restricted as it's too long") {
 			t.Fatalf("expected disclaimer in output, got: %v", got)
 		}
 		runeLen := utf8.RuneCountInString(got)
@@ -379,6 +379,14 @@ func Test_limitToolOutput(t *testing.T) {
 	t.Run("should return same string when within limit", func(t *testing.T) {
 		given := "short"
 		got := limitToolOutput(given, 10)
+		if got != given {
+			t.Fatalf("expected %v, got %v", given, got)
+		}
+	})
+
+	t.Run("should not limit output when limit is 0", func(t *testing.T) {
+		given := "this is a very long string that would normally be limited"
+		got := limitToolOutput(given, 0)
 		if got != given {
 			t.Fatalf("expected %v, got %v", given, got)
 		}


### PR DESCRIPTION
During my development I've noticed that tools sometimes outputs a whole lot of text. When running conversational
tooling assisted coding (read: agentic coding), these large calls bloat the context for the entire conversation. Remember
that the entire conversation is uploaded on every new request, with a new answer appended.

So it's crucial to keep the output from the tools under control to both reduce cost and to force 'smarter' tool calls from the 
llm.

Changes:
* Added new config field `tool-output-rune-limit` which specifies amount of 'runes' (read chars) a tool may output
* Set `tool-output-rune-limit` to 0 if you'd like to have unlimited length of tooling output
* PR also includes minor cleanup