### PR TITLE
tweak: rows_between numbering + raw output mode 

### DIFF
--- a/internal/text/querier.go
+++ b/internal/text/querier.go
@@ -133,6 +133,11 @@ func (q *Querier[C]) countTokens() int {
 }
 
 func (q *Querier[C]) postProcess() {
+	if q.Raw {
+		// Print a new line, otherwise cursor remains on the same position on
+		// the next contet block
+		fmt.Println()
+	}
 	// This is to ensure that it only post-processes once in recursive calls
 	if q.hasPrinted {
 		return

--- a/internal/tools/programming_tool_rows_between.go
+++ b/internal/tools/programming_tool_rows_between.go
@@ -74,7 +74,8 @@ func (r RowsBetweenTool) Call(input Input) (string, error) {
 	scanner := bufio.NewScanner(file)
 	for i := 1; scanner.Scan(); i++ {
 		if i >= startLine && i <= endLine {
-			lines = append(lines, scanner.Text())
+			lineWithNumber := fmt.Sprintf("%d: %s", i, scanner.Text())
+			lines = append(lines, lineWithNumber)
 		}
 		if i > endLine {
 			break

--- a/internal/tools/programming_tool_rows_between_test.go
+++ b/internal/tools/programming_tool_rows_between_test.go
@@ -18,10 +18,10 @@ func TestRowsBetweenTool_Call(t *testing.T) {
 		start, end int
 		expected   string
 	}{
-		{1, 3, "one\ntwo\nthree"},
-		{2, 4, "two\nthree\nfour"},
-		{4, 5, "four\nfive"},
-		{3, 3, "three"},
+		{1, 3, "1: one\n2: two\n3: three"},
+		{2, 4, "2: two\n3: three\n4: four"},
+		{4, 5, "4: four\n5: five"},
+		{3, 3, "3: three"},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
I'm using + developing my custom made coding agent, which uses clai under the hood. It's written in neovim and basically
just passes context information retrieved from neovim + the lsp to clai, then I've prompted clai to achieve
mundane tasks such as generating unit tests, documentation or simply generate whatever I ask it to generate.

This has worked great when the project is 'well maintained' with ~400-600 LoC per file and little bloat.
But now I'm working with projects which are monolithic and where files are both large and unmaintained and here
"ghettopilot" (it's like co-pilot, but ghetto-pilot, since I dont have the budget for anything but duct-tape) is struggling
a bit since it prefers to fetch entire files to build context. 

Changes:
* Added row break on raw postprocess, this is to aid separating the steam output context blocks on raw mode
* Added row number to the output of rows_between