### PR TITLE
Add MCP client tooling

### DIFF
--- a/internal/tools/mcp/client.go
+++ b/internal/tools/mcp/client.go
@@ -2,13 +2,76 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
 
 	"github.com/baalimago/clai/internal/tools"
 )
 
+// Client starts the MCP server process defined by mcpConfig and returns channels
+// for sending requests and receiving responses.
 func Client(ctx context.Context, mcpConfig tools.McpServer) (chan<- any, <-chan any, error) {
-	// Implementation needed
-	inputChan := make(chan any)
-	outputChan := make(chan any)
-	return inputChan, outputChan, nil
+	cmd := exec.CommandContext(ctx, mcpConfig.Command, mcpConfig.Args...)
+	cmd.Env = os.Environ()
+	for k, v := range mcpConfig.Env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, fmt.Errorf("stdout pipe: %w", err)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, nil, fmt.Errorf("stdin pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, nil, fmt.Errorf("start mcp server: %w", err)
+	}
+
+	in := make(chan any)
+	out := make(chan any)
+
+	go func() {
+		enc := json.NewEncoder(stdin)
+		for {
+			select {
+			case msg, ok := <-in:
+				if !ok {
+					return
+				}
+				enc.Encode(msg)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	go func() {
+		dec := json.NewDecoder(stdout)
+		for {
+			var raw json.RawMessage
+			if err := dec.Decode(&raw); err != nil {
+				if err == io.EOF {
+					close(out)
+					return
+				}
+				out <- fmt.Errorf("decode: %w", err)
+				close(out)
+				return
+			}
+			out <- raw
+		}
+	}()
+
+	go func() {
+		<-ctx.Done()
+		stdin.Close()
+		cmd.Wait()
+	}()
+
+	return in, out, nil
 }

--- a/internal/tools/mcp/client_test.go
+++ b/internal/tools/mcp/client_test.go
@@ -1,0 +1,44 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/baalimago/clai/internal/tools"
+)
+
+func TestClient(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := tools.McpServer{Command: "go", Args: []string{"run", "./testserver"}}
+	in, out, err := Client(ctx, srv)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+
+	req := Request{JSONRPC: "2.0", ID: 1, Method: "initialize"}
+	in <- req
+	msg := <-out
+	raw, ok := msg.(json.RawMessage)
+	if !ok {
+		t.Fatalf("unexpected type %T", msg)
+	}
+	var resp Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ID != 1 || resp.Error != nil {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+}
+
+func TestClientBadCommand(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, _, err := Client(ctx, tools.McpServer{Command: "does-not-exist"})
+	if err == nil {
+		t.Fatal("expected error for bad command")
+	}
+}

--- a/internal/tools/mcp/manager.go
+++ b/internal/tools/mcp/manager.go
@@ -2,9 +2,126 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/baalimago/clai/internal/tools"
 )
 
+// Manager registers MCP servers and their tools.
 func Manager(ctx context.Context, controlChannel <-chan ControlEvent, statusChan chan<- error) {
-	// Implementation needed
-	statusChan <- nil
+	var wg sync.WaitGroup
+	for {
+		select {
+		case ev := <-controlChannel:
+			wg.Add(1)
+			go func(e ControlEvent) {
+				defer wg.Done()
+				if err := handleServer(ctx, e); err != nil {
+					statusChan <- err
+				}
+			}(ev)
+		case <-ctx.Done():
+			wg.Wait()
+			statusChan <- nil
+			return
+		}
+	}
+}
+
+func handleServer(ctx context.Context, ev ControlEvent) error {
+	// Initialize
+	initReq := Request{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+		Params: map[string]any{
+			"capabilities": map[string]any{},
+			"clientInfo": map[string]string{
+				"name":    "clai",
+				"version": "dev",
+			},
+			"protocolVersion": "2025-03-26",
+		},
+	}
+	resp, err := sendRequest(ctx, ev.InputChan, ev.OutputChan, initReq)
+	if err != nil {
+		return fmt.Errorf("initialize: %w", err)
+	}
+	if resp.Error != nil {
+		return fmt.Errorf("initialize: %s", resp.Error.Message)
+	}
+
+	// Send initialized notification
+	ev.InputChan <- map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "notifications/initialized",
+		"params":  map[string]any{},
+	}
+
+	// List tools
+	listReq := Request{
+		JSONRPC: "2.0",
+		ID:      2,
+		Method:  "tools/list",
+	}
+	resp, err = sendRequest(ctx, ev.InputChan, ev.OutputChan, listReq)
+	if err != nil {
+		return fmt.Errorf("tools/list: %w", err)
+	}
+	if resp.Error != nil {
+		return fmt.Errorf("tools/list: %s", resp.Error.Message)
+	}
+	var listRes struct {
+		Tools []Tool `json:"tools"`
+	}
+	if err := json.Unmarshal(resp.Result, &listRes); err != nil {
+		return fmt.Errorf("decode list result: %w", err)
+	}
+
+	for _, t := range listRes.Tools {
+		spec := tools.Specification{
+			Name:        fmt.Sprintf("%s_%s", ev.ServerName, t.Name),
+			Description: t.Description,
+			Inputs:      &t.InputSchema,
+		}
+		mt := &mcpTool{
+			remoteName: t.Name,
+			spec:       spec,
+			inputChan:  ev.InputChan,
+			outputChan: ev.OutputChan,
+		}
+		tools.Tools[spec.Name] = mt
+	}
+	return nil
+}
+
+func sendRequest(ctx context.Context, in chan<- any, out <-chan any, req Request) (Response, error) {
+	select {
+	case in <- req:
+	case <-ctx.Done():
+		return Response{}, ctx.Err()
+	}
+	for {
+		select {
+		case msg := <-out:
+			raw, ok := msg.(json.RawMessage)
+			if !ok {
+				if err, ok := msg.(error); ok {
+					return Response{}, err
+				}
+				continue
+			}
+			var resp Response
+			if err := json.Unmarshal(raw, &resp); err != nil {
+				continue
+			}
+			if resp.ID == req.ID {
+				return resp, nil
+			}
+		case <-ctx.Done():
+			return Response{}, ctx.Err()
+		}
+	}
 }

--- a/internal/tools/mcp/manager_test.go
+++ b/internal/tools/mcp/manager_test.go
@@ -1,0 +1,82 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/baalimago/clai/internal/tools"
+)
+
+func TestHandleServerRegistersTool(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := tools.McpServer{Command: "go", Args: []string{"run", "./testserver"}}
+	in, out, err := Client(ctx, srv)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+
+	orig := tools.Tools
+	tools.Tools = make(map[string]tools.LLMTool)
+	defer func() { tools.Tools = orig }()
+
+	ev := ControlEvent{ServerName: "ts", Server: srv, InputChan: in, OutputChan: out}
+	if err := handleServer(ctx, ev); err != nil {
+		t.Fatalf("handleServer: %v", err)
+	}
+
+	tool, ok := tools.Tools["ts_echo"]
+	if !ok {
+		t.Fatal("tool not registered")
+	}
+	res, err := tool.Call(tools.Input{"text": "hello"})
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if res != "hello" {
+		t.Errorf("unexpected response %q", res)
+	}
+
+	if _, err := tool.Call(tools.Input{"text": "error"}); err == nil {
+		t.Error("expected error on isError=true")
+	}
+}
+
+func TestManager(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srv := tools.McpServer{Command: "go", Args: []string{"run", "./testserver"}}
+	in, out, err := Client(ctx, srv)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+
+	orig := tools.Tools
+	tools.Tools = make(map[string]tools.LLMTool)
+	defer func() { tools.Tools = orig }()
+
+	controlCh := make(chan ControlEvent)
+	statusCh := make(chan error, 1)
+	go Manager(ctx, controlCh, statusCh)
+
+	controlCh <- ControlEvent{ServerName: "man", Server: srv, InputChan: in, OutputChan: out}
+
+	var ok bool
+	for i := 0; i < 20; i++ {
+		_, ok = tools.Tools["man_echo"]
+		if ok {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !ok {
+		t.Fatal("tool not registered")
+	}
+
+	cancel()
+	if err := <-statusCh; err != nil {
+		t.Fatalf("manager error: %v", err)
+	}
+}

--- a/internal/tools/mcp/models.go
+++ b/internal/tools/mcp/models.go
@@ -1,10 +1,45 @@
 package mcp
 
-import "github.com/baalimago/clai/internal/tools"
+import (
+	"encoding/json"
 
+	"github.com/baalimago/clai/internal/tools"
+)
+
+// ControlEvent instructs the Manager to register a new MCP server.
 type ControlEvent struct {
 	ServerName string
 	Server     tools.McpServer
 	InputChan  chan<- any
 	OutputChan <-chan any
+}
+
+// Request represents a JSON-RPC request.
+type Request struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      int         `json:"id,omitempty"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params,omitempty"`
+}
+
+// Response represents a JSON-RPC response.
+type Response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+// RPCError represents a JSON-RPC error structure.
+type RPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+// Tool describes a tool as returned by tools/list.
+type Tool struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	InputSchema tools.InputSchema `json:"inputSchema"`
 }

--- a/internal/tools/mcp/testserver/main.go
+++ b/internal/tools/mcp/testserver/main.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+)
+
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+func main() {
+	dec := json.NewDecoder(os.Stdin)
+	enc := json.NewEncoder(os.Stdout)
+	for {
+		var req Request
+		if err := dec.Decode(&req); err != nil {
+			return
+		}
+		switch req.Method {
+		case "initialize":
+			enc.Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"result":  map[string]any{},
+			})
+		case "tools/list":
+			enc.Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"result": map[string]any{
+					"tools": []map[string]any{
+						{
+							"name":        "echo",
+							"description": "echo text",
+							"inputSchema": map[string]any{
+								"type":     "object",
+								"required": []string{"text"},
+								"properties": map[string]any{
+									"text": map[string]any{
+										"type":        "string",
+										"description": "text to echo",
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+		case "tools/call":
+			var p struct {
+				Name      string         `json:"name"`
+				Arguments map[string]any `json:"arguments"`
+			}
+			json.Unmarshal(req.Params, &p)
+			text, _ := p.Arguments["text"].(string)
+			result := map[string]any{
+				"content": []map[string]any{{"type": "text", "text": text}},
+				"isError": false,
+			}
+			if text == "error" {
+				result["isError"] = true
+			}
+			enc.Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"result":  result,
+			})
+		default:
+			enc.Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"error": map[string]any{
+					"code":    -32601,
+					"message": "method not found",
+				},
+			})
+		}
+	}
+}

--- a/internal/tools/mcp/tool.go
+++ b/internal/tools/mcp/tool.go
@@ -1,0 +1,88 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/baalimago/clai/internal/tools"
+)
+
+// mcpTool wraps a tool provided by an MCP server and implements tools.LLMTool.
+type mcpTool struct {
+	remoteName string
+	spec       tools.Specification
+	inputChan  chan<- any
+	outputChan <-chan any
+
+	mu  sync.Mutex
+	seq int
+}
+
+func (m *mcpTool) nextID() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.seq++
+	return m.seq
+}
+
+func (m *mcpTool) Call(input tools.Input) (string, error) {
+	id := m.nextID()
+	req := Request{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name":      m.remoteName,
+			"arguments": input,
+		},
+	}
+
+	m.inputChan <- req
+
+	for msg := range m.outputChan {
+		raw, ok := msg.(json.RawMessage)
+		if !ok {
+			if err, ok := msg.(error); ok {
+				return "", err
+			}
+			continue
+		}
+		var resp Response
+		if err := json.Unmarshal(raw, &resp); err != nil {
+			continue
+		}
+		if resp.ID != id {
+			continue
+		}
+		if resp.Error != nil {
+			return "", fmt.Errorf(resp.Error.Message)
+		}
+		var result struct {
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		}
+		if err := json.Unmarshal(resp.Result, &result); err != nil {
+			return "", fmt.Errorf("decode result: %w", err)
+		}
+		var buf bytes.Buffer
+		for _, c := range result.Content {
+			if c.Type == "text" {
+				buf.WriteString(c.Text)
+			}
+		}
+		if result.IsError {
+			return "", fmt.Errorf(buf.String())
+		}
+		return buf.String(), nil
+	}
+	return "", fmt.Errorf("connection closed")
+}
+
+func (m *mcpTool) Specification() tools.Specification {
+	return m.spec
+}


### PR DESCRIPTION
## Summary
- implement a JSON-RPC client for MCP servers
- add manager that initializes MCP servers and registers remote tools
- define types used by MCP tooling and implement `mcpTool`
- add test server and unit tests for MCP client and manager

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_684a5300df1c832c9202f193b30464de