### PR TITLE
Add thread safe tools registry and mcp wrappers

### DIFF
--- a/internal/setup/setup_actions.go
+++ b/internal/setup/setup_actions.go
@@ -185,7 +185,7 @@ func getToolsValue(v any) ([]string, error) {
 	fmt.Fprint(w, "-----\t----\t----------\n")
 	indexMap := map[int]string{}
 	i := 0
-	for name, v := range tools.Tools {
+	for name, v := range tools.Tools.All() {
 		indexMap[i] = name
 		fmt.Fprintf(w, "%v\t%v\t%v\n", i, name, v.Specification().Description)
 		i++

--- a/internal/text/querier_setup_tools.go
+++ b/internal/text/querier_setup_tools.go
@@ -76,7 +76,7 @@ func setupTooling[C models.StreamCompleter](ctx context.Context, modelConf C, us
 		}
 		// If usetools and no specific tools chocen, assume all are valid
 		if len(userConf.Tools) == 0 {
-			for _, tool := range tools.Tools {
+			for _, tool := range tools.Tools.All() {
 				if misc.Truthy(os.Getenv("DEBUG")) {
 					ancli.PrintOK(fmt.Sprintf("\tadding tool: %T\n", tool))
 				}
@@ -84,7 +84,7 @@ func setupTooling[C models.StreamCompleter](ctx context.Context, modelConf C, us
 			}
 		} else {
 			for _, t := range userConf.Tools {
-				tool, exists := tools.Tools[t]
+				tool, exists := tools.Tools.Get(t)
 				if !exists {
 					ancli.PrintWarn(fmt.Sprintf("attempted to find tool: '%v', which doesn't exist, skipping", tool))
 					continue

--- a/internal/tools/handler.go
+++ b/internal/tools/handler.go
@@ -1,26 +1,59 @@
 package tools
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
-var Tools = map[string]LLMTool{
-	"file_tree":        FileTree,
-	"cat":              Cat,
-	"find":             Find,
-	"file_type":        FileType,
-	"ls":               LS,
-	"website_text":     WebsiteText,
-	"rg":               RipGrep,
-	"go":               Go,
-	"write_file":       WriteFile,
-	"freetext_command": FreetextCmd,
-	"sed":              Sed,
-	"rows_between":     RowsBetween,
-	"line_count":       LineCount,
+type toolRegistry struct {
+	mu    sync.RWMutex
+	tools map[string]LLMTool
+}
+
+func (tr *toolRegistry) Get(name string) (LLMTool, bool) {
+	tr.mu.RLock()
+	defer tr.mu.RUnlock()
+	t, ok := tr.tools[name]
+	return t, ok
+}
+
+func (tr *toolRegistry) Register(tool LLMTool) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	tr.tools[tool.Specification().Name] = tool
+}
+
+func (tr *toolRegistry) All() map[string]LLMTool {
+	tr.mu.RLock()
+	defer tr.mu.RUnlock()
+	copy := make(map[string]LLMTool, len(tr.tools))
+	for k, v := range tr.tools {
+		copy[k] = v
+	}
+	return copy
+}
+
+var Tools = toolRegistry{
+	tools: map[string]LLMTool{
+		"file_tree":        FileTree,
+		"cat":              Cat,
+		"find":             Find,
+		"file_type":        FileType,
+		"ls":               LS,
+		"website_text":     WebsiteText,
+		"rg":               RipGrep,
+		"go":               Go,
+		"write_file":       WriteFile,
+		"freetext_command": FreetextCmd,
+		"sed":              Sed,
+		"rows_between":     RowsBetween,
+		"line_count":       LineCount,
+	},
 }
 
 // Invoke the call, and gather both error and output in the same string
 func Invoke(call Call) string {
-	t, exists := Tools[call.Name]
+	t, exists := Tools.Get(call.Name)
 	if !exists {
 		return "ERROR: unknown tool call: " + call.Name
 	}
@@ -33,7 +66,7 @@ func Invoke(call Call) string {
 
 // ToolFromName looks at the static tools.Tools map
 func ToolFromName(name string) Specification {
-	t, exists := Tools[name]
+	t, exists := Tools.Get(name)
 	if !exists {
 		return Specification{}
 	}

--- a/internal/tools/mcp/client.go
+++ b/internal/tools/mcp/client.go
@@ -2,21 +2,63 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
 
 	"github.com/baalimago/clai/internal/tools"
 )
 
+// Client spawns the configured MCP server as a subprocess and returns channels
+// used to send requests and receive responses. All messages are JSON encoded.
 func Client(ctx context.Context, mcpConfig tools.McpServer) (chan<- any, <-chan any, error) {
+	cmd := exec.CommandContext(ctx, mcpConfig.Command, mcpConfig.Args...)
+	if len(mcpConfig.Env) > 0 {
+		env := os.Environ()
+		for k, v := range mcpConfig.Env {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
+		cmd.Env = env
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, nil, fmt.Errorf("failed to start mcp server: %w", err)
+	}
+
 	inputChan := make(chan any)
 	outputChan := make(chan any)
 
 	go func() {
-		<-ctx.Done()
-		close(inputChan)
+		enc := json.NewEncoder(stdin)
+		for msg := range inputChan {
+			_ = enc.Encode(msg)
+		}
+		stdin.Close()
+	}()
+
+	go func() {
+		dec := json.NewDecoder(stdout)
+		for {
+			var raw json.RawMessage
+			if err := dec.Decode(&raw); err != nil {
+				break
+			}
+			outputChan <- raw
+		}
 		close(outputChan)
 	}()
 
-	_ = mcpConfig // placeholder for future use
+	go func() { _ = cmd.Wait() }()
 
 	return inputChan, outputChan, nil
 }

--- a/internal/tools/mcp/client.go
+++ b/internal/tools/mcp/client.go
@@ -7,8 +7,16 @@ import (
 )
 
 func Client(ctx context.Context, mcpConfig tools.McpServer) (chan<- any, <-chan any, error) {
-	// Implementation needed
 	inputChan := make(chan any)
 	outputChan := make(chan any)
+
+	go func() {
+		<-ctx.Done()
+		close(inputChan)
+		close(outputChan)
+	}()
+
+	_ = mcpConfig // placeholder for future use
+
 	return inputChan, outputChan, nil
 }

--- a/internal/tools/mcp/manager.go
+++ b/internal/tools/mcp/manager.go
@@ -2,9 +2,37 @@ package mcp
 
 import (
 	"context"
+
+	"github.com/baalimago/clai/internal/tools"
 )
 
 func Manager(ctx context.Context, controlChannel <-chan ControlEvent, statusChan chan<- error) {
-	// Implementation needed
-	statusChan <- nil
+	defer close(statusChan)
+	for {
+		select {
+		case <-ctx.Done():
+			statusChan <- ctx.Err()
+			return
+		case ev, ok := <-controlChannel:
+			if !ok {
+				statusChan <- nil
+				return
+			}
+			go handleServer(ev)
+		}
+	}
+}
+
+func handleServer(ev ControlEvent) {
+	msg, ok := <-ev.OutputChan
+	if !ok {
+		return
+	}
+	specs, ok := msg.([]tools.Specification)
+	if !ok {
+		return
+	}
+	for _, spec := range specs {
+		tools.Tools.Register(NewToolWrapper(spec, ev.InputChan, ev.OutputChan))
+	}
 }

--- a/internal/tools/mcp/manager.go
+++ b/internal/tools/mcp/manager.go
@@ -2,10 +2,13 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/baalimago/clai/internal/tools"
 )
 
+// Manager supervises running MCP clients. Each ControlEvent represents a single
+// server with which we exchange tool specifications and requests.
 func Manager(ctx context.Context, controlChannel <-chan ControlEvent, statusChan chan<- error) {
 	defer close(statusChan)
 	for {
@@ -24,14 +27,25 @@ func Manager(ctx context.Context, controlChannel <-chan ControlEvent, statusChan
 }
 
 func handleServer(ev ControlEvent) {
+	// Ask the server for its available tools. We expect it to reply with a
+	// JSON encoded list of tools.Specification values.
+	ev.InputChan <- map[string]string{"command": "list_tools"}
+
 	msg, ok := <-ev.OutputChan
 	if !ok {
 		return
 	}
-	specs, ok := msg.([]tools.Specification)
+
+	raw, ok := msg.(json.RawMessage)
 	if !ok {
 		return
 	}
+
+	var specs []tools.Specification
+	if err := json.Unmarshal(raw, &specs); err != nil {
+		return
+	}
+
 	for _, spec := range specs {
 		tools.Tools.Register(NewToolWrapper(spec, ev.InputChan, ev.OutputChan))
 	}

--- a/internal/tools/mcp/wrapper.go
+++ b/internal/tools/mcp/wrapper.go
@@ -1,0 +1,45 @@
+package mcp
+
+import (
+	"fmt"
+
+	"github.com/baalimago/clai/internal/tools"
+)
+
+// ToolWrapper implements tools.LLMTool and forwards calls to an MCP server
+// using the provided channels.
+type ToolWrapper struct {
+	spec       tools.Specification
+	inputChan  chan<- any
+	outputChan <-chan any
+}
+
+func NewToolWrapper(spec tools.Specification, in chan<- any, out <-chan any) ToolWrapper {
+	return ToolWrapper{spec: spec, inputChan: in, outputChan: out}
+}
+
+func (m ToolWrapper) Call(inp tools.Input) (string, error) {
+	req := map[string]any{
+		"name":   m.spec.Name,
+		"inputs": inp,
+	}
+	select {
+	case m.inputChan <- req:
+	default:
+		return "", fmt.Errorf("failed to send request to mcp server")
+	}
+
+	resp, ok := <-m.outputChan
+	if !ok {
+		return "", fmt.Errorf("mcp server closed")
+	}
+	s, ok := resp.(string)
+	if !ok {
+		return "", fmt.Errorf("unexpected response type %T", resp)
+	}
+	return s, nil
+}
+
+func (m ToolWrapper) Specification() tools.Specification {
+	return m.spec
+}

--- a/internal/tools/mcp/wrapper.go
+++ b/internal/tools/mcp/wrapper.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/baalimago/clai/internal/tools"
@@ -33,6 +34,15 @@ func (m ToolWrapper) Call(inp tools.Input) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("mcp server closed")
 	}
+
+	if raw, ok := resp.(json.RawMessage); ok {
+		var out string
+		if err := json.Unmarshal(raw, &out); err != nil {
+			return "", fmt.Errorf("failed to unmarshal mcp response: %w", err)
+		}
+		return out, nil
+	}
+
 	s, ok := resp.(string)
 	if !ok {
 		return "", fmt.Errorf("unexpected response type %T", resp)


### PR DESCRIPTION
## Summary
- make tools registry thread safe via mutex and provide Get/All/Register methods
- adjust code that iterates or fetches tools
- stub MCP manager and client, add ToolWrapper implementation

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6849d26ed1ac832c85a6c224d7496383