### PR TITLE
Refactor tools registry to be thread safe

### DIFF
--- a/internal/setup/setup_actions.go
+++ b/internal/setup/setup_actions.go
@@ -185,7 +185,7 @@ func getToolsValue(v any) ([]string, error) {
 	fmt.Fprint(w, "-----\t----\t----------\n")
 	indexMap := map[int]string{}
 	i := 0
-	for name, v := range tools.Tools {
+	for name, v := range tools.Tools.All() {
 		indexMap[i] = name
 		fmt.Fprintf(w, "%v\t%v\t%v\n", i, name, v.Specification().Description)
 		i++

--- a/internal/text/querier_setup_tools.go
+++ b/internal/text/querier_setup_tools.go
@@ -76,7 +76,7 @@ func setupTooling[C models.StreamCompleter](ctx context.Context, modelConf C, us
 		}
 		// If usetools and no specific tools chocen, assume all are valid
 		if len(userConf.Tools) == 0 {
-			for _, tool := range tools.Tools {
+			for _, tool := range tools.Tools.All() {
 				if misc.Truthy(os.Getenv("DEBUG")) {
 					ancli.PrintOK(fmt.Sprintf("\tadding tool: %T\n", tool))
 				}
@@ -84,7 +84,7 @@ func setupTooling[C models.StreamCompleter](ctx context.Context, modelConf C, us
 			}
 		} else {
 			for _, t := range userConf.Tools {
-				tool, exists := tools.Tools[t]
+				tool, exists := tools.Tools.Get(t)
 				if !exists {
 					ancli.PrintWarn(fmt.Sprintf("attempted to find tool: '%v', which doesn't exist, skipping", tool))
 					continue

--- a/internal/tools/handler.go
+++ b/internal/tools/handler.go
@@ -2,25 +2,28 @@ package tools
 
 import "fmt"
 
-var Tools = map[string]LLMTool{
-	"file_tree":        FileTree,
-	"cat":              Cat,
-	"find":             Find,
-	"file_type":        FileType,
-	"ls":               LS,
-	"website_text":     WebsiteText,
-	"rg":               RipGrep,
-	"go":               Go,
-	"write_file":       WriteFile,
-	"freetext_command": FreetextCmd,
-	"sed":              Sed,
-	"rows_between":     RowsBetween,
-	"line_count":       LineCount,
+// Tools is the global registry of available LLM tools.
+var Tools = NewRegistry()
+
+func init() {
+	Tools.Set("file_tree", FileTree)
+	Tools.Set("cat", Cat)
+	Tools.Set("find", Find)
+	Tools.Set("file_type", FileType)
+	Tools.Set("ls", LS)
+	Tools.Set("website_text", WebsiteText)
+	Tools.Set("rg", RipGrep)
+	Tools.Set("go", Go)
+	Tools.Set("write_file", WriteFile)
+	Tools.Set("freetext_command", FreetextCmd)
+	Tools.Set("sed", Sed)
+	Tools.Set("rows_between", RowsBetween)
+	Tools.Set("line_count", LineCount)
 }
 
 // Invoke the call, and gather both error and output in the same string
 func Invoke(call Call) string {
-	t, exists := Tools[call.Name]
+	t, exists := Tools.Get(call.Name)
 	if !exists {
 		return "ERROR: unknown tool call: " + call.Name
 	}
@@ -33,7 +36,7 @@ func Invoke(call Call) string {
 
 // ToolFromName looks at the static tools.Tools map
 func ToolFromName(name string) Specification {
-	t, exists := Tools[name]
+	t, exists := Tools.Get(name)
 	if !exists {
 		return Specification{}
 	}

--- a/internal/tools/mcp/manager.go
+++ b/internal/tools/mcp/manager.go
@@ -92,7 +92,7 @@ func handleServer(ctx context.Context, ev ControlEvent) error {
 			inputChan:  ev.InputChan,
 			outputChan: ev.OutputChan,
 		}
-		tools.Tools[spec.Name] = mt
+		tools.Tools.Set(spec.Name, mt)
 	}
 	return nil
 }

--- a/internal/tools/mcp/manager_test.go
+++ b/internal/tools/mcp/manager_test.go
@@ -19,7 +19,7 @@ func TestHandleServerRegistersTool(t *testing.T) {
 	}
 
 	orig := tools.Tools
-	tools.Tools = make(map[string]tools.LLMTool)
+	tools.Tools = tools.NewRegistry()
 	defer func() { tools.Tools = orig }()
 
 	ev := ControlEvent{ServerName: "ts", Server: srv, InputChan: in, OutputChan: out}
@@ -27,7 +27,7 @@ func TestHandleServerRegistersTool(t *testing.T) {
 		t.Fatalf("handleServer: %v", err)
 	}
 
-	tool, ok := tools.Tools["ts_echo"]
+	tool, ok := tools.Tools.Get("ts_echo")
 	if !ok {
 		t.Fatal("tool not registered")
 	}
@@ -54,7 +54,7 @@ func TestManager(t *testing.T) {
 	}
 
 	orig := tools.Tools
-	tools.Tools = make(map[string]tools.LLMTool)
+	tools.Tools = tools.NewRegistry()
 	defer func() { tools.Tools = orig }()
 
 	controlCh := make(chan ControlEvent)
@@ -65,7 +65,7 @@ func TestManager(t *testing.T) {
 
 	var ok bool
 	for i := 0; i < 20; i++ {
-		_, ok = tools.Tools["man_echo"]
+		_, ok = tools.Tools.Get("man_echo")
 		if ok {
 			break
 		}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -1,0 +1,47 @@
+package tools
+
+import "sync"
+
+// Registry is a threadsafe storage for LLMTools.
+type Registry struct {
+	mu    sync.RWMutex
+	tools map[string]LLMTool
+}
+
+// NewRegistry returns an empty tools registry.
+func NewRegistry() *Registry {
+	return &Registry{tools: make(map[string]LLMTool)}
+}
+
+// Get returns the tool registered under name.
+func (r *Registry) Get(name string) (LLMTool, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	t, ok := r.tools[name]
+	return t, ok
+}
+
+// Set registers tool under the provided name.
+func (r *Registry) Set(name string, t LLMTool) {
+	r.mu.Lock()
+	r.tools[name] = t
+	r.mu.Unlock()
+}
+
+// All returns a copy of all registered tools keyed by name.
+func (r *Registry) All() map[string]LLMTool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	cp := make(map[string]LLMTool, len(r.tools))
+	for k, v := range r.tools {
+		cp[k] = v
+	}
+	return cp
+}
+
+// Reset removes all registered tools. Primarily used for tests.
+func (r *Registry) Reset() {
+	r.mu.Lock()
+	r.tools = make(map[string]LLMTool)
+	r.mu.Unlock()
+}


### PR DESCRIPTION
## Summary
- implement `Registry` type for thread-safe tool access
- populate built-in tools via `init`
- use new registry in mcp manager and setup tooling
- update tests for new registry

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_684ab09a3a78832c876dae3acb5aedd6