### PR TITLE
Add read-only git tool

### DIFF
--- a/internal/tools/handler.go
+++ b/internal/tools/handler.go
@@ -16,6 +16,7 @@ var Tools = map[string]AiTool{
 	"sed":              Sed,
 	"rows_between":     RowsBetween,
 	"line_count":       LineCount,
+	"git":              Git,
 }
 
 // Invoke the call, and gather both error and output in the same string

--- a/internal/tools/programming_tool_git.go
+++ b/internal/tools/programming_tool_git.go
@@ -1,0 +1,115 @@
+package tools
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+)
+
+type GitTool UserFunction
+
+var Git = GitTool{
+	Name:        "git",
+	Description: "Run read-only git commands like log, diff, show, blame and status.",
+	Inputs: &InputSchema{
+		Type: "object",
+		Properties: map[string]ParameterObject{
+			"operation": {
+				Type:        "string",
+				Description: "The git operation to run.",
+				Enum:        []string{"log", "diff", "show", "status", "blame"},
+			},
+			"file": {
+				Type:        "string",
+				Description: "Optional file path used by diff, show or blame.",
+			},
+			"commit": {
+				Type:        "string",
+				Description: "Optional commit hash used by show or diff.",
+			},
+			"range": {
+				Type:        "string",
+				Description: "Optional revision range for log or diff.",
+			},
+			"n": {
+				Type:        "integer",
+				Description: "Number of log entries to display.",
+			},
+			"dir": {
+				Type:        "string",
+				Description: "Directory containing the git repository (optional).",
+			},
+		},
+		Required: []string{"operation"},
+	},
+}
+
+func (g GitTool) Call(input Input) (string, error) {
+	op, ok := input["operation"].(string)
+	if !ok {
+		return "", fmt.Errorf("operation must be a string")
+	}
+
+	args := []string{op}
+
+	switch op {
+	case "log":
+		if v, ok := input["n"]; ok {
+			num := 0
+			switch n := v.(type) {
+			case int:
+				num = n
+			case float64:
+				num = int(n)
+			case string:
+				if i, err := strconv.Atoi(n); err == nil {
+					num = i
+				}
+			}
+			if num > 0 {
+				args = append(args, "-n", fmt.Sprintf("%d", num))
+			}
+		}
+		if r, ok := input["range"].(string); ok && r != "" {
+			args = append(args, r)
+		}
+	case "diff":
+		if r, ok := input["range"].(string); ok && r != "" {
+			args = append(args, r)
+		}
+		if f, ok := input["file"].(string); ok && f != "" {
+			args = append(args, "--", f)
+		}
+	case "show":
+		if c, ok := input["commit"].(string); ok && c != "" {
+			args = append(args, c)
+		}
+		if f, ok := input["file"].(string); ok && f != "" {
+			args = append(args, "--", f)
+		}
+	case "status":
+		args = []string{"status", "--short"}
+	case "blame":
+		if f, ok := input["file"].(string); ok && f != "" {
+			args = append(args, f)
+		} else {
+			return "", fmt.Errorf("file is required for blame")
+		}
+	default:
+		return "", fmt.Errorf("unsupported git operation: %s", op)
+	}
+
+	cmd := exec.Command("git", args...)
+	if d, ok := input["dir"].(string); ok && d != "" {
+		cmd.Dir = d
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to run git %s: %w, output: %s", op, err, string(output))
+	}
+	return string(output), nil
+}
+
+func (g GitTool) UserFunction() UserFunction {
+	return UserFunction(Git)
+}

--- a/internal/tools/programming_tool_git_test.go
+++ b/internal/tools/programming_tool_git_test.go
@@ -1,0 +1,63 @@
+package tools
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setupRepo(t *testing.T) string {
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v, %s", err, out)
+	}
+	// Configure user
+	exec.Command("git", "-C", dir, "config", "user.email", "test@example.com").Run()
+	exec.Command("git", "-C", dir, "config", "user.name", "tester").Run()
+
+	os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello"), 0o644)
+	exec.Command("git", "-C", dir, "add", "a.txt").Run()
+	exec.Command("git", "-C", dir, "commit", "-m", "first").Run()
+
+	os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello world"), 0o644)
+	exec.Command("git", "-C", dir, "commit", "-am", "second").Run()
+	return dir
+}
+
+func TestGitTool_Log(t *testing.T) {
+	repo := setupRepo(t)
+	out, err := Git.Call(Input{"operation": "log", "n": 1, "range": "HEAD", "dir": repo})
+	if err != nil {
+		t.Fatalf("git log failed: %v", err)
+	}
+	if !strings.Contains(out, "second") {
+		t.Errorf("expected log to contain second commit, got %q", out)
+	}
+}
+
+func TestGitTool_Diff(t *testing.T) {
+	repo := setupRepo(t)
+	out, err := Git.Call(Input{"operation": "diff", "range": "HEAD~1..HEAD", "file": "a.txt", "dir": repo})
+	if err != nil {
+		t.Fatalf("git diff failed: %v", err)
+	}
+	if !strings.Contains(out, "hello world") {
+		t.Errorf("unexpected diff output: %q", out)
+	}
+}
+
+func TestGitTool_Status(t *testing.T) {
+	repo := setupRepo(t)
+	os.WriteFile(filepath.Join(repo, "b.txt"), []byte("x"), 0o644)
+	out, err := Git.Call(Input{"operation": "status", "dir": repo})
+	if err != nil {
+		t.Fatalf("git status failed: %v", err)
+	}
+	if !strings.Contains(out, "?? b.txt") {
+		t.Errorf("expected status to show untracked file, got %q", out)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a new `git` tool for read-only git inspection
- register the tool in the handlers
- test git log, diff and status operations

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_684ada536bcc832cad5d6d9244d9a68e