### PR TITLE
Add profile-path flag for profile loading

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -11,12 +11,14 @@ clai help `# For more info about the available commands (and shorthands)`
 ```
 
 ### Queries
+
 ```bash
 clai query My favorite color is blue, tell me some facts about it
 ```
+
 ```bash
 clai -re `# Use the -re flag to use the previous query as context for some next query` \
-    q Write a poem about my favorite colour 
+    q Write a poem about my favorite colour
 ```
 
 Personally I have `alias ask=clai q` and then `alias rask=clai -re q`.
@@ -25,16 +27,19 @@ This way I can `ask` -> `rask` -> `rask` for a temporary conversation.
 Every 'temporary conversation' is also saved as a chat, so it's possible to continue it later, see below on how to list chats.
 
 ### Tooling
+
 Many vendors support function calling/tooling.
-This basically means that the AI model will ask *your local machine* to run some command, then it will analyze the output of said command.
+This basically means that the AI model will ask _your local machine_ to run some command, then it will analyze the output of said command.
 
 See all the currently available tools [here](./internal/tools/), please create an issue if you'd like to see some tool added.
+
 ```bash
 clai -t q  `# Specify you wish to enable tools with -t/-tools` \
    Analyze the project found at ~/Projects/clai and give me a brief summary of what it does
 ```
 
 ### Chatting
+
 ```bash
 clai -chat-model claude-3-opus-20240229 `  # Using some other model` \
     chat new Lets have a conversation about Hegel
@@ -42,28 +47,33 @@ clai -chat-model claude-3-opus-20240229 `  # Using some other model` \
 
 The `-cm`/`-chat-model` flag works for any text-like command.
 Meaning: you can start a conversation with one chat model, then continue it with another.
+
 ```bash
 clai chat list
 ```
+
 ```bash
 clai c continue Lets_have_a_conversation_about
 ```
 
 ```bash
-clai c continue 1 kant is better `# Continue some previous chat with message ` 
+clai c continue 1 kant is better `# Continue some previous chat with message `
 ```
 
 ### Globs
+
 ```bash
 clai -raw `# Don't format output as markdown` \
     glob '*.go' Generate a README for this project > README.md
 ```
+
 The `-raw` flag will ensure that the output stays what the model outputs, without `glow` or animations.
 
 Note that the glob mode also can be used by using the `-g` flag, as in, `clai -g '<glob>' query/chat/photo/cmd`.
 Glob-as-arg will be deprecated at some point.
 
 ### Cmd
+
 ```bash
 clai cmd to show all files in home
 ```
@@ -72,9 +82,12 @@ Will work like many of the popular command suggestion LLM tools out there.
 Flags works with this mode as well, such as `clai -re -g 'some_file.go' cmd to cleanup this messy code`, but it's not guaranteed the LLM will output an executable output.
 
 ### Profiles
+
 1. `clai setup -> 2 -> n`
 1. Write some profile, example 'gopher'
 1. `clai -p gopher -g './internal/moneymaker/handler_test.go' q Fix the tests in this file`
+
+See examples [here](./examples/profiles/), try them out with `go run . -prp ./examples/profiles/cody.json q What is your purpose\?`
 
 Profiles allows you to preconfigure certain fields which will be passed to the llms, most noteably the prompt and which tools to use.
 This, in turn, enables you to quickly swap between different 'LLM-modes'.
@@ -83,7 +96,7 @@ For instance, you may have one profile which is prompted for golang programming 
 With these, you don't have to 'pre-prompt' with `clai q _in terraform_ ...` or `clai q _in golang_ ...` but instead can use `clai -p terry q ...`/`clai -p gopher q ...` and also restrict which tools are allowed, as opposed to enabling _all_ tools (with `-t`).
 
 These profiles are saved as json at [os.GetConfigDir()](https://pkg.go.dev/os#UserConfigDir)`/.clai/profiles`.
-This means that you can sync them across all of your machines and tweak your prompts wherever you code. 
+This means that you can sync them across all of your machines and tweak your prompts wherever you code.
 
 Yet again, I've personally utilized aliases here.
 `ask` -> Generic profile-less prompt
@@ -91,6 +104,7 @@ Yet again, I've personally utilized aliases here.
 These aliases are later on synched with the rest of my dotfiles + clai profiles, so they're shared on all my development machines.
 
 ### Photos
+
 ```bash
 printf "flowers" | clai -i `    # stdin replacement works for photos also` \
     --photo-prefix=flowercat `  # Sets the prefix for local photo` \
@@ -99,16 +113,18 @@ printf "flowers" | clai -i `    # stdin replacement works for photos also` \
 ```
 
 Since -N alternatives are disabled for many newer OpenAI models, you can use [repeater](https://github.com/baalimago/repeater) to generate several responses from the same prompt:
+
 ```bash
 NO_COLOR=true repeater -n 10 -w 3 -increment -file out.txt -output BOTH \
     clai -pp flower_INC p A cat made of flowers
 ```
 
-
 ## Configuration
+
 `clai` will create configuration files at [os.GetConfigDir()](https://pkg.go.dev/os#UserConfigDir)`/.clai/`.
-First time you run `clai`, two default command-related ones, `textConfig.json` and `photoConfig.json`,  will be created and then one for each specific model.
+First time you run `clai`, two default command-related ones, `textConfig.json` and `photoConfig.json`, will be created and then one for each specific model.
 The configuration presedence is as follows (from lowest to highest):
+
 1. Default hard-coded configurations [such as this](./internal/text/conf.go), these gets written to file first time you run `clai`
 1. Configurations from local `textConfig.json` or `photoConfig.json` file
 1. Profiles
@@ -118,8 +134,10 @@ The `textConfig.json/photoConfig.json` files configures _what_ you want done, no
 This way it scales for any vendor + model.
 
 ### Models
+
 There's two ways to configure the models:
-1. Set flag `-chat-model` or `-photo-model` 
+
+1. Set flag `-chat-model` or `-photo-model`
 1. Set the `model` field in the `textConfig.json` or `photoConfig.json` file. This will make it default, if not overwritten by flags.
 
 Then, for each model, a new configuration file will be created.
@@ -128,5 +146,6 @@ Instead, modify the model by adjusting its configuration file, found in [os.GetC
 This config json will in effect be unmarshaled into a request send to the model's vendor.
 
 ### Conversations
+
 Within [os.GetConfigDir()](https://pkg.go.dev/os#UserConfigDir)`/.clai/conversations` you'll find all the conversations.
 You can also modify the chats here as a way to prompt, or create entirely new ones as you see fit.

--- a/examples/profiles/cody.json
+++ b/examples/profiles/cody.json
@@ -1,0 +1,17 @@
+{
+  "model": "claude-sonnet-4-0",
+  "prompt": "I need you help to achieve diverse programming and devops tasks. I'll give you some information retrieved from my IDE, and you should use this + tooling to build up your context. Then, either answer, or generate the code.\n\nRequirements:\n\t* ONLY OUTPUT LINES SHORTER THAN 72 CHARACTERS\n\t* PRIMARILY USE 'rows_between' TO BUILD CONTEXT\n\t* ONLY USE 'cat' TOOL IF YOU KNOW THE FILE IS LESS THAN 400 lines\n\t* DO NOT WRAP THE OUTPUT IN QUOTES OR BACKTICKS.",
+  "save-reply-as-conv": true,
+  "tools": [
+    "git",
+    "file_tree",
+    "find",
+    "file_type",
+    "rows_between",
+    "cat",
+    "ls",
+    "website_text",
+    "rg"
+  ],
+  "use_tools": true
+}

--- a/examples/profiles/gopher.json
+++ b/examples/profiles/gopher.json
@@ -1,0 +1,19 @@
+{
+  "model": "gpt-4.1",
+  "prompt": "You are golang programming assistant. Answer consicely. ONLY use go standard library. NEVER write any files unless asked to. If context is lacking, assume that you should writ a function which achieves the task. Example: 'traverses a file tree' =\u003e 'write a function that traverses a file tree'",
+  "save-reply-as-conv": true,
+  "tools": [
+    "cat",
+    "file_type",
+    "file_tree",
+    "ls",
+    "rg",
+    "go",
+    "write_file",
+    "find",
+    "sed",
+    "rows_between",
+    "mcp_fetch"
+  ],
+  "use_tools": true
+}

--- a/internal/setup.go
+++ b/internal/setup.go
@@ -53,6 +53,7 @@ var defaultFlags = Configurations{
 	ExpectReplace: false,
 	ReplyMode:     false,
 	UseTools:      false,
+	ProfilePath:   "",
 }
 
 const PROFILE_HELP = `Profiles overwrites certain model configurations. The intent of profiles

--- a/internal/setup_flags.go
+++ b/internal/setup_flags.go
@@ -47,7 +47,8 @@ func setupFlags(defaults Configurations) Configurations {
 
 	pShort := flag.String("p", defaults.Profile, "Set this to the override profile you'd like to use. Configure with 'clai setup' -> 2.")
 	pLong := flag.String("profile", defaults.Profile, "Set this to the override profile you'd like to use. Configure with 'clai setup' -> 2.")
-	pPath := flag.String("profile-path", defaults.ProfilePath, "Set this to the path of a profile file to use. Mutually exclusive with -p/-profile.")
+	prPathShort := flag.String("prp", defaults.ProfilePath, "Set this to the path of a profile file to use. Mutually exclusive with -p/-profile.")
+	prPathLong := flag.String("profile-path", defaults.ProfilePath, "Set this to the path of a profile file to use. Mutually exclusive with -p/-profile.")
 
 	stdinReplaceShort := flag.String("I", defaults.StdinReplace, "Set the string to replace with stdin. (flag syntax borrowed from xargs)")
 	stdinReplaceLong := flag.String("replace", defaults.StdinReplace, "Set the string to replace with stdin. (flag syntax borrowed from xargs)'")
@@ -79,10 +80,8 @@ func setupFlags(defaults Configurations) Configurations {
 	exitWithFlagError(err, "t", "tools")
 	profile, err := utils.ReturnNonDefault(*pShort, *pLong, defaults.Profile)
 	exitWithFlagError(err, "p", "profile")
-	profilePath := *pPath
-	if profile != defaults.Profile && profilePath != defaults.ProfilePath {
-		exitWithFlagError(fmt.Errorf("values are mutually exclusive"), "profile", "profile-path")
-	}
+	profilePath, err := utils.ReturnNonDefault(*prPathShort, *prPathLong, defaults.ProfilePath)
+	exitWithFlagError(err, "prp", "profile-path")
 	replyMode := *replyShort || *replyLong
 	printRaw := *printRawShort || *printRawLong
 

--- a/internal/setup_flags.go
+++ b/internal/setup_flags.go
@@ -24,6 +24,7 @@ type Configurations struct {
 	UseTools      bool
 	Glob          string
 	Profile       string
+	ProfilePath   string
 }
 
 func setupFlags(defaults Configurations) Configurations {
@@ -46,6 +47,7 @@ func setupFlags(defaults Configurations) Configurations {
 
 	pShort := flag.String("p", defaults.Profile, "Set this to the override profile you'd like to use. Configure with 'clai setup' -> 2.")
 	pLong := flag.String("profile", defaults.Profile, "Set this to the override profile you'd like to use. Configure with 'clai setup' -> 2.")
+	pPath := flag.String("profile-path", defaults.ProfilePath, "Set this to the path of a profile file to use. Mutually exclusive with -p/-profile.")
 
 	stdinReplaceShort := flag.String("I", defaults.StdinReplace, "Set the string to replace with stdin. (flag syntax borrowed from xargs)")
 	stdinReplaceLong := flag.String("replace", defaults.StdinReplace, "Set the string to replace with stdin. (flag syntax borrowed from xargs)'")
@@ -77,6 +79,10 @@ func setupFlags(defaults Configurations) Configurations {
 	exitWithFlagError(err, "t", "tools")
 	profile, err := utils.ReturnNonDefault(*pShort, *pLong, defaults.Profile)
 	exitWithFlagError(err, "p", "profile")
+	profilePath := *pPath
+	if profile != defaults.Profile && profilePath != defaults.ProfilePath {
+		exitWithFlagError(fmt.Errorf("values are mutually exclusive"), "profile", "profile-path")
+	}
 	replyMode := *replyShort || *replyLong
 	printRaw := *printRawShort || *printRawLong
 
@@ -96,6 +102,7 @@ func setupFlags(defaults Configurations) Configurations {
 		Glob:          glob,
 		ExpectReplace: *expectReplace,
 		Profile:       profile,
+		ProfilePath:   profilePath,
 	}
 }
 
@@ -124,6 +131,9 @@ func applyFlagOverridesForText(tConf *text.Configurations, flagSet, defaultFlags
 	}
 	if flagSet.Profile != defaultFlags.Profile {
 		tConf.UseProfile = flagSet.Profile
+	}
+	if flagSet.ProfilePath != defaultFlags.ProfilePath {
+		tConf.ProfilePath = flagSet.ProfilePath
 	}
 }
 

--- a/internal/setup_flags_test.go
+++ b/internal/setup_flags_test.go
@@ -107,6 +107,14 @@ func TestSetupFlags(t *testing.T) {
 				ExpectReplace: true,
 			},
 		},
+		{
+			name:     "Profile path",
+			args:     []string{"cmd", "-profile-path", "/tmp/p.json"},
+			defaults: Configurations{},
+			expected: Configurations{
+				ProfilePath: "/tmp/p.json",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/text/conf.go
+++ b/internal/text/conf.go
@@ -35,6 +35,7 @@ type Configurations struct {
 	Glob                string      `json:"-"`
 	InitialPrompt       models.Chat `json:"-"`
 	UseProfile          string      `json:"-"`
+	ProfilePath         string      `json:"-"`
 	Tools               []string    `json:"-"`
 	// PostProccessedPrompt which has had it's strings replaced etc
 	PostProccessedPrompt string `json:"-"`

--- a/internal/text/conf_profile.go
+++ b/internal/text/conf_profile.go
@@ -20,11 +20,29 @@ func findProfile(profileName string) (Profile, error) {
 	return p, nil
 }
 
+func findProfileByPath(p string) (Profile, error) {
+	var prof Profile
+	err := utils.ReadAndUnmarshal(p, &prof)
+	if err != nil {
+		return prof, err
+	}
+	return prof, nil
+}
+
 func (c *Configurations) ProfileOverrides() error {
-	if c.UseProfile == "" {
+	if c.UseProfile == "" && c.ProfilePath == "" {
 		return nil
 	}
-	profile, err := findProfile(c.UseProfile)
+	if c.UseProfile != "" && c.ProfilePath != "" {
+		return fmt.Errorf("profile and profile-path are mutually exclusive")
+	}
+	var profile Profile
+	var err error
+	if c.ProfilePath != "" {
+		profile, err = findProfileByPath(c.ProfilePath)
+	} else {
+		profile, err = findProfile(c.UseProfile)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to find profile: %w", err)
 	}

--- a/internal/text/querier_setup_tools.go
+++ b/internal/text/querier_setup_tools.go
@@ -99,7 +99,7 @@ func setupTooling[C models.StreamCompleter](ctx context.Context, modelConf C, us
 			for _, t := range userConf.Tools {
 				tool, exists := tools.Tools.Get(t)
 				if !exists {
-					ancli.PrintWarn(fmt.Sprintf("attempted to find tool: '%v', which doesn't exist, skipping", tool))
+					ancli.Warnf("attempted to find tool: '%v', which doesn't exist, skipping\n", t)
 					continue
 				}
 

--- a/internal/tools/handler.go
+++ b/internal/tools/handler.go
@@ -19,6 +19,7 @@ func init() {
 	Tools.Set("sed", Sed)
 	Tools.Set("rows_between", RowsBetween)
 	Tools.Set("line_count", LineCount)
+	Tools.Set("git", Git)
 }
 
 // Invoke the call, and gather both error and output in the same string

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ Flags:
   -t, -tools bool              Set to true to use text tools. Some models might not support streaming. (default %v)
   -g, -glob string             Set the glob to use for globbing. Same as glob mode. (default '%v')
   -p, -profile string          Set the profile which should be used. For details, see 'clai help profile'. (default '%v')
+  -profile-path string        Set the path to a profile file to use instead of -p/-profile.
 
 Commands:
   h|help                        Display this help message


### PR DESCRIPTION
## Summary
- add new `profile-path` flag in flags setup
- parse and propagate `profile-path` to text configuration
- ensure `profile` and `profile-path` are mutually exclusive
- allow loading a profile from an arbitrary file path
- test new flag behavior

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_684d085d166c832cb2aa4d768f472b22