### PR TITLE
Improve help documentation

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -4,7 +4,7 @@ All of the commands support xargs-like `-i`/`-I`/`-replace` flags.
 
 Example: `clai h | clai -i q Summarize this for me: {}`, this would summarize the output of `clai h`.
 
-Regardless of you wish to generate a photo, continue a chat or reply to your previous query, the prompt system remains the same.
+Regardless of whether you want to generate a photo, continue a chat, or reply to your previous query, the prompt system remains the same.
 
 ```bash
 clai help `# For more info about the available commands (and shorthands)`
@@ -78,8 +78,8 @@ Glob-as-arg will be deprecated at some point.
 clai cmd to show all files in home
 ```
 
-Will work like many of the popular command suggestion LLM tools out there.
-Flags works with this mode as well, such as `clai -re -g 'some_file.go' cmd to cleanup this messy code`, but it's not guaranteed the LLM will output an executable output.
+This works like many popular command-suggestion LLM tools.
+Flags work with this mode as well, for example `clai -re -g 'some_file.go' cmd to cleanup this messy code`, but it's not guaranteed the LLM will return an executable command.
 
 ### Profiles
 
@@ -89,7 +89,7 @@ Flags works with this mode as well, such as `clai -re -g 'some_file.go' cmd to c
 
 See examples [here](./examples/profiles/), try them out with `go run . -prp ./examples/profiles/cody.json q What is your purpose\?`
 
-Profiles allows you to preconfigure certain fields which will be passed to the llms, most noteably the prompt and which tools to use.
+Profiles allow you to preconfigure certain fields passed to the LLMs, most notably the prompt and which tools to use.
 This, in turn, enables you to quickly swap between different 'LLM-modes'.
 
 For instance, you may have one profile which is prompted for golang programming tasks "gopher", it has tools `write_file`, `rip grep` and `go` enabled, and then another profile which is for terraform named "terry".
@@ -101,7 +101,7 @@ This means that you can sync them across all of your machines and tweak your pro
 Yet again, I've personally utilized aliases here.
 `ask` -> Generic profile-less prompt
 `gask` -> `clai -p gopher q`, `grask` -> `clai -re -p gopher q` and then `task` -> `clai -p terry q`, etc.
-These aliases are later on synched with the rest of my dotfiles + clai profiles, so they're shared on all my development machines.
+These aliases are later synced with the rest of my dotfiles and clai profiles, so they're shared on all my development machines.
 
 ### Photos
 
@@ -123,9 +123,9 @@ NO_COLOR=true repeater -n 10 -w 3 -increment -file out.txt -output BOTH \
 
 `clai` will create configuration files at [os.GetConfigDir()](https://pkg.go.dev/os#UserConfigDir)`/.clai/`.
 First time you run `clai`, two default command-related ones, `textConfig.json` and `photoConfig.json`, will be created and then one for each specific model.
-The configuration presedence is as follows (from lowest to highest):
+The configuration precedence is as follows (from lowest to highest):
 
-1. Default hard-coded configurations [such as this](./internal/text/conf.go), these gets written to file first time you run `clai`
+1. Default hard-coded configurations [such as this](./internal/text/conf.go), these get written to file the first time you run `clai`
 1. Configurations from local `textConfig.json` or `photoConfig.json` file
 1. Profiles
 1. Flags
@@ -143,7 +143,7 @@ There's two ways to configure the models:
 Then, for each model, a new configuration file will be created.
 Since each vendor's model supports quite different configurations, the model configurations aren't exposed as flags.
 Instead, modify the model by adjusting its configuration file, found in [os.GetConfigDir()](https://pkg.go.dev/os#UserConfigDir)`/.clai/<vendor>_<model-type>_<model-name>.json`.
-This config json will in effect be unmarshaled into a request send to the model's vendor.
+This config JSON will in effect be unmarshaled into a request sent to the model's vendor.
 
 ### Conversations
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Continue a chat with another profile, or another chat model.
 
 All the configuration files and chats are json, so manual tweaks and manipulation is easy to do.
 
-If you have time, checkout [this blogpost](https://lorentz.app/blog-item.html?id=clai) for a slightly more structured introduction on how to use clai efficiently.
+If you have time, check out [this blogpost](https://lorentz.app/blog-item.html?id=clai) for a slightly more structured introduction on how to use clai efficiently.
 
 ## Supported vendors
 

--- a/internal/chat/handler.go
+++ b/internal/chat/handler.go
@@ -19,7 +19,7 @@ import (
 	"github.com/baalimago/go_away_boilerplate/pkg/num"
 )
 
-const chatUsage = `clai - (c)omand (l)ine (a)rtificial (i)intelligence
+const chatUsage = `clai - (c)ommand (l)ine (a)rtificial (i)ntelligence
 
 Usage: clai [flags] chat <subcommand> <prompt/chatID>
 
@@ -28,7 +28,7 @@ are normally used in query mode.
 
 Commands:
   n|new      <prompt>             Create a new chat with the given prompt.
-  c|cotinue  <chatID> <prompt>    Continue an existing chat with the given chat ID. Prompt is optional
+  c|continue <chatID> <prompt>    Continue an existing chat with the given chat ID. Prompt is optional
   d|delete   <chatID>             Delete the chat with the given chat ID.
   l|list                          List all existing chats.
 

--- a/internal/setup.go
+++ b/internal/setup.go
@@ -56,14 +56,14 @@ var defaultFlags = Configurations{
 	ProfilePath:   "",
 }
 
-const PROFILE_HELP = `Profiles overwrites certain model configurations. The intent of profiles
-is to reduce usage for repetitive flags, and to persist + tweak specifc llm agents.
-For instance, you may create a 'gopher' profile which has a prompt that tells the agent that it's
-a programming helper and then specify which tools it's allowed to use.
+const PROFILE_HELP = `Profiles overwrite certain model configurations. The intent of profiles
+is to reduce usage for repetitive flags and to persist and tweak specific LLM agents.
+For instance, you may create a 'gopher' profile with a prompt that explains the agent is
+a programming helper and then specify which tools it may use.
 
-Then you can use this profile by specifying it using the '-p/-profile' flag. Example:
+Use this profile by passing the '-p/-profile' flag. Example:
 
-1. clai setup -> 2 -> follow setup wizard (create 'gopher' profile)
+1. clai setup -> 2 -> follow the setup wizard (create 'gopher' profile)
 2. clai -p gopher -g internal/thing/handler.go q write tests for this file`
 
 func getModeFromArgs(cmd string) (Mode, error) {

--- a/internal/setup_flags.go
+++ b/internal/setup_flags.go
@@ -42,8 +42,8 @@ func setupFlags(defaults Configurations) Configurations {
 	ppShort := flag.String("pp", defaults.PhotoPrefix, "Set the prefix for the generated pictures. Default is 'clai'")
 	ppLong := flag.String("photo-prefix", defaults.PhotoPrefix, "Set the prefix for the generated pictures. Default is 'clai'")
 
-	gShort := flag.String("g", defaults.Glob, "Set this to true to use globbing, but from query/chat. This flag will deperecate glob mode in some upcoming release.")
-	gLong := flag.String("glob", defaults.Glob, "Set this to true to use globbing, but from query/chat. This flag will deperecate glob mode in some upcoming release.")
+	gShort := flag.String("g", defaults.Glob, "Use globbing from query or chat. This flag will deprecate glob mode in a future release.")
+	gLong := flag.String("glob", defaults.Glob, "Use globbing from query or chat. This flag will deprecate glob mode in a future release.")
 
 	pShort := flag.String("p", defaults.Profile, "Set this to the override profile you'd like to use. Configure with 'clai setup' -> 2.")
 	pLong := flag.String("profile", defaults.Profile, "Set this to the override profile you'd like to use. Configure with 'clai setup' -> 2.")

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ Prerequisites:
   - Set the DEEPSEEK_API_KEY environment variable to your Deepseek API key
   - Set the NOVITA_API_KEY environment variable to your Novita API key
   - (Optional) Set the NO_COLOR environment variable to disable ansi color output
-  - (Optional) Install glow - https://github.com/charmbracelet/glow for formated markdown output
+  - (Optional) Install glow - https://github.com/charmbracelet/glow for formatted markdown output
 
 Usage: clai [flags] <command>
 
@@ -45,7 +45,7 @@ Commands:
   h|help                        Display this help message
   s|setup                       Setup the configuration files
   q|query <text>                Query the chat model with the given text
-  p|photo <text>                Ask the photo model a picture with the requested prompt
+  p|photo <text>                Ask the photo model for a picture with the given prompt
   g|glob  <glob> <text>         Query the chat model with the contents of the files found by the glob and the given text
   cmd <text>                    Describe the command you wish to do, then execute the suggested command. It's a bit wonky when used with -re.
   re|replay                     Replay the most recent message.


### PR DESCRIPTION
## Summary
- fix various spelling issues across README, EXAMPLES and help text
- update profile help and flag descriptions
- clarify usage strings for chat and photo commands

## Testing
- `go test ./...`
- `go vet ./...` *(fails: possible context leak)*

------
https://chatgpt.com/codex/tasks/task_b_684d358aa510832c96f324a5c6b70d34