### PR TITLE
Ensure MCP tools load with tools flag

### DIFF
--- a/internal/text/querier_setup_tools.go
+++ b/internal/text/querier_setup_tools.go
@@ -85,7 +85,7 @@ func addMcpTools(ctx context.Context, mcpServersDir string) error {
 
 func setupTooling[C models.StreamCompleter](ctx context.Context, modelConf C, userConf Configurations) {
 	toolBox, ok := any(modelConf).(models.ToolBox)
-	if ok && userConf.UsingProfile() {
+	if ok && (userConf.UsingProfile() || userConf.UseTools) {
 		tools.Init()
 		// Only setup MCP tools if they're there's a chance of using tools
 		err := addMcpTools(ctx, path.Join(userConf.ConfigDir, "mcpServers"))


### PR DESCRIPTION
## Summary
- load MCP tools when `-t`/`--tools` flag is used without profiles

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68500e6364b4832c82bb40cfdf901374