### PR TITLE
Config dir generalizations + first-run cleanup

### DIFF
--- a/internal/chat/handler.go
+++ b/internal/chat/handler.go
@@ -69,7 +69,7 @@ func (q *ChatHandler) Query(ctx context.Context) error {
 	return q.actOnSubCmd(ctx)
 }
 
-func New(q models.ChatQuerier, confDir, args string, preMessages []models.Message, conf NotCyclicalImport) (*ChatHandler, error) {
+func New(q models.ChatQuerier, args string, preMessages []models.Message, conf NotCyclicalImport) (*ChatHandler, error) {
 	username := "user"
 	debug := misc.Truthy(os.Getenv("DEBUG"))
 	argsArr := strings.Split(args, " ")
@@ -80,6 +80,10 @@ func New(q models.ChatQuerier, confDir, args string, preMessages []models.Messag
 	}
 
 	subPrompt := strings.Join(argsArr[1:], " ")
+	claiDir, err := utils.GetClaiConfigDir()
+	if err != nil {
+		return nil, err
+	}
 	return &ChatHandler{
 		q:           q,
 		username:    username,
@@ -87,7 +91,7 @@ func New(q models.ChatQuerier, confDir, args string, preMessages []models.Messag
 		subCmd:      subCmd,
 		prompt:      subPrompt,
 		preMessages: preMessages,
-		convDir:     path.Join(confDir, "/.clai/conversations/"),
+		convDir:     path.Join(claiDir, "conversations"),
 		config:      conf,
 	}, nil
 }

--- a/internal/create_queriers.go
+++ b/internal/create_queriers.go
@@ -108,8 +108,7 @@ func CreateTextQuerier(ctx context.Context, conf text.Configurations) (models.Qu
 		if !isTextQuerier {
 			return nil, fmt.Errorf("failed to cast Querier using model: '%v' to TextQuerier, cannot proceed to chat", conf.Model)
 		}
-		configDir, _ := os.UserConfigDir()
-		chatQ, err := chat.New(tq, configDir, conf.PostProccessedPrompt, conf.InitialPrompt.Messages, chat.NotCyclicalImport{
+		chatQ, err := chat.New(tq, conf.PostProccessedPrompt, conf.InitialPrompt.Messages, chat.NotCyclicalImport{
 			UseTools:   conf.UseTools,
 			UseProfile: conf.UseProfile,
 			Model:      conf.Model,

--- a/internal/photo/prompt.go
+++ b/internal/photo/prompt.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path"
 
 	"github.com/baalimago/clai/internal/reply"
 	"github.com/baalimago/clai/internal/utils"
@@ -16,11 +15,11 @@ import (
 func (c *Configurations) SetupPrompts() error {
 	args := flag.Args()
 	if c.ReplyMode {
-		confDir, err := os.UserConfigDir()
+		confDir, err := utils.GetClaiConfigDir()
 		if err != nil {
 			return fmt.Errorf("failed to get config dir: %w", err)
 		}
-		iP, err := reply.Load(path.Join(confDir, ".clai"))
+		iP, err := reply.Load(confDir)
 		if err != nil {
 			return fmt.Errorf("failed to load previous query: %w", err)
 		}

--- a/internal/reply/reply.go
+++ b/internal/reply/reply.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"path"
 	"time"
 
 	"github.com/baalimago/clai/internal/chat"
 	"github.com/baalimago/clai/internal/models"
+	"github.com/baalimago/clai/internal/utils"
 	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
 )
 
@@ -46,11 +46,11 @@ func SaveAsPreviousQuery(claiConfDir string, msgs []models.Message) error {
 // is piling up quite fast here
 func Load(claiConfDir string) (models.Chat, error) {
 	if claiConfDir == "" {
-		confDir, err := os.UserConfigDir()
+		dir, err := utils.GetClaiConfigDir()
 		if err != nil {
 			return models.Chat{}, fmt.Errorf("failed to find home dir: %v", err)
 		}
-		claiConfDir = path.Join(confDir, ".clai")
+		claiConfDir = dir
 	}
 
 	c, err := chat.FromPath(path.Join(claiConfDir, "conversations", "prevQuery.json"))

--- a/internal/reply/reply.go
+++ b/internal/reply/reply.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
 	"path"
 	"time"
 
@@ -32,7 +33,11 @@ func SaveAsPreviousQuery(claiConfDir string, msgs []models.Message) error {
 			ID:       chat.IDFromPrompt(firstUserMsg.Content),
 			Messages: msgs,
 		}
-		err = chat.Save(path.Join(claiConfDir, "conversations"), convChat)
+		convPath := path.Join(claiConfDir, "conversations")
+		if _, convDirExistsErr := os.Stat(convPath); convDirExistsErr != nil {
+			os.MkdirAll(convPath, 0o755)
+		}
+		err = chat.Save(convPath, convChat)
 		if err != nil {
 			return fmt.Errorf("failed to save previous query as new conversation: %w", err)
 		}

--- a/internal/setup.go
+++ b/internal/setup.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path"
 	"runtime/debug"
 
 	"github.com/baalimago/clai/internal/glob"
@@ -99,7 +98,7 @@ func getModeFromArgs(cmd string) (Mode, error) {
 func setupTextQuerier(ctx context.Context, mode Mode, confDir string, flagSet Configurations) (models.Querier, error) {
 	// The flagset is first used to find chatModel and potentially setup a new configuration file from some default
 	tConf, err := utils.LoadConfigFromFile(confDir, "textConfig.json", migrateOldChatConfig, &text.DEFAULT)
-	tConf.ConfigDir = path.Join(confDir, ".clai")
+	tConf.ConfigDir, _ = utils.GetClaiConfigDir()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load configs: %err", err)
 	}

--- a/internal/setup.go
+++ b/internal/setup.go
@@ -55,7 +55,7 @@ var defaultFlags = Configurations{
 	ProfilePath:   "",
 }
 
-const PROFILE_HELP = `Profiles overwrite certain model configurations. The intent of profiles
+const ProfileHelp = `Profiles overwrite certain model configurations. The intent of profiles
 is to reduce usage for repetitive flags and to persist and tweak specific LLM agents.
 For instance, you may create a 'gopher' profile with a prompt that explains the agent is
 a programming helper and then specify which tools it may use.
@@ -155,7 +155,7 @@ func setupTextQuerier(ctx context.Context, mode Mode, confDir string, flagSet Co
 
 func printHelp(usage string, args []string) {
 	if len(args) > 1 && (args[1] == "profile" || args[1] == "p") {
-		fmt.Println(PROFILE_HELP)
+		fmt.Println(ProfileHelp)
 		return
 	}
 	fmt.Printf(usage,

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -67,11 +67,10 @@ func Run() error {
 	}
 	var configs []config
 	var a action
-	configDir, err := os.UserConfigDir()
+	claiDir, err := utils.GetClaiConfigDir()
 	if err != nil {
 		return fmt.Errorf("failed to get user config directory: %v", err)
 	}
-	claiDir := filepath.Join(configDir, ".clai")
 	switch input {
 	case "0":
 		t, err := getConfigs(filepath.Join(claiDir, "*Config.json"), []string{})

--- a/internal/text/conf_profile.go
+++ b/internal/text/conf_profile.go
@@ -2,15 +2,14 @@ package text
 
 import (
 	"fmt"
-	"os"
 	"path"
 
 	"github.com/baalimago/clai/internal/utils"
 )
 
 func findProfile(profileName string) (Profile, error) {
-	cfg, _ := os.UserConfigDir()
-	profilePath := path.Join(cfg, ".clai", "profiles")
+	cfg, _ := utils.GetClaiConfigDir()
+	profilePath := path.Join(cfg, "profiles")
 	var p Profile
 	err := utils.ReadAndUnmarshal(path.Join(profilePath, fmt.Sprintf("%v.json", profileName)), &p)
 	if err != nil {

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -12,25 +12,26 @@ import (
 	"github.com/baalimago/go_away_boilerplate/pkg/misc"
 )
 
-func createConfigDir(configDirPath string) error {
-	if _, err := os.Stat(configDirPath); os.IsNotExist(err) {
-		err := setupClaiConfigDir(configDirPath)
+func createConfigDir(configPath string) error {
+	requiredDirs := []string{"conversations", "profiles", "mcpServers"}
+	for _, d := range requiredDirs {
+		err := ensureDirExists(configPath, d)
 		if err != nil {
-			return fmt.Errorf("failed to setup config dotdir: %w", err)
+			return fmt.Errorf("failed to setup config dir: %w", err)
 		}
 	}
 	return nil
 }
 
-func setupClaiConfigDir(configPath string) error {
-	conversationsDir := filepath.Join(configPath, "conversations")
-	ancli.PrintOK("created conversations directory\n")
-
-	// Create the .clai directory.
-	if err := os.MkdirAll(conversationsDir, os.ModePerm); err != nil {
-		return fmt.Errorf("failed to create .clai + .clai/conversations directory: %w", err)
+func ensureDirExists(configPath, toCreate string) error {
+	shouldExist := path.Join(configPath, toCreate)
+	if _, err := os.Stat(shouldExist); os.IsNotExist(err) {
+		// Create the .clai directory.
+		if err := os.MkdirAll(shouldExist, os.ModePerm); err != nil {
+			return fmt.Errorf("failed to create .clai + .clai/%v directory: %w", toCreate, err)
+		}
+		ancli.Okf("created directory: %v \n", shouldExist)
 	}
-	ancli.PrintOK(fmt.Sprintf("created .clai directory at: '%v'\n", configPath))
 	return nil
 }
 

--- a/internal/utils/path.go
+++ b/internal/utils/path.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path"
+)
+
+// GetClaiConfigDir returns the path to the clai configuration directory.
+// The directory is located inside the user's configuration directory
+// as <UserConfigDir>/.clai.
+func GetClaiConfigDir() (string, error) {
+	cfg, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get user config directory: %w", err)
+	}
+	return path.Join(cfg, ".clai"), nil
+}

--- a/oopsies.go
+++ b/oopsies.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/baalimago/clai/internal/utils"
 	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
 )
 
@@ -23,7 +24,10 @@ func moveConfFromHomeToConfig() error {
 			return fmt.Errorf("failed to get conf dir: %w", err)
 		}
 		ancli.PrintWarn(fmt.Sprintf("oopsie detected: attempting to move config from: %v, to %v, to better adhere to standards\n", oldClaiDir, confDir))
-		newClaiDir := path.Join(confDir, ".clai")
+		newClaiDir, err := utils.GetClaiConfigDir()
+		if err != nil {
+			return fmt.Errorf("failed to get new config dir: %w", err)
+		}
 		err = os.Rename(oldClaiDir, newClaiDir)
 		if err != nil {
 			return fmt.Errorf("failed to rename: %w", err)


### PR DESCRIPTION
## Summary
- add `utils.GetClaiConfigDir` for resolving the clai config directory
- refactor chat handler to use the helper and drop obsolete parameter
- update creation of chat querier accordingly
- keep tests passing

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6852a4b65378832ca0bbb3d20c97671f