### PR TITLE
feat: Added ability to paste mcp servers from 'standard format'

### DIFF
--- a/internal/setup/mcp_parser.go
+++ b/internal/setup/mcp_parser.go
@@ -1,0 +1,101 @@
+package setup
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/baalimago/clai/internal/tools"
+	"github.com/baalimago/clai/internal/utils"
+	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
+)
+
+// McpServerInput represents the external format that users might paste
+type McpServerInput struct {
+	McpServers map[string]McpServerExternal `json:"mcpServers"`
+}
+
+// McpServerExternal represents various external MCP server formats
+type McpServerExternal struct {
+	Command string            `json:"command"`
+	Args    []string          `json:"args"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+// ParseAndAddMcpServer parses pasted MCP server configuration and adds it to the system
+func ParseAndAddMcpServer(mcpServersDir, pastedConfig string) ([]string, error) {
+	// Try to parse as the external format first
+	var input McpServerInput
+	if err := json.Unmarshal([]byte(pastedConfig), &input); err != nil {
+		return nil, fmt.Errorf("failed to parse MCP server configuration: %w", err)
+	}
+
+	if len(input.McpServers) == 0 {
+		return nil, fmt.Errorf("no MCP servers found in configuration")
+	}
+
+	ret := make([]string, 0)
+
+	// Convert and save each server
+	for serverName, externalServer := range input.McpServers {
+		internalServer := convertToInternalFormat(externalServer)
+
+		// Save to individual file
+		serverPath := filepath.Join(mcpServersDir, fmt.Sprintf("%s.json", serverName))
+		if err := utils.CreateFile(serverPath, &internalServer); err != nil {
+			return nil, fmt.Errorf("failed to create server file for %s: %w", serverName, err)
+		}
+
+		ancli.Noticef("Added MCP server: %s\n", serverName)
+		ret = append(ret, serverName)
+	}
+
+	return ret, nil
+}
+
+// convertToInternalFormat converts external format to internal tools.McpServer format
+func convertToInternalFormat(external McpServerExternal) tools.McpServer {
+	internal := tools.McpServer{
+		Command: external.Command,
+		Args:    external.Args,
+		Env:     external.Env,
+	}
+
+	// Initialize empty env map if nil
+	if internal.Env == nil {
+		internal.Env = make(map[string]string)
+	}
+
+	return internal
+}
+
+// ValidateMcpServerConfig validates that the pasted config is valid
+func ValidateMcpServerConfig(pastedConfig string) error {
+	pastedConfig = strings.TrimSpace(pastedConfig)
+	if pastedConfig == "" {
+		return fmt.Errorf("empty configuration provided")
+	}
+
+	// Try to parse as JSON
+	var input McpServerInput
+	if err := json.Unmarshal([]byte(pastedConfig), &input); err != nil {
+		return fmt.Errorf("invalid JSON format: %w", err)
+	}
+
+	if len(input.McpServers) == 0 {
+		return fmt.Errorf("no 'mcpServers' section found or it's empty")
+	}
+
+	// Validate each server
+	for serverName, server := range input.McpServers {
+		if serverName == "" {
+			return fmt.Errorf("server name cannot be empty")
+		}
+		if server.Command == "" {
+			return fmt.Errorf("command cannot be empty for server '%s'", serverName)
+		}
+	}
+
+	return nil
+}

--- a/internal/setup/mcp_parser_test.go
+++ b/internal/setup/mcp_parser_test.go
@@ -1,0 +1,157 @@
+package setup
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/baalimago/clai/internal/tools"
+)
+
+func TestValidateMcpServerConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      string
+		expectError bool
+	}{
+		{
+			name:        "empty config",
+			config:      "",
+			expectError: true,
+		},
+		{
+			name:        "invalid JSON",
+			config:      `{"invalid": json}`,
+			expectError: true,
+		},
+		{
+			name: "valid config",
+			config: `{
+				"mcpServers": {
+					"browsermcp": {
+						"command": "npx",
+						"args": ["@browsermcp/mcp@latest"]
+					}
+				}
+			}`,
+			expectError: false,
+		},
+		{
+			name: "missing command",
+			config: `{
+				"mcpServers": {
+					"test": {
+						"args": ["something"]
+					}
+				}
+			}`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMcpServerConfig(tt.config)
+			if tt.expectError && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestConvertToInternalFormat(t *testing.T) {
+	external := McpServerExternal{
+		Command: "npx",
+		Args:    []string{"@browsermcp/mcp@latest"},
+		Env:     map[string]string{"NODE_ENV": "production"},
+	}
+
+	internal := convertToInternalFormat(external)
+
+	if internal.Command != "npx" {
+		t.Errorf("expected command 'npx', got '%s'", internal.Command)
+	}
+	if len(internal.Args) != 1 || internal.Args[0] != "@browsermcp/mcp@latest" {
+		t.Errorf("expected args ['@browsermcp/mcp@latest'], got %v", internal.Args)
+	}
+	if internal.Env["NODE_ENV"] != "production" {
+		t.Errorf("expected env NODE_ENV=production, got %v", internal.Env)
+	}
+}
+
+func TestConvertToInternalFormatNilEnv(t *testing.T) {
+	external := McpServerExternal{
+		Command: "echo",
+		Args:    []string{"hello"},
+	}
+
+	internal := convertToInternalFormat(external)
+
+	if internal.Env == nil {
+		t.Error("expected env to be initialized as empty map")
+	}
+}
+
+func TestParseAndAddMcpServer(t *testing.T) {
+	tempDir := t.TempDir()
+
+	config := `{
+		"mcpServers": {
+			"browsermcp": {
+				"command": "npx",
+				"args": ["@browsermcp/mcp@latest"]
+			},
+			"filesystem": {
+				"command": "npx",
+				"args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+				"env": {"DEBUG": "true"}
+			}
+		}
+	}`
+
+	got, err := ParseAndAddMcpServer(tempDir, config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"browsermcp", "filesystem"}
+	bothOk := true
+	for _, k := range want {
+		if !slices.Contains(got, k) {
+			bothOk = false
+		}
+	}
+	if !bothOk {
+		t.Fatalf("expected: %v, to have: %v", got, want)
+	}
+
+	// Check that files were created
+	browsermcpPath := filepath.Join(tempDir, "browsermcp.json")
+	filesystemPath := filepath.Join(tempDir, "filesystem.json")
+
+	if _, statErr := os.Stat(browsermcpPath); os.IsNotExist(statErr) {
+		t.Error("browsermcp.json was not created")
+	}
+	if _, statErr := os.Stat(filesystemPath); os.IsNotExist(statErr) {
+		t.Error("filesystem.json was not created")
+	}
+
+	// Verify content of one file
+	data, err := os.ReadFile(browsermcpPath)
+	if err != nil {
+		t.Fatalf("failed to read browsermcp.json: %v", err)
+	}
+
+	var server tools.McpServer
+	if err := json.Unmarshal(data, &server); err != nil {
+		t.Fatalf("failed to unmarshal server config: %v", err)
+	}
+
+	if server.Command != "npx" {
+		t.Errorf("expected command 'npx', got '%s'", server.Command)
+	}
+}

--- a/internal/setup/setup_actions.go
+++ b/internal/setup/setup_actions.go
@@ -49,8 +49,11 @@ func queryForAction(options []action) (action, error) {
 		if slices.Contains(options, confWithEditor) {
 			ret = confWithEditor
 		}
+	case "p", "pasteNew":
+		ret = pasteNew
 	case "q", "quit":
 		return unset, utils.ErrUserInitiatedExit
+
 	}
 
 	if ret == unset {

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -12,7 +12,7 @@ import (
 	"github.com/baalimago/go_away_boilerplate/pkg/misc"
 )
 
-func createConfigDir(configPath string) error {
+func CreateConfigDir(configPath string) error {
 	requiredDirs := []string{"conversations", "profiles", "mcpServers"}
 	for _, d := range requiredDirs {
 		err := ensureDirExists(configPath, d)
@@ -71,7 +71,7 @@ func LoadConfigFromFile[T any](
 		ancli.PrintOK(fmt.Sprintf("attempting to load file: %v%v\n", configDirPath, configFileName))
 	}
 
-	err := createConfigDir(configDirPath)
+	err := CreateConfigDir(configDirPath)
 	if err != nil {
 		var nilVal T
 		return nilVal, err

--- a/internal/utils/config_test.go
+++ b/internal/utils/config_test.go
@@ -107,7 +107,7 @@ func TestCreateConfigDir(t *testing.T) {
 	configDirPath := filepath.Join(t.TempDir(), ".clai")
 
 	// Test creating a new config directory
-	err := createConfigDir(configDirPath)
+	err := CreateConfigDir(configDirPath)
 	if err != nil {
 		t.Errorf("Unexpected error creating config directory: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestCreateConfigDir(t *testing.T) {
 	}
 
 	// Test creating an existing config directory
-	err = createConfigDir(configDirPath)
+	err = CreateConfigDir(configDirPath)
 	if err != nil {
 		t.Errorf("Unexpected error creating existing config directory: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -93,6 +93,19 @@ func main() {
 	if err != nil {
 		ancli.PrintWarn(fmt.Sprintf("failed to handle oopsies, but as we didn't panic, it should be benign. Error: %v\n", err))
 	}
+
+	configDirPath, err := utils.GetClaiConfigDir()
+	if err != nil {
+		ancli.Errf("failed to find config dir path: %v", err)
+		os.Exit(1)
+	}
+
+	err = utils.CreateConfigDir(configDirPath)
+	if err != nil {
+		ancli.Errf("failed to find config dir path: %v", err)
+		os.Exit(1)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	querier, err := internal.Setup(ctx, usage)
 	if err != nil {


### PR DESCRIPTION
This is the standard format:
``` json
{
  "mcpServers": {
    "sequential-thinking": {
      "command": "npx",
      "args": [
        "-y",
        "@modelcontextprotocol/server-sequential-thinking"
      ]
    }
  }
}
```

You can now paste this by running `clai setup -> 3 -> 'p' -> paste`