### PR TITLE
Upgrade rate limit circumvention

### DIFF
--- a/internal/chat/chat.go
+++ b/internal/chat/chat.go
@@ -37,7 +37,7 @@ func Save(saveAt string, chat models.Chat) error {
 	}
 	fileName := path.Join(saveAt, fmt.Sprintf("%v.json", chat.ID))
 	if misc.Truthy(os.Getenv("DEBUG")) && misc.Truthy(os.Getenv("DEBUG_VERBOSE")) || misc.Truthy(os.Getenv("DEBUG_REPLY_MODE")) {
-		ancli.PrintOK(fmt.Sprintf("saving chat to: '%v', content (on new line):\n'%v'\n", fileName, string(b)))
+		ancli.PrintOK(fmt.Sprintf("saving chat to: '%v'", fileName))
 	}
 	return os.WriteFile(fileName, b, 0o644)
 }

--- a/internal/text/querier.go
+++ b/internal/text/querier.go
@@ -340,9 +340,10 @@ func (q *Querier[C]) handleFunctionCall(ctx context.Context, call tools.Call) er
 	}
 	// Post process here since a function call should be treated as the function call
 	// should be handeled mid-stream, but still requires multiple rounds of user input
+	pre := q.shouldSaveReply
 	q.shouldSaveReply = false
 	q.postProcess()
-	q.shouldSaveReply = true
+	q.shouldSaveReply = pre
 
 	call.Patch()
 	call.Function.Inputs.Patch()

--- a/internal/text/querier_setup_tools.go
+++ b/internal/text/querier_setup_tools.go
@@ -17,11 +17,35 @@ import (
 	"github.com/baalimago/go_away_boilerplate/pkg/misc"
 )
 
+// filterMcpServersByProfile filters MCP server files based on whether their tools are needed by the profile
+func filterMcpServersByProfile(files []string, userConf Configurations) []string {
+	// If no specific tools are configured, load all servers (existing behavior)
+	if len(userConf.Tools) == 0 {
+		return files
+	}
+
+	var filteredFiles []string
+	for _, file := range files {
+		serverName := strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))
+		mcpPrefix := "mcp_" + serverName + "_"
+
+		// Check if any tool in the profile matches this MCP server
+		for _, tool := range userConf.Tools {
+			if strings.HasPrefix(tool, mcpPrefix) || strings.Contains(tool, "*") {
+				filteredFiles = append(filteredFiles, file)
+				break
+			}
+		}
+	}
+
+	return filteredFiles
+}
+
 // addMcpTools loads MCP server configurations from a directory.
 // Each file inside the directory should contain a single MCP server configuration.
 // Every server is started and its tools registered with a prefix of the filename.
 // If the directory is missing, an error is returned.
-func addMcpTools(ctx context.Context, mcpServersDir string) error {
+func addMcpTools(ctx context.Context, mcpServersDir string, userConf Configurations) error {
 	if _, err := os.Stat(mcpServersDir); os.IsNotExist(err) {
 		return fmt.Errorf("MCP servers directory not found at %s.\nIf you want MCP server support, create one using 'clai setup' and select option 3", mcpServersDir)
 	}
@@ -30,15 +54,16 @@ func addMcpTools(ctx context.Context, mcpServersDir string) error {
 	if err != nil {
 		return fmt.Errorf("failed to list mcp server configs: %w", err)
 	}
-
+	// Filter MCP servers based on profile tools
+	filteredFiles := filterMcpServersByProfile(files, userConf)
 	controlChannel := make(chan mcp.ControlEvent)
 	statusChan := make(chan error, 1)
 
 	toolWg := sync.WaitGroup{}
-	toolWg.Add(len(files))
+	toolWg.Add(len(filteredFiles))
 	go mcp.Manager(ctx, controlChannel, statusChan, &toolWg)
 
-	for _, file := range files {
+	for _, file := range filteredFiles {
 		data, err := os.ReadFile(file)
 		if err != nil {
 			continue
@@ -89,7 +114,7 @@ func setupTooling[C models.StreamCompleter](ctx context.Context, modelConf C, us
 	if ok && (userConf.UsingProfile() || userConf.UseTools) {
 		tools.Init()
 		// Only setup MCP tools if they're there's a chance of using tools
-		err := addMcpTools(ctx, path.Join(userConf.ConfigDir, "mcpServers"))
+		err := addMcpTools(ctx, path.Join(userConf.ConfigDir, "mcpServers"), userConf)
 		if misc.Truthy(os.Getenv("DEBUG")) {
 			ancli.Okf("Registering tools on querier of type: %T\n", modelConf)
 		}

--- a/internal/text/querier_setup_tools_test.go
+++ b/internal/text/querier_setup_tools_test.go
@@ -1,1 +1,76 @@
 package text
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
+)
+
+func Test_filterMcpServersByProfile(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    []string
+		userConf Configurations
+		want     []string
+	}{
+		{
+			name:  "No specific tools configured, return all files",
+			files: []string{"server1.json", "server2.json"},
+			userConf: Configurations{
+				Tools: []string{},
+			},
+			want: []string{"server1.json", "server2.json"},
+		},
+		{
+			name:  "Specific tool matches one server",
+			files: []string{"server1.json", "server2.json"},
+			userConf: Configurations{
+				Tools: []string{"mcp_server1"},
+			},
+			want: []string{"server1.json"},
+		},
+		{
+			name:  "Wildcard matches all mcp",
+			files: []string{"server1.json", "server2.json"},
+			userConf: Configurations{
+				Tools: []string{"mcp_*"},
+			},
+			want: []string{"server1.json", "server2.json"},
+		},
+		{
+			name:  "Wildcard match on some servers",
+			files: []string{"server1.json", "server2.json"},
+			userConf: Configurations{
+				Tools: []string{"mcp_server1*"},
+			},
+			want: []string{"server1.json"},
+		},
+		{
+			name:  "Match on server tool",
+			files: []string{"server1.json", "server2.json"},
+			userConf: Configurations{
+				Tools: []string{"mcp_server1_tool0"},
+			},
+			want: []string{"server1.json"},
+		},
+		{
+			name:  "No match for any servers",
+			files: []string{"server1.json", "server2.json"},
+			userConf: Configurations{
+				Tools: []string{"mcp_server3"},
+			},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ancli.Noticef("== test: %v\n", tt.name)
+			got := filterMcpServersByProfile(tt.files, tt.userConf)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("want %v, got: %v", tt.want, got)
+			}
+		})
+	}
+}

--- a/internal/tools/mcp/manager.go
+++ b/internal/tools/mcp/manager.go
@@ -74,10 +74,10 @@ func handleServer(ctx context.Context, ev ControlEvent, readyChan chan struct{})
 	}
 	resp, err = sendRequest(ctx, ev.InputChan, ev.OutputChan, listReq)
 	if err != nil {
-		return fmt.Errorf("tools/list: %w", err)
+		return fmt.Errorf("tools/list err: %w", err)
 	}
 	if resp.Error != nil {
-		return fmt.Errorf("tools/list: %s", resp.Error.Message)
+		return fmt.Errorf("tools/list resp.Error: %s", resp.Error.Message)
 	}
 	var listRes struct {
 		Tools []Tool `json:"tools"`
@@ -94,7 +94,7 @@ func handleServer(ctx context.Context, ev ControlEvent, readyChan chan struct{})
 			continue
 		}
 		spec := tools.Specification{
-			Name:        fmt.Sprintf("mcp_%s", t.Name),
+			Name:        fmt.Sprintf("mcp_%s_%s", ev.ServerName, t.Name),
 			Description: t.Description,
 			Inputs:      t.InputSchema,
 		}
@@ -122,7 +122,7 @@ func sendRequest(ctx context.Context, in chan<- any, out <-chan any, req Request
 			raw, ok := msg.(json.RawMessage)
 			if !ok {
 				if err, ok := msg.(error); ok {
-					return Response{}, err
+					return Response{}, fmt.Errorf("failed to parse json.RawMessage: '%v', err: %w", msg, err)
 				}
 				continue
 			}

--- a/internal/tools/mcp/manager_test.go
+++ b/internal/tools/mcp/manager_test.go
@@ -23,13 +23,13 @@ func TestHandleServerRegistersTool(t *testing.T) {
 	tools.Registry = tools.NewRegistry()
 	defer func() { tools.Registry = orig }()
 
-	ev := ControlEvent{ServerName: "ts", Server: srv, InputChan: in, OutputChan: out}
+	ev := ControlEvent{ServerName: "echo", Server: srv, InputChan: in, OutputChan: out}
 	readyChan := make(chan struct{}, 1)
 	if serveErr := handleServer(ctx, ev, readyChan); serveErr != nil {
 		t.Fatalf("handleServer: %v", serveErr)
 	}
 
-	tool, ok := tools.Registry.Get("mcp_echo")
+	tool, ok := tools.Registry.Get("mcp_echo_echo")
 	if !ok {
 		t.Fatal("tool not registered")
 	}
@@ -65,11 +65,11 @@ func TestManager(t *testing.T) {
 	wg.Add(1)
 	go Manager(ctx, controlCh, statusCh, &wg)
 
-	controlCh <- ControlEvent{ServerName: "man", Server: srv, InputChan: in, OutputChan: out}
+	controlCh <- ControlEvent{ServerName: "echo", Server: srv, InputChan: in, OutputChan: out}
 
 	var ok bool
 	for i := 0; i < 20; i++ {
-		_, ok = tools.Registry.Get("mcp_echo")
+		_, ok = tools.Registry.Get("mcp_echo_echo")
 		if ok {
 			break
 		}

--- a/internal/tools/programming_tool_recall.go
+++ b/internal/tools/programming_tool_recall.go
@@ -75,8 +75,9 @@ func (r RecallTool) Call(input Input) (string, error) {
 		return "", fmt.Errorf("failed to decode conversation: %w", err)
 	}
 
-	if idx < 0 || idx >= len(conv.Messages) {
-		return "", fmt.Errorf("index out of range")
+	lenConv := len(conv.Messages)
+	if idx < 0 || idx >= lenConv {
+		return "", fmt.Errorf("index out of range. Am messages: %v, index: %v", lenConv, idx)
 	}
 	msg := conv.Messages[idx]
 	return fmt.Sprintf("%s: %s", msg.Role, msg.Content), nil

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -37,14 +37,14 @@ func (r *registry) WildcardGet(pattern string) []LLMTool {
 
 	var matches []LLMTool
 	for name, tool := range r.tools {
-		if wildcardMatch(pattern, name) {
+		if WildcardMatch(pattern, name) {
 			matches = append(matches, tool)
 		}
 	}
 	return matches
 }
 
-func wildcardMatch(pattern, name string) bool {
+func WildcardMatch(pattern, name string) bool {
 	if pattern == "*" {
 		return true
 	}
@@ -71,7 +71,7 @@ func wildcardMatch(pattern, name string) bool {
 // Set registers tool under the provided name.
 func (r *registry) Set(name string, t LLMTool) {
 	r.mu.Lock()
-	if r.debug {
+	if r.debug || misc.Truthy(os.Getenv("DEBUG_TOOLS_REGISTRY_SET")) {
 		ancli.Okf("adding tool too registry, name: %v\n", t.Specification().Name)
 	}
 	r.tools[name] = t

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -113,11 +113,12 @@ func TestRegistry_WildcardGet(t *testing.T) {
 
 	// Setup test tools
 	tools := map[string]*mockLLMTool{
-		"bash_cat":  newMockTool("bash_cat"),
-		"bash_find": newMockTool("bash_find"),
-		"prog_git":  newMockTool("prog_git"),
-		"prog_go":   newMockTool("prog_go"),
-		"web_fetch": newMockTool("web_fetch"),
+		"bash_cat":           newMockTool("bash_cat"),
+		"bash_find":          newMockTool("bash_find"),
+		"prog_git":           newMockTool("prog_git"),
+		"prog_go":            newMockTool("prog_go"),
+		"web_fetch":          newMockTool("web_fetch"),
+		"mcp_everyhing_test": newMockTool("mcp_everyhing_test"),
 	}
 
 	for name, tool := range tools {
@@ -128,13 +129,14 @@ func TestRegistry_WildcardGet(t *testing.T) {
 		pattern  string
 		expected []string
 	}{
-		{"*", []string{"bash_cat", "bash_find", "prog_git", "prog_go", "web_fetch"}},
+		{"*", []string{"bash_cat", "bash_find", "prog_git", "prog_go", "web_fetch", "mcp_everyhing_test"}},
 		{"bash_*", []string{"bash_cat", "bash_find"}},
 		{"*_git", []string{"prog_git"}},
 		{"*prog*", []string{"prog_git", "prog_go"}},
 		{"bash_cat", []string{"bash_cat"}},
 		{"nonexistent", []string{}},
 		{"*nonexistent*", []string{}},
+		{"mcp_everyhing*", []string{"mcp_everyhing_test"}},
 	}
 
 	for _, tc := range testCases {
@@ -187,7 +189,7 @@ func TestWildcardMatch(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.pattern+"_"+tc.name, func(t *testing.T) {
-			result := wildcardMatch(tc.pattern, tc.name)
+			result := WildcardMatch(tc.pattern, tc.name)
 			if result != tc.expected {
 				t.Errorf("wildcardMatch(%q, %q) = %v, want %v",
 					tc.pattern, tc.name, result, tc.expected)


### PR DESCRIPTION
It now actually works decently. Only problem is that it's not prompted well enough, so it eats up _alot_ of tokens. But,
then again, so does Codex and the likes, only that it's still in beta so it's for free.

Changes:
  * Upgraded summary + resume prompts
  * Fixed issues where multi-summarized conversations would overwrite its own conv
  * Added some MCP server startup optimizations (this was task for LLM while debuggin)