### PR TITLE
feat: Gemini flash image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ See [examples](./EXAMPLES.md) for additional info.
 
 ## Supported vendors
 
-| Vendor    | Environment Variable | Models                                                                                                                                             |
-| --------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| OpenAI    | `OPENAI_API_KEY`     | [Text models](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo), [photo models](https://platform.openai.com/docs/models/dall-e)       |
-| Anthropic | `ANTHROPIC_API_KEY`  | [Text models](https://docs.anthropic.com/claude/docs/models-overview#model-recommendations)                                                        |
-| Mistral   | `MISTRAL_API_KEY`    | [Text models](https://docs.mistral.ai/getting-started/models/)                                                                                     |
-| Deepseek  | `DEEPSEEK_API_KEY`   | [Text models](https://api-docs.deepseek.com/quick_start/pricing)                                                                                   |
-| Novita AI | `NOVITA_API_KEY`     | [Text models](https://novita.ai/model-api/product/llm-api?utm_source=github_clai&utm_medium=github_readme&utm_campaign=link), use prefix `novita:` |
-| Ollama    | N/A                  | Use format `ollama:` (defaults to llama3), server defaults to localhost:11434                                                                      |
-| Inception | `INCEPTION_API_KEY`  | [Text models](https://platform.inceptionlabs.ai/docs#models)                                                                                       |
-| xAi       | `XAI_API_KEY`        | [Text models](https://docs.x.ai/docs/models)                                                                                                       |
-| Gemini    | `GEMINI_API_KEY`     | [Text models](https://ai.google.dev/gemini-api/docs/models)                                                                                        |
+| Vendor    | Environment Variable | Models                                                                                                                                                             |
+| --------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| OpenAI    | `OPENAI_API_KEY`     | [Text models](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo), [photo models](https://platform.openai.com/docs/models/dall-e)                       |
+| Anthropic | `ANTHROPIC_API_KEY`  | [Text models](https://docs.anthropic.com/claude/docs/models-overview#model-recommendations)                                                                        |
+| Mistral   | `MISTRAL_API_KEY`    | [Text models](https://docs.mistral.ai/getting-started/models/)                                                                                                     |
+| Deepseek  | `DEEPSEEK_API_KEY`   | [Text models](https://api-docs.deepseek.com/quick_start/pricing)                                                                                                   |
+| Novita AI | `NOVITA_API_KEY`     | [Text models](https://novita.ai/model-api/product/llm-api?utm_source=github_clai&utm_medium=github_readme&utm_campaign=link), use prefix `novita:`                 |
+| Ollama    | N/A                  | Use format `ollama:` (defaults to llama3), server defaults to localhost:11434                                                                                      |
+| Inception | `INCEPTION_API_KEY`  | [Text models](https://platform.inceptionlabs.ai/docs#models)                                                                                                       |
+| xAi       | `XAI_API_KEY`        | [Text models](https://docs.x.ai/docs/models)                                                                                                                       |
+| Gemini    | `GEMINI_API_KEY`     | [Text models](https://ai.google.dev/gemini-api/docs/models), [photo models](https://ai.google.dev/gemini-api/docs/image-generation#image_generation_text-to-image) |
 
 ## Get started
 

--- a/internal/create_queriers.go
+++ b/internal/create_queriers.go
@@ -175,7 +175,7 @@ func CreateTextQuerier(ctx context.Context, conf text.Configurations) (models.Qu
 	return q, nil
 }
 
-func NewPhotoQuerier(conf photo.Configurations) (models.Querier, error) {
+func CreatePhotoQuerier(conf photo.Configurations) (models.Querier, error) {
 	if err := photo.ValidateOutputType(conf.Output.Type); err != nil {
 		return nil, err
 	}
@@ -190,6 +190,14 @@ func NewPhotoQuerier(conf photo.Configurations) (models.Querier, error) {
 		q, err := openai.NewPhotoQuerier(conf)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create dall-e photo querier: %w", err)
+		}
+		return q, nil
+	}
+
+	if strings.Contains(conf.Model, "gemini") {
+		q, err := gemini.NewPhotoQuerier(conf)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create gemini photo querier: %w", err)
 		}
 		return q, nil
 	}

--- a/internal/create_queriers_test.go
+++ b/internal/create_queriers_test.go
@@ -31,7 +31,7 @@ func TestNewPhotoQuerier(t *testing.T) {
 	os.Setenv("OPENAI_API_KEY", "key")
 	defer os.Unsetenv("OPENAI_API_KEY")
 	conf := photo.Configurations{Model: "dall-e-3", Output: photo.Output{Type: photo.URL, Dir: tmp}}
-	q, err := NewPhotoQuerier(conf)
+	q, err := CreatePhotoQuerier(conf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/photo/store.go
+++ b/internal/photo/store.go
@@ -1,0 +1,29 @@
+package photo
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	"github.com/baalimago/clai/internal/utils"
+	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
+)
+
+func SaveImage(out Output, b64JSON, encoding string) (string, error) {
+	data, err := base64.StdEncoding.DecodeString(b64JSON)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode base64: %w", err)
+	}
+	pictureName := fmt.Sprintf("%v_%v.%v", out.Prefix, utils.RandomPrefix(), encoding)
+	outFile := fmt.Sprintf("%v/%v", out.Dir, pictureName)
+	err = os.WriteFile(outFile, data, 0o644)
+	if err != nil {
+		ancli.PrintWarn(fmt.Sprintf("failed to write file: '%v', attempting tmp file...\n", err))
+		outFile = fmt.Sprintf("/tmp/%v", pictureName)
+		err = os.WriteFile(outFile, data, 0o644)
+		if err != nil {
+			return "", fmt.Errorf("failed to write file: %w", err)
+		}
+	}
+	return outFile, nil
+}

--- a/internal/setup.go
+++ b/internal/setup.go
@@ -207,7 +207,7 @@ func Setup(ctx context.Context, usage string) (models.Querier, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to setup prompt: %v", err)
 		}
-		pq, err := NewPhotoQuerier(pConf)
+		pq, err := CreatePhotoQuerier(pConf)
 		if misc.Truthy(os.Getenv("DEBUG")) {
 			ancli.PrintOK(fmt.Sprintf("photo querier: %+v\n", imagodebug.IndentedJsonFmt(pq)))
 		}

--- a/internal/vendors/gemini/image.go
+++ b/internal/vendors/gemini/image.go
@@ -1,0 +1,147 @@
+package gemini
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/baalimago/clai/internal/models"
+	"github.com/baalimago/clai/internal/photo"
+	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
+	"golang.org/x/net/context"
+)
+
+// Behold, a multi-billion dollar company API request/resonse schema
+type InlineData struct {
+	MimeType string `json:"mime_type"`
+	Data     string `json:"data"`
+}
+
+type Part struct {
+	InlineData *InlineData `json:"inlineData,omitempty"`
+	Text       *string     `json:"text,omitempty"`
+}
+
+type Content struct {
+	Parts []Part `json:"parts"`
+}
+
+type GeminiRequest struct {
+	Contents []Content `json:"contents"`
+}
+
+type GeminiFlashImage struct {
+	photo.Configurations
+	apiKey string
+}
+
+type Candidate struct {
+	Content Content `json:"content"`
+}
+
+type GeminiResponse struct {
+	Candidates []Candidate `json:"candidates"`
+}
+
+func (gr *GeminiResponse) GetFirstB64Blob() string {
+	for _, candidate := range gr.Candidates {
+		for _, part := range candidate.Content.Parts {
+			if part.InlineData != nil {
+				return part.InlineData.Data
+			}
+		}
+	}
+	return ""
+}
+
+// Seems like gemini lacks a lot of configuration. Even the model selection is via url, not body
+const urlFormat = "https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent"
+
+func (g *GeminiFlashImage) Query(ctx context.Context) error {
+	if !g.Raw {
+		stop := photo.StartAnimation()
+		defer stop()
+	}
+
+	url := fmt.Sprintf(urlFormat, g.Model)
+	req := GeminiRequest{
+		Contents: []Content{
+			{
+				Parts: []Part{
+					{
+						Text: &g.Prompt,
+					},
+				},
+			},
+		},
+	}
+	b, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	httpReq, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		url,
+		bytes.NewReader(b),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to creat gemini req: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if g.apiKey != "" {
+		httpReq.Header.Set("x-goog-api-key", g.apiKey)
+	}
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("failed to query gemini: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf(
+			"gemini: status %d: %s",
+			resp.StatusCode,
+			string(body),
+		)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read body: %w", err)
+	}
+	var gemResp GeminiResponse
+	if err := json.Unmarshal(body, &gemResp); err != nil {
+		return fmt.Errorf("failed to decode JSON: %w", err)
+	}
+
+	localPath, err := photo.SaveImage(
+		g.Output,
+		gemResp.GetFirstB64Blob(),
+		"png")
+	if err != nil {
+		return fmt.Errorf("failed to save image: %w", err)
+	}
+	// Defer to let animator finish first
+	defer func() {
+		ancli.PrintOK(fmt.Sprintf("image saved to: '%v'\n", localPath))
+	}()
+
+	return nil
+}
+
+func NewPhotoQuerier(pConf photo.Configurations) (models.Querier, error) {
+	apiKey := os.Getenv("GEMINI_API_KEY")
+	if apiKey == "" {
+		return nil, fmt.Errorf("environment variable 'GEMINI_API_KEY' not set")
+	}
+
+	geminiFlash := GeminiFlashImage{
+		pConf,
+		apiKey,
+	}
+	return &geminiFlash, nil
+}

--- a/internal/vendors/openai/dalle.go
+++ b/internal/vendors/openai/dalle.go
@@ -3,7 +3,6 @@ package openai
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -161,7 +160,7 @@ func (q *DallE) do(req *http.Request) error {
 			ancli.PrintOK(fmt.Sprintf("image URL: '%v'", imgResps.Data[0].URL))
 		}()
 	} else {
-		localPath, err := q.saveImage(imgResps.Data[0])
+		localPath, err := photo.SaveImage(q.Output, imgResps.Data[0].B64JSON, "jpg")
 		if err != nil {
 			return fmt.Errorf("failed to save image: %w", err)
 		}
@@ -177,25 +176,6 @@ func (q *DallE) do(req *http.Request) error {
 	}()
 
 	return nil
-}
-
-func (q *DallE) saveImage(imgResp ImageResponse) (string, error) {
-	data, err := base64.StdEncoding.DecodeString(imgResp.B64JSON)
-	if err != nil {
-		return "", fmt.Errorf("failed to decode base64: %w", err)
-	}
-	pictureName := fmt.Sprintf("%v_%v.jpg", q.Output.Prefix, utils.RandomPrefix())
-	outFile := fmt.Sprintf("%v/%v", q.Output.Dir, pictureName)
-	err = os.WriteFile(outFile, data, 0o644)
-	if err != nil {
-		ancli.PrintWarn(fmt.Sprintf("failed to write file: '%v', attempting tmp file...\n", err))
-		outFile = fmt.Sprintf("/tmp/%v", pictureName)
-		err = os.WriteFile(outFile, data, 0o644)
-		if err != nil {
-			return "", fmt.Errorf("failed to write file: %w", err)
-		}
-	}
-	return outFile, nil
 }
 
 func (q *DallE) Query(ctx context.Context) error {


### PR DESCRIPTION
Only support for text2image at the moment. Might extend this and support omni-models at some point but I don't see the productive value of it tbh. Generating images is mostly ftlulz

Try it out with:
1. Add `GEMINI_API_KEY=<your token>` as env var
2. `clai -pm gemini-2.5-flash-image photo Generate an image of a litter of sleeping puppies please`