### PR TITLE
feat: Gemini 3 pro preview support

### DIFF
--- a/internal/text/generic/stream_completer_models.go
+++ b/internal/text/generic/stream_completer_models.go
@@ -22,6 +22,7 @@ type StreamCompleter struct {
 	// Argument string exists since the arguments for function calls is streamed token by token... yeah... great idea
 	toolsCallArgsString string
 	toolsCallID         string
+	extraContent        map[string]any
 	client              *http.Client
 	apiKey              string
 	debug               bool
@@ -60,11 +61,16 @@ type Delta struct {
 	ToolCalls []ToolsCall `json:"tool_calls"`
 }
 
+type ExtraContent map[string]map[string]any
+
 type ToolsCall struct {
 	Function Func   `json:"function"`
 	ID       string `json:"id"`
 	Index    int    `json:"index"`
 	Type     string `json:"type"`
+
+	// ExtraContent for initially google thought_signature
+	ExtraContent map[string]any `json:"extra_content,omitempty"`
 }
 
 type Func struct {

--- a/internal/text/querier_gemini_test.go
+++ b/internal/text/querier_gemini_test.go
@@ -1,0 +1,151 @@
+package text
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/baalimago/clai/internal/models"
+	pub_models "github.com/baalimago/clai/pkg/text/models"
+)
+
+func Test_checkIfGemini3Preview(t *testing.T) {
+	t.Run("should return false if no extra content", func(t *testing.T) {
+		q := &Querier[*MockQuerier]{}
+		call := pub_models.Call{}
+		if q.checkIfGemini3Preview(call) {
+			t.Error("expected false, got true")
+		}
+	})
+
+	t.Run("should return false if extra content is not google", func(t *testing.T) {
+		q := &Querier[*MockQuerier]{}
+		call := pub_models.Call{
+			ExtraContent: map[string]any{
+				"openai": "something",
+			},
+		}
+		if q.checkIfGemini3Preview(call) {
+			t.Error("expected false, got true")
+		}
+	})
+
+	t.Run("should return true if extra content has google thought_signature", func(t *testing.T) {
+		q := &Querier[*MockQuerier]{}
+		call := pub_models.Call{
+			ExtraContent: map[string]any{
+				"google": map[string]any{
+					"thought_signature": "some signature",
+				},
+			},
+		}
+		if !q.checkIfGemini3Preview(call) {
+			t.Error("expected true, got false")
+		}
+	})
+
+	t.Run("should return true if already detected", func(t *testing.T) {
+		q := &Querier[*MockQuerier]{
+			isLikelyGemini3Preview: true,
+		}
+		call := pub_models.Call{}
+		if !q.checkIfGemini3Preview(call) {
+			t.Error("expected true, got false")
+		}
+	})
+}
+
+func Test_handleFunctionCall_GeminiLogic(t *testing.T) {
+	t.Run("should return nil and not call tool if Gemini 3 detected and no extra content", func(t *testing.T) {
+		q := &Querier[*MockQuerier]{
+			isLikelyGemini3Preview: true,
+			// Model is nil, will panic if TextQuery is called
+		}
+
+		call := pub_models.Call{
+			Name:         "some_tool",
+			ExtraContent: nil,
+		}
+
+		err := q.handleFunctionCall(context.Background(), call)
+		if err != nil {
+			t.Errorf("expected nil error (early return), got: %v", err)
+		}
+	})
+
+	t.Run("should NOT return early if Gemini 3 detected AND extra content present", func(t *testing.T) {
+		mockModel := &MockQuerier{
+			errChan:        make(chan error, 1),
+			completionChan: make(chan models.CompletionEvent, 1),
+		}
+		mockModel.errChan <- errors.New("mock error to stop query")
+
+		q := &Querier[*MockQuerier]{
+			isLikelyGemini3Preview: true,
+			Model:                  mockModel,
+		}
+
+		call := pub_models.Call{
+			Name: "some_tool",
+			ExtraContent: map[string]any{
+				"foo": "bar",
+			},
+		}
+
+		err := q.handleFunctionCall(context.Background(), call)
+
+		expectedErr := "failed to query after tool call: TextQuery: failed to handle completion: completion stream error: mock error to stop query"
+		if err == nil {
+			t.Error("expected error, got nil")
+		} else if err.Error() != expectedErr {
+			t.Errorf("expected error \n'%v'\n, got: \n'%v'", expectedErr, err)
+		}
+	})
+
+	t.Run("should detect Gemini 3 and return early in one pass", func(t *testing.T) {
+		mockModel := &MockQuerier{
+			errChan:        make(chan error, 1),
+			completionChan: make(chan models.CompletionEvent, 1),
+		}
+
+		go func() {
+			mockModel.errChan <- errors.New("mock error to stop query")
+		}()
+
+		q := &Querier[*MockQuerier]{
+			isLikelyGemini3Preview: false,
+			Model:                  mockModel,
+		}
+
+		call1 := pub_models.Call{
+			Name: "some_tool",
+			ExtraContent: map[string]any{
+				"google": map[string]any{
+					"thought_signature": "confirmed",
+				},
+			},
+		}
+
+		err := q.handleFunctionCall(context.Background(), call1)
+		expectedErr := "failed to query after tool call: TextQuery: failed to handle completion: completion stream error: mock error to stop query"
+		if err == nil {
+			t.Error("expected error, got nil")
+		} else if err.Error() != expectedErr {
+			t.Errorf("expected error \n'%v'\n, got: \n'%v'", expectedErr, err)
+		}
+
+		if !q.isLikelyGemini3Preview {
+			t.Error("expected isLikelyGemini3Preview to be set to true")
+		}
+
+		// Second call has NO extra content. Should return early (no error).
+		call2 := pub_models.Call{
+			Name:         "some_tool",
+			ExtraContent: nil,
+		}
+		err = q.handleFunctionCall(context.Background(), call2)
+		if err != nil {
+			t.Errorf("expected nil error (early return), got: %v", err)
+		}
+	})
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -71,6 +71,9 @@ func WildcardMatch(pattern, name string) bool {
 // Set registers tool under the provided name.
 func (r *registry) Set(name string, t LLMTool) {
 	r.mu.Lock()
+	if strings.Contains(name, "printEnv") {
+		ancli.Warnf("found env printing tool, skipping for security's sake. Tool name: '%v'", name)
+	}
 	if r.debug || misc.Truthy(os.Getenv("DEBUG_TOOLS_REGISTRY_SET")) {
 		ancli.Okf("adding tool too registry, name: %v\n", t.Specification().Name)
 	}

--- a/pkg/text/models/tools.go
+++ b/pkg/text/models/tools.go
@@ -37,11 +37,12 @@ const (
 type Input map[string]any
 
 type Call struct {
-	ID       string        `json:"id,omitempty"`
-	Name     string        `json:"name,omitempty"`
-	Type     string        `json:"type,omitempty"`
-	Inputs   *Input        `json:"inputs,omitempty"`
-	Function Specification `json:"function,omitempty"`
+	ID           string         `json:"id,omitempty"`
+	Name         string         `json:"name,omitempty"`
+	Type         string         `json:"type,omitempty"`
+	Inputs       *Input         `json:"inputs,omitempty"`
+	Function     Specification  `json:"function,omitempty"`
+	ExtraContent map[string]any `json:"extra_content"`
 }
 
 // Patch the call, filling structs and initializing fields so that


### PR DESCRIPTION
This was harder than it needed to be. Gemini 3 preview requires to have a "thought_signature" to work. This is added via the field "extra_content" which apparently is openai API compatible. Fairly straightforward to add.

But..! As it is an experimental model, there seem sto be a bug on their end where once the tool-calls have been completed. In short, `gemini-3-pro-preview` sends an additional erroneous tools-call for no reason whatsoever once it wants to stop calling tools.
The "proof" that it's on their end can be seen via checking the tools-call-id, and noting that it's not been sent before: it's both set and not been sent before = not a caching issue.

So to handle this case, I needed to add additional checks in the generic stream querier which detects if the underlying model most likely is gemini-3-preview (one of the tool-calls has had a thought_signature) and then return early if a subsequent call is without thought_signature. Sigh.

Now I can finally get back to doing what I was supposed to do: hack on a dart project...

**Additional features:**
* Tightneted up security by:
  * Removed mcp everything printEnv (this kept sending all
                  my access tokens to the models I was testing out)
  * Removed any api-key printing from DEBUG=1
* Tests written by gemini-3-pro-preview to be a bit meta

---

Try it out with:
```
clai -cm gemini-3-pro-preview -t q Hello please run some tools
```