### PR TITLE
fix: Made streaming stop-management more robust

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -45,6 +45,8 @@ type CompletionEvent any
 
 type NoopEvent struct{}
 
+type StopEvent struct{}
+
 type ErrRateLimit struct {
 	ResetAt         time.Time
 	TokensRemaining int

--- a/internal/text/generic/stream_completer_test.go
+++ b/internal/text/generic/stream_completer_test.go
@@ -226,8 +226,10 @@ func TestHandleStreamChunk_Table(t *testing.T) {
 	s := &StreamCompleter{}
 
 	// DONE -> Noop
-	if ev := s.handleStreamChunk([]byte("data: [DONE]\n")); !isNoop(ev) {
-		t.Fatalf("expected Noop for DONE, got: %T %v", ev, ev)
+	maybeStopEv := s.handleStreamChunk([]byte("data: [DONE]\n"))
+	_, isStopEvent := maybeStopEv.(models.StopEvent)
+	if !isStopEvent {
+		t.Fatalf("expected STOP for DONE, got: %T %v", maybeStopEv, maybeStopEv)
 	}
 
 	// Invalid JSON with DEBUG=false -> Noop
@@ -260,9 +262,9 @@ func TestHandleStreamChunk_Table(t *testing.T) {
 	// Prefer Call over string
 	tools.Init()
 	payload := `{"choices":[{"delta":{"content":"text"}},{"delta":{"tool_calls":[{"id":"1","type":"function","index":0,"function":{"name":"ls","arguments":"{}"}}]}}]}`
-	ev := s.handleStreamChunk([]byte("data: " + payload + "\n"))
-	if _, ok := ev.(pub_models.Call); !ok {
-		t.Fatalf("expected Call to be preferred, got: %T %v", ev, ev)
+	maybeStopEv = s.handleStreamChunk([]byte("data: " + payload + "\n"))
+	if _, ok := maybeStopEv.(pub_models.Call); !ok {
+		t.Fatalf("expected Call to be preferred, got: %T %v", maybeStopEv, maybeStopEv)
 	}
 }
 

--- a/internal/tools/mcp/client.go
+++ b/internal/tools/mcp/client.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -81,6 +82,9 @@ func Client(ctx context.Context, mcpConfig pub_models.McpServer) (chan<- any, <-
 			if line != "" {
 				ancli.Noticef("mcp_%v: %v\n", mcpConfig.Name, line)
 			}
+		}
+		if ctx.Err() != nil && errors.Is(ctx.Err(), context.Canceled) {
+			return
 		}
 		if err := scanner.Err(); err != nil {
 			ancli.Errf("mcp_%v: %s\n", mcpConfig.Name, err)

--- a/internal/utils/context_keys.go
+++ b/internal/utils/context_keys.go
@@ -1,0 +1,7 @@
+package utils
+
+type ContextKey string
+
+const (
+	ContextCancelKey ContextKey = "contextCancel"
+)

--- a/main.go
+++ b/main.go
@@ -106,6 +106,10 @@ func main() {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	// Build in cancel into the context to allow it to be called downstream
+	// Anti-pattern? Not sure, honestly, needed here to cleanly stop
+	// clai. Could've been solved by proper structure
+	ctx = context.WithValue(ctx, utils.ContextCancelKey, cancel)
 	querier, err := internal.Setup(ctx, usage)
 	if err != nil {
 		if errors.Is(err, utils.ErrUserInitiatedExit) {


### PR DESCRIPTION
There were/are some issues when the models return "empty" newlines at the end of their SSE stream. I'm sure
they do this by the API spec i totally have read, but i hadn't added any functionality to take height for it. 
Or well, until now. 