### PR TITLE
fix: Mixtral LLMaaS now work again

### DIFF
--- a/internal/vendors/mistral/mistral.go
+++ b/internal/vendors/mistral/mistral.go
@@ -45,6 +45,7 @@ func clean(msg []pub_models.Message) []pub_models.Message {
 				tc.Inputs = nil
 				tc.Function.Description = ""
 				tc.Function.Inputs = nil
+				tc.ExtraContent = nil
 				m.ToolCalls[j] = tc
 			}
 		}

--- a/pkg/text/models/tools.go
+++ b/pkg/text/models/tools.go
@@ -42,7 +42,7 @@ type Call struct {
 	Type         string         `json:"type,omitempty"`
 	Inputs       *Input         `json:"inputs,omitempty"`
 	Function     Specification  `json:"function,omitempty"`
-	ExtraContent map[string]any `json:"extra_content"`
+	ExtraContent map[string]any `json:"extra_content,omitempty"`
 }
 
 // Patch the call, filling structs and initializing fields so that


### PR DESCRIPTION
Pretty self-explanatory. Mistral still doesn't like extra fields. Broken by gemini openai implementation.

The mixtral LLMaaS still seems to freeze randomly though