### PR TITLE
feat: Add deepseek reasoning

### DIFF
--- a/architecture/colours.md
+++ b/architecture/colours.md
@@ -35,10 +35,11 @@ All colour fields are raw ANSI escape sequences represented as JSON strings.
 | `roleSystem` | Colour for `system` role labels. |
 | `roleUser` | Colour for `user` role labels. |
 | `roleTool` | Colour for `tool` role labels. |
+| `roleReasoning` | Colour for `reasoning` role labels (thinking/chain-of-thought). |
 | `roleOther` | Fallback colour for any other/unknown role. |
 | `notificationBell` | Whether clai should emit terminal BEL (`\a`) after successful task completion. |
 
-Defaults are chosen to match the existing `AttemptPrettyPrint` role palette (system=blue, user=cyan, tool=magenta).
+Defaults are chosen to match the existing `AttemptPrettyPrint` role palette (system=blue, user=cyan, tool=magenta, reasoning=warm-gray).
 
 Example:
 
@@ -50,6 +51,7 @@ Example:
   "roleSystem": "\u001b[34m",
   "roleUser": "\u001b[36m",
   "roleTool": "\u001b[35m",
+  "roleReasoning": "\u001b[38;2;180;170;150m",
   "roleOther": "\u001b[34m",
   "notificationBell": true
 }

--- a/internal/create_queriers.go
+++ b/internal/create_queriers.go
@@ -75,6 +75,7 @@ func selectTextQuerier(ctx context.Context, conf text.Configurations) (models.Qu
 			return nil, found, fmt.Errorf("failed to create text querier: %w", err)
 		}
 		q = &qTmp
+		return q, found, nil
 	}
 
 	if strings.Contains(conf.Model, "gpt") && !strings.HasPrefix(conf.Model, "or:") {

--- a/internal/create_queriers_test.go
+++ b/internal/create_queriers_test.go
@@ -183,6 +183,33 @@ func TestSelectTextQuerier_OpenRouterPrefix(t *testing.T) {
 	}
 }
 
+func TestSelectTextQuerier_OpenRouterPrefixBeatsProviderSubstring(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("OPENROUTER_API_KEY", "k")
+	t.Setenv("CLAI_CONFIG_DIR", tmp)
+
+	q, found, err := selectTextQuerier(context.Background(), text.Configurations{
+		Model:     "or:deepseek/deepseek-v4-pro",
+		ConfigDir: tmp,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found")
+	}
+	if q == nil {
+		t.Fatal("expected querier")
+	}
+	typed, ok := q.(*text.Querier[*openrouter.OpenRouter])
+	if !ok {
+		t.Fatalf("expected openrouter querier, got: %T", q)
+	}
+	if typed.Model.Model != "or:deepseek/deepseek-v4-pro" {
+		t.Fatalf("expected prefixed openrouter model, got: %q", typed.Model.Model)
+	}
+}
+
 func TestSelectTextQuerier_ErrorPropagation(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("ANTHROPIC_API_KEY", "")

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -48,6 +48,13 @@ type CompletionEvent any
 
 type NoopEvent struct{}
 
+// ReasoningEvent carries a single reasoning/thinking token from the model.
+// It is handled like content but displayed dimmed so users can distinguish
+// chain-of-thought from the final answer.
+type ReasoningEvent struct {
+	Content string
+}
+
 type StopEvent struct{}
 
 type ErrRateLimit struct {

--- a/internal/text/generic/stream_completer.go
+++ b/internal/text/generic/stream_completer.go
@@ -23,6 +23,7 @@ var dataPrefix = []byte("data: ")
 
 // StreamCompletions taking the messages as prompt conversation. Returns the messages from the chat model.
 func (s *StreamCompleter) StreamCompletions(ctx context.Context, chat pub_models.Chat) (chan models.CompletionEvent, error) {
+	s.reasoningContent = ""
 	if s.Clean != nil {
 		cpy := make([]pub_models.Message, len(chat.Messages))
 		copy(cpy, chat.Messages)
@@ -168,10 +169,12 @@ func (s *StreamCompleter) handleStreamChunk(token []byte) models.CompletionEvent
 	for _, choice := range chunk.Choices {
 		compEvent := s.handleChoice(choice)
 		switch compEvent.(type) {
-		// Set chosen to the first error, string
-		case error, string, models.NoopEvent:
+		// Set chosen to the first error, string, or reasoning event.
+		// NoopEvents and ReasoningEvents can be replaced by more useful events.
+		case error, string, models.NoopEvent, models.ReasoningEvent:
 			_, isNoopEvent := chosen.(models.NoopEvent)
-			if chosen == nil || isNoopEvent {
+			_, isReasoningEvent := chosen.(models.ReasoningEvent)
+			if chosen == nil || isNoopEvent || isReasoningEvent {
 				chosen = compEvent
 			}
 		case pub_models.Call:
@@ -188,6 +191,9 @@ func (s *StreamCompleter) handleStreamChunk(token []byte) models.CompletionEvent
 }
 
 func (s *StreamCompleter) handleChoice(choice Choice) models.CompletionEvent {
+	if choice.Delta.ReasoningContent != "" {
+		s.reasoningContent += choice.Delta.ReasoningContent
+	}
 	// If there is no tools call, just handle it as a strings. This works for most cases
 	if len(choice.Delta.ToolCalls) == 0 {
 		if choice.FinishReason != "" {
@@ -195,6 +201,9 @@ func (s *StreamCompleter) handleChoice(choice Choice) models.CompletionEvent {
 				ancli.Noticef("stopping due to FinishReason: '%v'", choice.FinishReason)
 			}
 			return models.StopEvent{}
+		}
+		if choice.Delta.Content == nil && choice.Delta.ReasoningContent != "" {
+			return models.ReasoningEvent{Content: choice.Delta.ReasoningContent}
 		}
 		return choice.Delta.Content
 	}
@@ -243,12 +252,13 @@ func (s *StreamCompleter) doToolsCall() models.CompletionEvent {
 	userFunc.Inputs = &pub_models.InputSchema{}
 
 	return pub_models.Call{
-		ID:           s.toolsCallID,
-		Name:         s.toolsCallName,
-		Inputs:       &input,
-		Type:         "function",
-		Function:     userFunc,
-		ExtraContent: s.extraContent,
+		ID:               s.toolsCallID,
+		Name:             s.toolsCallName,
+		Inputs:           &input,
+		Type:             "function",
+		Function:         userFunc,
+		ExtraContent:     s.extraContent,
+		ReasoningContent: s.reasoningContent,
 	}
 }
 

--- a/internal/text/generic/stream_completer_models.go
+++ b/internal/text/generic/stream_completer_models.go
@@ -24,6 +24,7 @@ type StreamCompleter struct {
 	toolsCallArgsString string
 	toolsCallID         string
 	extraContent        map[string]any
+	reasoningContent    string
 	client              *http.Client
 	apiKey              string
 	debug               bool
@@ -60,9 +61,10 @@ type Choice struct {
 }
 
 type Delta struct {
-	Content   any         `json:"content"`
-	Role      string      `json:"role"`
-	ToolCalls []ToolsCall `json:"tool_calls"`
+	Content          any         `json:"content"`
+	ReasoningContent string      `json:"reasoning_content"`
+	Role             string      `json:"role"`
+	ToolCalls        []ToolsCall `json:"tool_calls"`
 }
 
 type ExtraContent map[string]map[string]any

--- a/internal/text/generic/stream_completer_test.go
+++ b/internal/text/generic/stream_completer_test.go
@@ -104,6 +104,32 @@ func TestStreamCompletions_HappyPath_FirstEventOnly(t *testing.T) {
 	}
 }
 
+func TestHandleStreamChunk_ReasoningContentIsTracked(t *testing.T) {
+	s := &StreamCompleter{}
+
+	ev := s.handleStreamChunk([]byte(`data: {"choices":[{"delta":{"reasoning_content":"I should inspect."}}]}` + "\n"))
+	rev, ok := ev.(models.ReasoningEvent)
+	if !ok {
+		t.Fatalf("expected reasoning-only delta to be a ReasoningEvent, got: %T %v", ev, ev)
+	}
+	if rev.Content != "I should inspect." {
+		t.Fatalf("expected reasoning event content, got %q", rev.Content)
+	}
+	if s.reasoningContent != "I should inspect." {
+		t.Fatalf("expected reasoning content captured, got %q", s.reasoningContent)
+	}
+
+	tools.Init()
+	ev = s.handleStreamChunk([]byte(`data: {"choices":[{"delta":{"reasoning_content":" Then call."}},{"delta":{"tool_calls":[{"id":"call-1","type":"function","index":0,"function":{"name":"ls","arguments":"{}"}}]}}]}` + "\n"))
+	call, ok := ev.(pub_models.Call)
+	if !ok {
+		t.Fatalf("expected tool call, got: %T %v", ev, ev)
+	}
+	if call.ReasoningContent != "I should inspect. Then call." {
+		t.Fatalf("expected reasoning on tool call, got %q", call.ReasoningContent)
+	}
+}
+
 func TestCreateRequest_BodyAndHeaders(t *testing.T) {
 	fpen, ppen, temp, top, max := 0.25, 0.75, 0.5, 0.9, 123
 	choice := "auto"
@@ -175,6 +201,41 @@ func TestCreateRequest_BodyAndHeaders(t *testing.T) {
 	fn, _ := tool0["function"].(map[string]any)
 	if name, _ := fn["name"].(string); name != "x" {
 		t.Fatalf("tool name mismatch: %v", name)
+	}
+}
+
+func TestCreateRequest_PassesBackReasoningContent(t *testing.T) {
+	s := &StreamCompleter{
+		Model:  "m",
+		apiKey: "sekret",
+		URL:    "http://example.invalid",
+	}
+	chat := pub_models.Chat{Messages: []pub_models.Message{{
+		Role:             "assistant",
+		Content:          "Let me inspect.",
+		ReasoningContent: "Need tool.",
+		ToolCalls:        []pub_models.Call{{ID: "call-1", Name: "ls", Type: "function"}},
+	}}}
+	httpReq, err := s.createRequest(context.Background(), chat)
+	if err != nil {
+		t.Fatalf("createRequest err: %v", err)
+	}
+
+	b, _ := io.ReadAll(httpReq.Body)
+	var body map[string]any
+	if err := jsonUnmarshal(b, &body); err != nil {
+		t.Fatalf("unmarshal body: %v\nbody=%s", err, string(b))
+	}
+	messages, ok := body["messages"].([]any)
+	if !ok || len(messages) != 1 {
+		t.Fatalf("expected one message, got: %T %v", body["messages"], body["messages"])
+	}
+	msg, ok := messages[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected message object, got: %T %v", messages[0], messages[0])
+	}
+	if got, _ := msg["reasoning_content"].(string); got != "Need tool." {
+		t.Fatalf("reasoning_content mismatch: got %q", got)
 	}
 }
 

--- a/internal/text/querier.go
+++ b/internal/text/querier.go
@@ -44,6 +44,12 @@ type Querier[C models.StreamCompleter] struct {
 	toolOutputRuneLimit     int
 	rateLimitLastAmTokens   int
 
+	// reasoningBuf accumulates thinking/chain-of-thought tokens streamed
+	// before the final answer.  It is wrapped in [thinking]…[/thinking]
+	// when displayed.
+	reasoningBuf    strings.Builder
+	reasoningActive bool
+
 	// Output of the querier. This is used mostly when Querier is invoked as an agent
 	out io.Writer
 
@@ -162,6 +168,8 @@ func (q *Querier[C]) resetTransientState() {
 	q.line = ""
 	q.lineCount = 0
 	q.hasPrinted = false
+	q.reasoningBuf.Reset()
+	q.reasoningActive = false
 }
 
 func (q *Querier[C]) handleToken(token string) {
@@ -185,6 +193,33 @@ func (q *Querier[C]) handleTokenForSession(session *QuerySession, token string) 
 	if !q.debug {
 		fmt.Fprint(w, token)
 	}
+}
+
+// closeReasoningIfOpen prints the closing [/thinking] tag and prepends the
+// wrapped reasoning block to session.PendingText so it survives terminal
+// line-clearing and gets re-printed by the pretty-printer.
+func (q *Querier[C]) closeReasoningIfOpen(session *QuerySession) {
+	if !q.reasoningActive {
+		return
+	}
+	q.reasoningActive = false
+	if !q.debug {
+		w := q.out
+		if w == nil {
+			w = os.Stdout
+		}
+		fmt.Fprint(w, utils.Colorize(utils.RoleColor("reasoning"), "[/thinking]\n"))
+	}
+	reasoningWrapped := "[thinking]" + q.reasoningBuf.String() + "[/thinking]\n"
+	if session.PendingTextString() == "" {
+		session.PendingText.WriteString(reasoningWrapped)
+	} else {
+		existing := session.PendingText.String()
+		session.PendingText.Reset()
+		session.PendingText.WriteString(reasoningWrapped + existing)
+	}
+	q.fullMsg = session.PendingTextString()
+	q.reasoningBuf.Reset()
 }
 
 func (q *Querier[C]) currentTokenUsage() *pub_models.Usage {

--- a/internal/text/session_runner.go
+++ b/internal/text/session_runner.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	"github.com/baalimago/clai/internal/models"
@@ -169,6 +170,7 @@ func (r *sessionRunner[C]) executeModelStep(ctx context.Context, session *QueryS
 		select {
 		case completion, ok := <-completionsChan:
 			if !ok {
+				q.closeReasoningIfOpen(session)
 				result.EndedNormally = true
 				result.AssistantText = session.PendingTextString()
 				result.Usage = q.currentTokenUsage()
@@ -176,14 +178,17 @@ func (r *sessionRunner[C]) executeModelStep(ctx context.Context, session *QueryS
 			}
 			switch cast := completion.(type) {
 			case pub_models.Call:
+				q.closeReasoningIfOpen(session)
 				result.ToolCall = &cast
 				result.AssistantText = session.PendingTextString()
 				result.Usage = q.currentTokenUsage()
 				return result, nil
 			case string:
+				q.closeReasoningIfOpen(session)
 				q.handleTokenForSession(session, cast)
 			case error:
 				if errors.Is(cast, context.Canceled) || errors.Is(cast, io.EOF) {
+					q.closeReasoningIfOpen(session)
 					result.EndedNormally = true
 					result.AssistantText = session.PendingTextString()
 					result.Usage = q.currentTokenUsage()
@@ -191,7 +196,21 @@ func (r *sessionRunner[C]) executeModelStep(ctx context.Context, session *QueryS
 				}
 				return ModelStepResult{}, fmt.Errorf("completion stream error: %w", cast)
 			case models.NoopEvent:
+			case models.ReasoningEvent:
+				if !q.debug {
+					w := q.out
+					if w == nil {
+						w = os.Stdout
+					}
+					if !q.reasoningActive {
+						fmt.Fprint(w, utils.Colorize(utils.RoleColor("reasoning"), "[thinking]"))
+						q.reasoningActive = true
+					}
+					fmt.Fprint(w, utils.Colorize(utils.RoleColor("reasoning"), cast.Content))
+					q.reasoningBuf.WriteString(cast.Content)
+				}
 			case models.StopEvent:
+				q.closeReasoningIfOpen(session)
 				contextCancel := ctx.Value(utils.ContextCancelKey)
 				castContextCancel, ok := contextCancel.(context.CancelFunc)
 				if ok {
@@ -210,6 +229,7 @@ func (r *sessionRunner[C]) executeModelStep(ctx context.Context, session *QueryS
 				return ModelStepResult{}, fmt.Errorf("unknown completion type: %v", completion)
 			}
 		case <-ctx.Done():
+			q.closeReasoningIfOpen(session)
 			result.StopRequested = true
 			result.AssistantText = session.PendingTextString()
 			result.Usage = q.currentTokenUsage()

--- a/internal/text/session_runner_test.go
+++ b/internal/text/session_runner_test.go
@@ -179,6 +179,53 @@ func Test_sessionRunner_Run_ToolThenReplyRecordsEachCompletedCall(t *testing.T) 
 	}
 }
 
+func Test_sessionRunner_Run_ToolCallPropagatesReasoningContent(t *testing.T) {
+	model := &MockQuerier{}
+	callCount := 0
+	model.streamFn = func(_ context.Context, chat pub_models.Chat) (chan models.CompletionEvent, error) {
+		callCount++
+		out := make(chan models.CompletionEvent, 1)
+		if callCount == 1 {
+			out <- pub_models.Call{ID: "call-1", Name: "pwd", ReasoningContent: "Need cwd."}
+			close(out)
+			return out, nil
+		}
+		if len(chat.Messages) < 2 {
+			t.Fatalf("expected assistant tool-call message in follow-up chat, got %d messages", len(chat.Messages))
+		}
+		assistantToolCall := chat.Messages[1]
+		if assistantToolCall.Role != "assistant" {
+			t.Fatalf("expected assistant tool-call message, got role %q", assistantToolCall.Role)
+		}
+		if assistantToolCall.ReasoningContent != "Need cwd." {
+			t.Fatalf("expected reasoning content passed back, got %q", assistantToolCall.ReasoningContent)
+		}
+		out <- "done"
+		close(out)
+		return out, nil
+	}
+
+	q := &Querier[*MockQuerier]{
+		out:   &strings.Builder{},
+		Model: model,
+	}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    &countingFinalizer{},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+	}
+
+	err := runner.Run(context.Background(), session)
+	if err != nil {
+		t.Fatalf("Run returned err: %v", err)
+	}
+	if callCount != 2 {
+		t.Fatalf("expected 2 calls, got %d", callCount)
+	}
+}
+
 func Test_sessionRunner_Run_RecorderFailureDoesNotFailQuery(t *testing.T) {
 	model := &MockQuerier{}
 	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {

--- a/internal/text/tool_executor.go
+++ b/internal/text/tool_executor.go
@@ -46,9 +46,10 @@ func (e toolExecutor[C]) Execute(ctx context.Context, session *QuerySession, cal
 	call = decision.PatchedCall
 
 	assistantToolsCall := pub_models.Message{
-		Role:      "assistant",
-		Content:   call.PrettyPrint(),
-		ToolCalls: []pub_models.Call{call},
+		Role:             "assistant",
+		Content:          call.PrettyPrint(),
+		ToolCalls:        []pub_models.Call{call},
+		ReasoningContent: call.ReasoningContent,
 	}
 	if !q.debug {
 		err := utils.AttemptPrettyPrint(q.out, assistantToolsCall, q.username, q.Raw)

--- a/internal/utils/theme.go
+++ b/internal/utils/theme.go
@@ -22,10 +22,11 @@ type Theme struct {
 	Secondary string `json:"secondary"`
 	Breadtext string `json:"breadtext"`
 
-	RoleSystem string `json:"roleSystem"`
-	RoleUser   string `json:"roleUser"`
-	RoleTool   string `json:"roleTool"`
-	RoleOther  string `json:"roleOther"`
+	RoleSystem    string `json:"roleSystem"`
+	RoleUser      string `json:"roleUser"`
+	RoleTool      string `json:"roleTool"`
+	RoleReasoning string `json:"roleReasoning"`
+	RoleOther     string `json:"roleOther"`
 
 	NotificationBell bool `json:"notificationBell"`
 }
@@ -41,6 +42,7 @@ func defaultTheme() *Theme {
 		RoleSystem:       "\u001b[34m",
 		RoleUser:         "\u001b[36m",
 		RoleTool:         "\u001b[35m",
+		RoleReasoning:    "\u001b[38;2;180;170;150m",
 		RoleOther:        "\u001b[34m",
 		NotificationBell: true,
 	}
@@ -121,6 +123,8 @@ func RoleColor(role string) string {
 		return globalTheme.RoleUser
 	case "system":
 		return globalTheme.RoleSystem
+	case "reasoning":
+		return globalTheme.RoleReasoning
 	default:
 		return globalTheme.RoleOther
 	}

--- a/pkg/text/models/chat.go
+++ b/pkg/text/models/chat.go
@@ -91,9 +91,10 @@ type ImageOrTextInput struct {
 }
 
 type Message struct {
-	Role       string `json:"role"`
-	ToolCalls  []Call `json:"tool_calls,omitempty"`
-	ToolCallID string `json:"tool_call_id,omitempty"`
+	Role             string `json:"role"`
+	ToolCalls        []Call `json:"tool_calls,omitempty"`
+	ToolCallID       string `json:"tool_call_id,omitempty"`
+	ReasoningContent string `json:"reasoning_content,omitempty"`
 	// Content and ContentParts is like this since
 	// making Mesage generic would cause changes in 70+ places.
 	//
@@ -112,6 +113,9 @@ func (m Message) MarshalJSON() ([]byte, error) {
 	}
 	if m.ToolCallID != "" {
 		obj["tool_call_id"] = m.ToolCallID
+	}
+	if m.ReasoningContent != "" {
+		obj["reasoning_content"] = m.ReasoningContent
 	}
 	if len(m.ContentParts) > 0 {
 		obj["content"] = m.ContentParts
@@ -138,6 +142,11 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 	}
 	if v, ok := raw["tool_call_id"]; ok {
 		if err := json.Unmarshal(v, &m.ToolCallID); err != nil {
+			return err
+		}
+	}
+	if v, ok := raw["reasoning_content"]; ok {
+		if err := json.Unmarshal(v, &m.ReasoningContent); err != nil {
 			return err
 		}
 	}

--- a/pkg/text/models/chat_test.go
+++ b/pkg/text/models/chat_test.go
@@ -134,6 +134,35 @@ func TestMessageJSON(t *testing.T) {
 	}
 }
 
+func TestMessageJSONReasoningContentRoundTrip(t *testing.T) {
+	msg := Message{
+		Role:             "assistant",
+		Content:          "I will call a tool.",
+		ReasoningContent: "Need current files.",
+		ToolCalls:        []Call{{ID: "call-1", Name: "ls", Type: "function"}},
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("failed to marshal message: %v", err)
+	}
+
+	var encoded map[string]any
+	if err := json.Unmarshal(data, &encoded); err != nil {
+		t.Fatalf("failed to unmarshal encoded message: %v", err)
+	}
+	if got, _ := encoded["reasoning_content"].(string); got != msg.ReasoningContent {
+		t.Fatalf("reasoning_content missing from json: got %q", got)
+	}
+
+	var decoded Message
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal message: %v", err)
+	}
+	if decoded.ReasoningContent != msg.ReasoningContent {
+		t.Fatalf("reasoning_content roundtrip mismatch: got %q", decoded.ReasoningContent)
+	}
+}
+
 func TestChatHelpers(t *testing.T) {
 	c := Chat{
 		Created: time.Now(),

--- a/pkg/text/models/tools.go
+++ b/pkg/text/models/tools.go
@@ -59,12 +59,13 @@ const (
 type Input map[string]any
 
 type Call struct {
-	ID           string         `json:"id,omitempty"`
-	Name         string         `json:"name,omitempty"`
-	Type         string         `json:"type,omitempty"`
-	Inputs       *Input         `json:"inputs,omitempty"`
-	Function     Specification  `json:"function"`
-	ExtraContent map[string]any `json:"extra_content,omitempty"`
+	ID               string         `json:"id,omitempty"`
+	Name             string         `json:"name,omitempty"`
+	Type             string         `json:"type,omitempty"`
+	Inputs           *Input         `json:"inputs,omitempty"`
+	Function         Specification  `json:"function"`
+	ExtraContent     map[string]any `json:"extra_content,omitempty"`
+	ReasoningContent string         `json:"-"`
 }
 
 // Patch the call, filling structs and initializing fields so that


### PR DESCRIPTION
Depeseek has 75% of their already very cheap models (judging by intelligence/$), time to utilize it!

I noticed that they required an extra field for reasoning which I believe is exclusive to openrouter, but I'm not sure. Extended the
output to take height for thinking as well. 