### PR TITLE
feat: PrettyPrint `glow` with width from terminal

### DIFF
--- a/internal/utils/print.go
+++ b/internal/utils/print.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -118,7 +119,16 @@ func AttemptPrettyPrint(w io.Writer, chatMessage pub_models.Message, username st
 		return nil
 	}
 
-	cmd = exec.Command("glow")
+	termWidth, err := TermWidth()
+	if err != nil {
+		return fmt.Errorf("get terminal width for glow: %w", err)
+	}
+	glowWidth := termWidth - 5
+	if glowWidth < 1 {
+		glowWidth = 1
+	}
+
+	cmd = exec.Command("glow", "-w", strconv.Itoa(glowWidth))
 	inp := chatMessage.Content
 	// For some reason glow hides specifically <thikning>. So, replace it to [thinking]
 	inp = strings.ReplaceAll(inp, "<thinking>", "[thinking]")

--- a/internal/utils/print_theme_test.go
+++ b/internal/utils/print_theme_test.go
@@ -2,7 +2,10 @@ package utils
 
 import (
 	"bytes"
+	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	pub_models "github.com/baalimago/clai/pkg/text/models"
@@ -41,5 +44,48 @@ func TestAttemptPrettyPrint_UsesThemeColorsWhenNoGlow(t *testing.T) {
 	// We should see the themed role color applied (wrapped with ansiReset) and the username used for user role.
 	if want := "<USER_COLOR>alice" + ansiReset + ": hello\n"; out != want {
 		t.Fatalf("unexpected output\nwant: %q\ngot:  %q", want, out)
+	}
+}
+
+func TestAttemptPrettyPrint_PassesTerminalWidthMinusFiveToGlow(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("COLUMNS", "100")
+
+	origTheme := globalTheme
+	t.Cleanup(func() { globalTheme = origTheme })
+	globalTheme = Theme{}
+
+	tmpDir := t.TempDir()
+	argsPath := filepath.Join(tmpDir, "glow-args.txt")
+	glowPath := filepath.Join(tmpDir, "glow")
+
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "--version" ]; then
+	echo "glow test"
+	exit 0
+fi
+printf '%%s\n' "$*" > %q
+/bin/cat
+`, argsPath)
+
+	if err := os.WriteFile(glowPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake glow: %v", err)
+	}
+
+	t.Setenv("PATH", tmpDir)
+
+	var buf bytes.Buffer
+	msg := pub_models.Message{Role: "assistant", Content: "hello markdown"}
+	if err := AttemptPrettyPrint(&buf, msg, "alice", false); err != nil {
+		t.Fatalf("AttemptPrettyPrint: %v", err)
+	}
+
+	gotArgsBytes, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read fake glow args: %v", err)
+	}
+
+	if got, want := strings.TrimSpace(string(gotArgsBytes)), "-w 95"; got != want {
+		t.Fatalf("unexpected glow args\nwant: %q\ngot:  %q", want, got)
 	}
 }


### PR DESCRIPTION
On smaller terminal panes the pretty-print exceeded the width, causing very wonky output. No more!