### PR TITLE
feat: Response formats for pkg and cli

### DIFF
--- a/internal/setup.go
+++ b/internal/setup.go
@@ -208,6 +208,13 @@ func setupTextQuerierWithConf(ctx context.Context, mode Mode, confDir string, fl
 	// to re-apply the flag overrides to the configuration
 	applyFlagOverridesForText(&tConf, flagSet, defaultFlags)
 
+	// Load response format from file if specified
+	if flagSet.ResponseFormatPath != "" {
+		if err := tConf.LoadResponseFormat(flagSet.ResponseFormatPath); err != nil {
+			return nil, nil, fmt.Errorf("response format: %w", err)
+		}
+	}
+
 	if misc.Truthy(os.Getenv("DEBUG")) {
 		ancli.PrintOK(fmt.Sprintf("config post flag override: %+v\n", imagodebug.IndentedJsonFmt(tConf)))
 	}

--- a/internal/setup_flags.go
+++ b/internal/setup_flags.go
@@ -40,6 +40,9 @@ type Configurations struct {
 	ProfilePath string
 	// ShellContext is the selected shell context name (ASC).
 	ShellContext string
+	// ResponseFormatPath is a path to a JSON file describing the OpenAI response_format.
+	// Supports "json_object" and "json_schema" types.
+	ResponseFormatPath string
 }
 
 // parseFlags parses CLI flags into an internal Configurations.
@@ -98,6 +101,9 @@ func parseFlags(defaults Configurations, args []string) (Configurations, []strin
 	ascShort := fs.String("asc", defaults.ShellContext, "Auto-append shell context by name. Mutually exclusive with add-shell-context.")
 	ascLong := fs.String("add-shell-context", defaults.ShellContext, "Auto-append shell context by name. Mutually exclusive with asc.")
 
+	rfShort := fs.String("rf", defaults.ResponseFormatPath, "Path to a response_format JSON file for structured output.")
+	rfLong := fs.String("response-format", defaults.ResponseFormatPath, "Path to a response_format JSON file for structured output.")
+
 	// Breaking change: -t/-tools are string-only value flags.
 	// Use: -t=* or -t=a,b ("-t" without value is undefined/ignored).
 	useToolsShort := fs.String("t", defaults.UseTools, "Enable tools. Use '*' for all tools or comma-separated list for specific tools.")
@@ -136,6 +142,8 @@ func parseFlags(defaults Configurations, args []string) (Configurations, []strin
 	exitWithFlagError(err, "vp", "video-prefix")
 	shellContext, err := utils.ReturnNonDefault(*ascShort, *ascLong, defaults.ShellContext)
 	exitWithFlagError(err, "asc", "add-shell-context")
+	responseFormatPath, err := utils.ReturnNonDefault(*rfShort, *rfLong, defaults.ResponseFormatPath)
+	exitWithFlagError(err, "rf", "response-format")
 
 	replyMode := *replyShort || *replyLong
 	printRaw := *printRawShort || *printRawLong
@@ -146,23 +154,24 @@ func parseFlags(defaults Configurations, args []string) (Configurations, []strin
 	}
 
 	newConf := Configurations{
-		ChatModel:     chatModel,
-		PhotoModel:    photoModel,
-		PhotoDir:      pictureDir,
-		PhotoPrefix:   picturePrefix,
-		VideoModel:    videoModel,
-		VideoDir:      videoDir,
-		VideoPrefix:   videoPrefix,
-		StdinReplace:  stdinReplace,
-		PrintRaw:      printRaw,
-		ReplyMode:     replyMode,
-		DirReplyMode:  dirReplyMode,
-		UseTools:      useTools,
-		Glob:          glob,
-		ExpectReplace: *expectReplace,
-		Profile:       profile,
-		ProfilePath:   profilePath,
-		ShellContext:  shellContext,
+		ChatModel:          chatModel,
+		PhotoModel:         photoModel,
+		PhotoDir:           pictureDir,
+		PhotoPrefix:        picturePrefix,
+		VideoModel:         videoModel,
+		VideoDir:           videoDir,
+		VideoPrefix:        videoPrefix,
+		StdinReplace:       stdinReplace,
+		PrintRaw:           printRaw,
+		ReplyMode:          replyMode,
+		DirReplyMode:       dirReplyMode,
+		UseTools:           useTools,
+		Glob:               glob,
+		ExpectReplace:      *expectReplace,
+		Profile:            profile,
+		ProfilePath:        profilePath,
+		ShellContext:       shellContext,
+		ResponseFormatPath: responseFormatPath,
 	}
 
 	return newConf, postParseArgs, nil

--- a/internal/setup_flags_test.go
+++ b/internal/setup_flags_test.go
@@ -179,6 +179,22 @@ func TestSetupFlags(t *testing.T) {
 			},
 			wantPostArgs: []string{"q", "hello"},
 		},
+		{
+			name:     "Response format path short flag",
+			args:     []string{"cmd", "-rf", "/tmp/rf.json"},
+			defaults: Configurations{},
+			want: Configurations{
+				ResponseFormatPath: "/tmp/rf.json",
+			},
+		},
+		{
+			name:     "Response format path long flag",
+			args:     []string{"cmd", "-response-format", "/tmp/rf.json"},
+			defaults: Configurations{},
+			want: Configurations{
+				ResponseFormatPath: "/tmp/rf.json",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/text/conf.go
+++ b/internal/text/conf.go
@@ -237,3 +237,34 @@ func toGenericResponseFormat(rf *pub_models.ResponseFormat) *generic.ResponseFor
 	}
 	return gf
 }
+
+// responseFormatFromGeneric converts the internal generic.ResponseFormat (used for
+// JSON deserialization from files) to the public ResponseFormat.
+func responseFormatFromGeneric(gf *generic.ResponseFormat) *pub_models.ResponseFormat {
+	if gf == nil {
+		return nil
+	}
+	rf := &pub_models.ResponseFormat{
+		Type: gf.Type,
+	}
+	if gf.JSONSchema != nil {
+		rf.Schema = &pub_models.JSONSchema{
+			Name:        gf.JSONSchema.Name,
+			Description: gf.JSONSchema.Description,
+			Strict:      gf.JSONSchema.Strict,
+			Schema:      gf.JSONSchema.Schema,
+		}
+	}
+	return rf
+}
+
+// LoadResponseFormat loads a response_format JSON file from disk and sets it
+// on the configuration. The file must follow the OpenAI response_format schema.
+func (c *Configurations) LoadResponseFormat(path string) error {
+	var gf generic.ResponseFormat
+	if err := utils.ReadAndUnmarshal(path, &gf); err != nil {
+		return fmt.Errorf("failed to load response format from %q: %w", path, err)
+	}
+	c.ResponseFormat = responseFormatFromGeneric(&gf)
+	return nil
+}

--- a/internal/text/conf.go
+++ b/internal/text/conf.go
@@ -11,6 +11,7 @@ import (
 	"github.com/baalimago/clai/internal/chat"
 	"github.com/baalimago/clai/internal/chatid"
 	"github.com/baalimago/clai/internal/glob"
+	"github.com/baalimago/clai/internal/text/generic"
 	"github.com/baalimago/clai/internal/utils"
 	pub_models "github.com/baalimago/clai/pkg/text/models"
 	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
@@ -56,6 +57,10 @@ type Configurations struct {
 
 	// Out writer. Normally stdout, but may also be a file when invoked as a package
 	Out io.Writer `json:"-"`
+
+	// ResponseFormat configures structured output (json_object, json_schema).
+	// When nil, no response_format is sent (defaults to text).
+	ResponseFormat *pub_models.ResponseFormat `json:"-"`
 }
 
 type CostManager interface {
@@ -210,4 +215,25 @@ func (c *Configurations) SetupInitialChat(args []string) error {
 	}
 	traceChatf("setup initial chat done chat_id=%q total_messages=%d", c.InitialChat.ID, len(c.InitialChat.Messages))
 	return nil
+}
+
+// toGenericResponseFormat converts the public ResponseFormat to the internal type
+// used by generic.StreamCompleter.
+func toGenericResponseFormat(rf *pub_models.ResponseFormat) *generic.ResponseFormat {
+	if rf == nil {
+		return nil
+	}
+	gf := &generic.ResponseFormat{
+		Type: rf.Type,
+	}
+	if rf.Schema != nil {
+		s := rf.Schema
+		gf.JSONSchema = &generic.JSONSchemaSpec{
+			Name:        s.Name,
+			Description: s.Description,
+			Strict:      s.Strict,
+			Schema:      s.Schema,
+		}
+	}
+	return gf
 }

--- a/internal/text/conf_test.go
+++ b/internal/text/conf_test.go
@@ -1,0 +1,141 @@
+package text
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/baalimago/clai/internal/text/generic"
+)
+
+func TestResponseFormatFromGeneric_Nil(t *testing.T) {
+	if got := responseFormatFromGeneric(nil); got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+func TestResponseFormatFromGeneric_JSONObject(t *testing.T) {
+	gf := &generic.ResponseFormat{Type: "json_object"}
+	rf := responseFormatFromGeneric(gf)
+	if rf == nil {
+		t.Fatal("expected non-nil")
+	}
+	if rf.Type != "json_object" {
+		t.Fatalf("expected json_object, got %q", rf.Type)
+	}
+	if rf.Schema != nil {
+		t.Fatal("expected nil Schema")
+	}
+}
+
+func TestResponseFormatFromGeneric_JSONSchema(t *testing.T) {
+	gf := &generic.ResponseFormat{
+		Type: "json_schema",
+		JSONSchema: &generic.JSONSchemaSpec{
+			Name:        "person",
+			Description: "A person record",
+			Strict:      true,
+			Schema: map[string]any{
+				"type": "object",
+			},
+		},
+	}
+	rf := responseFormatFromGeneric(gf)
+	if rf == nil {
+		t.Fatal("expected non-nil")
+	}
+	if rf.Type != "json_schema" {
+		t.Fatalf("expected json_schema, got %q", rf.Type)
+	}
+	if rf.Schema == nil {
+		t.Fatal("expected Schema")
+	}
+	if rf.Schema.Name != "person" {
+		t.Fatalf("expected Name=person, got %q", rf.Schema.Name)
+	}
+	if rf.Schema.Description != "A person record" {
+		t.Fatalf("expected Description='A person record', got %q", rf.Schema.Description)
+	}
+	if !rf.Schema.Strict {
+		t.Fatal("expected Strict=true")
+	}
+}
+
+func TestLoadResponseFormat_JSONObject(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rf.json")
+	if err := os.WriteFile(path, []byte(`{"type":"json_object"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var c Configurations
+	if err := c.LoadResponseFormat(path); err != nil {
+		t.Fatalf("LoadResponseFormat: %v", err)
+	}
+	if c.ResponseFormat == nil {
+		t.Fatal("expected ResponseFormat")
+	}
+	if c.ResponseFormat.Type != "json_object" {
+		t.Fatalf("expected json_object, got %q", c.ResponseFormat.Type)
+	}
+}
+
+func TestLoadResponseFormat_JSONSchema(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rf.json")
+	content := `{
+		"type": "json_schema",
+		"json_schema": {
+			"name": "person",
+			"description": "A person record",
+			"strict": true,
+			"schema": {
+				"type": "object",
+				"properties": {
+					"name": {"type": "string"},
+					"age": {"type": "integer"}
+				},
+				"required": ["name", "age"]
+			}
+		}
+	}`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var c Configurations
+	if err := c.LoadResponseFormat(path); err != nil {
+		t.Fatalf("LoadResponseFormat: %v", err)
+	}
+	if c.ResponseFormat == nil {
+		t.Fatal("expected ResponseFormat")
+	}
+	if c.ResponseFormat.Type != "json_schema" {
+		t.Fatalf("expected json_schema, got %q", c.ResponseFormat.Type)
+	}
+	if c.ResponseFormat.Schema == nil {
+		t.Fatal("expected Schema")
+	}
+	if c.ResponseFormat.Schema.Name != "person" {
+		t.Fatalf("expected Name=person, got %q", c.ResponseFormat.Schema.Name)
+	}
+}
+
+func TestLoadResponseFormat_FileNotFound(t *testing.T) {
+	var c Configurations
+	err := c.LoadResponseFormat("/nonexistent/path.json")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLoadResponseFormat_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rf.json")
+	if err := os.WriteFile(path, []byte(`not json`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var c Configurations
+	err := c.LoadResponseFormat(path)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/text/generic/stream_completer.go
+++ b/internal/text/generic/stream_completer.go
@@ -53,6 +53,10 @@ func (s *StreamCompleter) StreamCompletions(ctx context.Context, chat pub_models
 }
 
 func (s *StreamCompleter) createRequest(ctx context.Context, chat pub_models.Chat) (*http.Request, error) {
+	respFmt := ResponseFormat{Type: "text"}
+	if s.ResponseFormat != nil {
+		respFmt = *s.ResponseFormat
+	}
 	reqData := req{
 		Model:            s.Model,
 		FrequencyPenalty: s.FrequencyPenalty,
@@ -60,7 +64,7 @@ func (s *StreamCompleter) createRequest(ctx context.Context, chat pub_models.Cha
 		PresencePenalty:  s.PresencePenalty,
 		Temperature:      s.Temperature,
 		TopP:             s.TopP,
-		ResponseFormat:   responseFormat{Type: "text"},
+		ResponseFormat:   respFmt,
 		Messages:         chat.Messages,
 		Stream:           true,
 		StreamOptions: map[string]any{

--- a/internal/text/generic/stream_completer_models.go
+++ b/internal/text/generic/stream_completer_models.go
@@ -29,7 +29,21 @@ type StreamCompleter struct {
 	apiKey              string
 	debug               bool
 
+	// ResponseFormat configures structured output. When nil, defaults to {type: "text"}.
+	ResponseFormat *ResponseFormat `json:"-"`
+
 	usage *pub_models.Usage
+}
+
+// SetResponseFormat configures the response format for structured output.
+// Pass nil to reset to default (text).
+func (s *StreamCompleter) SetResponseFormat(rf *ResponseFormat) {
+	s.ResponseFormat = rf
+}
+
+// ResponseFormatSetter is implemented by types that can accept a response format.
+type ResponseFormatSetter interface {
+	SetResponseFormat(*ResponseFormat)
 }
 
 type ToolSuper struct {
@@ -84,13 +98,24 @@ type Func struct {
 	Name      string `json:"name"`
 }
 
-type responseFormat struct {
-	Type string `json:"type"`
+// ResponseFormat follows the OpenAI chat completions response_format schema.
+// Supported types: "text", "json_object", "json_schema".
+type ResponseFormat struct {
+	Type       string          `json:"type"`
+	JSONSchema *JSONSchemaSpec `json:"json_schema,omitempty"`
+}
+
+// JSONSchemaSpec defines the schema when response_format type is "json_schema".
+type JSONSchemaSpec struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Strict      bool           `json:"strict,omitempty"`
+	Schema      map[string]any `json:"schema"`
 }
 
 type req struct {
 	Model             string               `json:"model,omitempty"`
-	ResponseFormat    responseFormat       `json:"response_format"`
+	ResponseFormat    ResponseFormat       `json:"response_format"`
 	Messages          []pub_models.Message `json:"messages,omitempty"`
 	Stream            bool                 `json:"stream,omitempty"`
 	StreamOptions     map[string]any       `json:"stream_options"`

--- a/internal/text/generic/stream_completer_test.go
+++ b/internal/text/generic/stream_completer_test.go
@@ -554,3 +554,70 @@ func TestSetResponseFormat(t *testing.T) {
 		t.Fatalf("expected nil after reset")
 	}
 }
+
+// TestDumpResponseFormatPayloads is a visual validation test that prints the
+// actual JSON payloads for each response format mode. Run with:
+//
+//	go test -v -run TestDumpResponseFormatPayloads ./internal/text/generic/
+func TestDumpResponseFormatPayloads(t *testing.T) {
+	examples := []struct {
+		name string
+		sc   *StreamCompleter
+	}{
+		{
+			"text (default)",
+			&StreamCompleter{Model: "gpt-4.1", apiKey: "sk-test", URL: "http://localhost"},
+		},
+		{
+			"json_object",
+			&StreamCompleter{
+				Model:          "gpt-4.1",
+				apiKey:         "sk-test",
+				URL:            "http://localhost",
+				ResponseFormat: &ResponseFormat{Type: "json_object"},
+			},
+		},
+		{
+			"json_schema",
+			&StreamCompleter{
+				Model:  "gpt-4.1",
+				apiKey: "sk-test",
+				URL:    "http://localhost",
+				ResponseFormat: &ResponseFormat{
+					Type: "json_schema",
+					JSONSchema: &JSONSchemaSpec{
+						Name:   "person",
+						Strict: true,
+						Schema: map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"name": map[string]any{"type": "string"},
+								"age":  map[string]any{"type": "integer"},
+							},
+							"required": []any{"name", "age"},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, ex := range examples {
+		ex.sc.client = &http.Client{}
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			var body map[string]any
+			json.Unmarshal(b, &body)
+			rf := body["response_format"]
+			jsn, _ := json.MarshalIndent(rf, "", "  ")
+			t.Logf("\n=== %s ===\n%s", ex.name, string(jsn))
+		}))
+		ex.sc.URL = ts.URL
+		ch, _ := ex.sc.StreamCompletions(context.Background(),
+			pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}})
+		if ch != nil {
+			for range ch {
+			}
+		}
+		ts.Close()
+	}
+}

--- a/internal/text/generic/stream_completer_test.go
+++ b/internal/text/generic/stream_completer_test.go
@@ -437,3 +437,120 @@ func TestCountInputTokens(t *testing.T) {
 		t.Fatalf("expected 0, got %d", n)
 	}
 }
+
+func TestCreateRequest_ResponseFormat_DefaultText(t *testing.T) {
+	s := &StreamCompleter{
+		Model:  "m",
+		apiKey: "sekret",
+		URL:    "http://example.invalid",
+	}
+	httpReq, err := s.createRequest(context.Background(), pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "c"}}})
+	if err != nil {
+		t.Fatalf("createRequest err: %v", err)
+	}
+	b, _ := io.ReadAll(httpReq.Body)
+	var body map[string]any
+	if err := jsonUnmarshal(b, &body); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	rf, ok := body["response_format"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected response_format map, got: %T", body["response_format"])
+	}
+	if rf["type"] != "text" {
+		t.Fatalf("expected type=text, got: %v", rf["type"])
+	}
+}
+
+func TestCreateRequest_ResponseFormat_JSONObject(t *testing.T) {
+	s := &StreamCompleter{
+		Model:          "m",
+		apiKey:         "sekret",
+		URL:            "http://example.invalid",
+		ResponseFormat: &ResponseFormat{Type: "json_object"},
+	}
+	httpReq, err := s.createRequest(context.Background(), pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "c"}}})
+	if err != nil {
+		t.Fatalf("createRequest err: %v", err)
+	}
+	b, _ := io.ReadAll(httpReq.Body)
+	var body map[string]any
+	if err := jsonUnmarshal(b, &body); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	rf, ok := body["response_format"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected response_format map, got: %T", body["response_format"])
+	}
+	if rf["type"] != "json_object" {
+		t.Fatalf("expected type=json_object, got: %v", rf["type"])
+	}
+}
+
+func TestCreateRequest_ResponseFormat_JSONSchema(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string"},
+			"age":  map[string]any{"type": "integer"},
+		},
+		"required": []any{"name", "age"},
+	}
+	s := &StreamCompleter{
+		Model:  "m",
+		apiKey: "sekret",
+		URL:    "http://example.invalid",
+		ResponseFormat: &ResponseFormat{
+			Type: "json_schema",
+			JSONSchema: &JSONSchemaSpec{
+				Name:   "person",
+				Strict: true,
+				Schema: schema,
+			},
+		},
+	}
+	httpReq, err := s.createRequest(context.Background(), pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "c"}}})
+	if err != nil {
+		t.Fatalf("createRequest err: %v", err)
+	}
+	b, _ := io.ReadAll(httpReq.Body)
+	var body map[string]any
+	if err := jsonUnmarshal(b, &body); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	rf, ok := body["response_format"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected response_format map, got: %T", body["response_format"])
+	}
+	if rf["type"] != "json_schema" {
+		t.Fatalf("expected type=json_schema, got: %v", rf["type"])
+	}
+	js, ok := rf["json_schema"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected json_schema map, got: %T", rf["json_schema"])
+	}
+	if js["name"] != "person" {
+		t.Fatalf("expected name=person, got: %v", js["name"])
+	}
+	if js["strict"] != true {
+		t.Fatalf("expected strict=true, got: %v", js["strict"])
+	}
+	if js["schema"] == nil {
+		t.Fatalf("expected schema to be present")
+	}
+}
+
+func TestSetResponseFormat(t *testing.T) {
+	s := &StreamCompleter{}
+	if s.ResponseFormat != nil {
+		t.Fatalf("expected nil ResponseFormat")
+	}
+	s.SetResponseFormat(&ResponseFormat{Type: "json_object"})
+	if s.ResponseFormat == nil || s.ResponseFormat.Type != "json_object" {
+		t.Fatalf("expected json_object, got: %+v", s.ResponseFormat)
+	}
+	s.SetResponseFormat(nil)
+	if s.ResponseFormat != nil {
+		t.Fatalf("expected nil after reset")
+	}
+}

--- a/internal/text/querier_setup.go
+++ b/internal/text/querier_setup.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/baalimago/clai/internal/cost"
 	"github.com/baalimago/clai/internal/models"
+	"github.com/baalimago/clai/internal/text/generic"
 	"github.com/baalimago/clai/internal/utils"
 	"github.com/baalimago/clai/internal/vendors/openrouter"
 	pub_models "github.com/baalimago/clai/pkg/text/models"
@@ -186,6 +187,13 @@ func NewQuerier[C models.StreamCompleter](ctx context.Context, userConf Configur
 	querier.toolOutputRuneLimit = userConf.ToolOutputRuneLimit
 	querier.maxToolCalls = userConf.MaxToolCalls
 	querier.out = userConf.Out
+
+	// Propagate response format to the model if it supports it
+	if userConf.ResponseFormat != nil {
+		if setter, ok := any(&modelConf).(generic.ResponseFormatSetter); ok {
+			setter.SetResponseFormat(toGenericResponseFormat(userConf.ResponseFormat))
+		}
+	}
 
 	var fetcher cost.ModelCatalogFetcher
 	if fetcher == nil {

--- a/internal/text/querier_setup.go
+++ b/internal/text/querier_setup.go
@@ -190,7 +190,7 @@ func NewQuerier[C models.StreamCompleter](ctx context.Context, userConf Configur
 
 	// Propagate response format to the model if it supports it
 	if userConf.ResponseFormat != nil {
-		if setter, ok := any(&modelConf).(generic.ResponseFormatSetter); ok {
+		if setter, ok := any(modelConf).(generic.ResponseFormatSetter); ok {
 			setter.SetResponseFormat(toGenericResponseFormat(userConf.ResponseFormat))
 		}
 	}

--- a/internal/vendors/openai/gpt.go
+++ b/internal/vendors/openai/gpt.go
@@ -36,6 +36,7 @@ type ChatGPT struct {
 
 	streamCompleter *generic.StreamCompleter
 	useResponses    bool
+	responseFormat  *generic.ResponseFormat
 }
 
 func (g *ChatGPT) Setup() error {
@@ -66,6 +67,10 @@ func (g *ChatGPT) TokenUsage() *pub_models.Usage {
 		return nil
 	}
 	return g.streamCompleter.TokenUsage()
+}
+
+func (g *ChatGPT) SetResponseFormat(rf *generic.ResponseFormat) {
+	g.responseFormat = rf
 }
 
 func (g *ChatGPT) setUsage(usage *pub_models.Usage) error {
@@ -123,6 +128,11 @@ func (g *ChatGPT) StreamCompletions(ctx context.Context, chat pub_models.Chat) (
 	g.streamCompleter.ToolChoice = &toolChoice
 	for _, tool := range g.tools {
 		g.streamCompleter.InternalRegisterTool(tool)
+	}
+
+	// Propagate response format if configured
+	if g.responseFormat != nil {
+		g.streamCompleter.ResponseFormat = g.responseFormat
 	}
 
 	out, err := g.streamCompleter.StreamCompletions(ctx, chat)

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ Flags:
   -p, -profile string              Set the profile which should be used. For details, see 'clai help profile'. (default '%v')
   -prp, profile-path string        Set the path to a profile file to use instead of -p/-profile.
   -asc, -append-shell-context str  Append a named shell context from <config-dir>/shellContexts/<name>.json to the final query prompt.
+  -rf, -response-format string     Path to a response_format JSON file for structured output (json_object, json_schema).
 
 Config dir: %v
 Cache dir:  %v

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -15,13 +15,14 @@ import (
 )
 
 type Agent struct {
-	name         string
-	model        string
-	prompt       string
-	tools        []models.LLMTool
-	mcpServers   []models.McpServer
-	cfgDir       string
-	maxToolCalls *int
+	name           string
+	model          string
+	prompt         string
+	tools          []models.LLMTool
+	mcpServers     []models.McpServer
+	cfgDir         string
+	maxToolCalls   *int
+	responseFormat *models.ResponseFormat
 
 	querierCreator func(ctx context.Context, conf text.Configurations) (priv_models.Querier, error)
 
@@ -100,6 +101,14 @@ func WithOutputTo(out io.Writer) Option {
 	}
 }
 
+// WithResponseFormat configures structured output for the agent.
+// Supports "json_object" and "json_schema" types.
+func WithResponseFormat(rf models.ResponseFormat) Option {
+	return func(a *Agent) {
+		a.responseFormat = &rf
+	}
+}
+
 func (a *Agent) asInternalConfig() text.Configurations {
 	return text.Configurations{
 		Model:           a.model,
@@ -110,6 +119,7 @@ func (a *Agent) asInternalConfig() text.Configurations {
 		McpServers:      a.mcpServers,
 		Tools:           a.tools,
 		MaxToolCalls:    a.maxToolCalls,
+		ResponseFormat:  a.responseFormat,
 	}
 }
 

--- a/pkg/text/models/response_format.go
+++ b/pkg/text/models/response_format.go
@@ -1,0 +1,22 @@
+package models
+
+// ResponseFormat configures structured output for compatible models.
+// Supported types: "text", "json_object", "json_schema".
+type ResponseFormat struct {
+	// Type of response format: "text", "json_object", or "json_schema".
+	Type string
+	// Schema is used when Type is "json_schema".
+	Schema *JSONSchema
+}
+
+// JSONSchema defines the JSON Schema for structured output.
+type JSONSchema struct {
+	// Name of the schema. Required by the API.
+	Name string
+	// Description of what the schema represents. Optional.
+	Description string
+	// Strict enables strict mode. When true, the model will be forced to comply.
+	Strict bool
+	// Schema is the JSON Schema definition as a map.
+	Schema map[string]any
+}


### PR DESCRIPTION
Added response format in CLI and for pkg. It works quite well. Set the response format as a json scheme file under
file `-rf <path-to-json-schema>` and ensure the underlying model supports it.

Only added for generic stream completer, so no anthropic or responses (codex) support.
