### PR TITLE
vendor: Berget.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ See [examples](./EXAMPLES.md) for additional info.
 
 | Vendor      | Environment Variable | Models                                                                                                                                                             |
 | ----------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Berget AI   | `BERGET_API_KEY`     | [Text models](https://berget.ai/models), use prefix `berget:`                                                                                                      |
 | OpenRouter  | `OPENROUTER_API_KEY` | [Text models](https://openrouter.ai/models), use prefix `or:`                                                                                                       |
 | Mistral     | `MISTRAL_API_KEY`    | [Text models](https://docs.mistral.ai/getting-started/models/)                                                                                                     |
 | OpenAI      | `OPENAI_API_KEY`     | [Text models](https://platform.openai.com/docs/models), [photo models](https://platform.openai.com/docs/models/dall-e)                                             |

--- a/internal/cost/manager.go
+++ b/internal/cost/manager.go
@@ -58,7 +58,7 @@ type Session interface {
 func NewManager(fetcher ModelCatalogFetcher, model, configPath string) Manager {
 	debug := misc.Truthy(os.Getenv("DEBUG")) || misc.Truthy(os.Getenv("DEBUG_COST_MANAGER"))
 	if debug {
-		ancli.Noticef("setting up cost manager")
+		ancli.Noticef("setting up cost manager\n")
 	}
 
 	return Manager{
@@ -192,7 +192,7 @@ func (m *Manager) Start(ctx context.Context) (<-chan struct{}, <-chan error) {
 		defer close(readyCh)
 
 		if m.debug {
-			ancli.Noticef("resolve routine started")
+			ancli.Noticef("resolve routine started\n")
 		}
 		price, err := m.resolveModelPrice(ctx)
 		if err != nil {
@@ -204,7 +204,7 @@ func (m *Manager) Start(ctx context.Context) (<-chan struct{}, <-chan error) {
 		}
 		m.price = &price
 		if m.debug {
-			ancli.Noticef("resolve routine done, setting price to: %v", price)
+			ancli.Noticef("resolve routine done, setting price to: %v\n", price)
 		}
 	}()
 	return readyCh, errCh

--- a/internal/create_queriers.go
+++ b/internal/create_queriers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/baalimago/clai/internal/utils"
 	"github.com/baalimago/clai/internal/vendors"
 	"github.com/baalimago/clai/internal/vendors/anthropic"
+	"github.com/baalimago/clai/internal/vendors/berget"
 	"github.com/baalimago/clai/internal/vendors/deepseek"
 	"github.com/baalimago/clai/internal/vendors/gemini"
 	"github.com/baalimago/clai/internal/vendors/huggingface"
@@ -162,6 +163,15 @@ func selectTextQuerier(ctx context.Context, conf text.Configurations) (models.Qu
 	} else if strings.HasPrefix(conf.Model, "novita:") {
 		found = true
 		defaultCpy := novita.Default
+		defaultCpy.Model = conf.Model[7:]
+		qTmp, err := text.NewQuerier(ctx, conf, &defaultCpy)
+		if err != nil {
+			return nil, found, fmt.Errorf("failed to create text querier: %w", err)
+		}
+		q = &qTmp
+	} else if strings.HasPrefix(conf.Model, "berget:") {
+		found = true
+		defaultCpy := berget.Default
 		defaultCpy.Model = conf.Model[7:]
 		qTmp, err := text.NewQuerier(ctx, conf, &defaultCpy)
 		if err != nil {

--- a/internal/text/querier.go
+++ b/internal/text/querier.go
@@ -43,6 +43,10 @@ type Querier[C models.StreamCompleter] struct {
 	toolOutputRuneLimit     int
 	rateLimitLastAmTokens   int
 
+	// systemPrompt is the configured system prompt, injected into every
+	// TextQuery call that does not already carry a system message.
+	systemPrompt string
+
 	// reasoningBuf accumulates thinking/chain-of-thought tokens streamed
 	// before the final answer.  It is wrapped in [thinking]…[/thinking]
 	// when displayed.
@@ -289,6 +293,26 @@ func (q *Querier[C]) Query(ctx context.Context) error {
 
 func (q *Querier[C]) TextQuery(ctx context.Context, chat pub_models.Chat) (pub_models.Chat, error) {
 	q.resetTransientState()
+	// Inject the configured system prompt when the incoming chat
+	// does not already carry one.  This ensures system prompts
+	// configured via Configurations.SystemPrompt (e.g. through
+	// agent.WithPrompt) reach the model even when the caller
+	// bypasses SetupInitialChat (the CLI path).
+	if q.systemPrompt != "" {
+		hasSystem := false
+		for _, m := range chat.Messages {
+			if m.Role == "system" {
+				hasSystem = true
+				break
+			}
+		}
+		if !hasSystem {
+			chat.Messages = append(
+				[]pub_models.Message{{Role: "system", Content: q.systemPrompt}},
+				chat.Messages...,
+			)
+		}
+	}
 	q.chat = chat
 	// Query will update the chat with the latest system message
 	err := q.Query(ctx)

--- a/internal/text/querier_setup.go
+++ b/internal/text/querier_setup.go
@@ -165,6 +165,7 @@ func NewQuerier[C models.StreamCompleter](ctx context.Context, userConf Configur
 		return Querier[C]{}, fmt.Errorf("failed to setup model: %w", err)
 	}
 
+	traceChatf("post setup")
 	termWidth, err := utils.TermWidth()
 	if err == nil {
 		querier.termWidth = termWidth
@@ -179,14 +180,11 @@ func NewQuerier[C models.StreamCompleter](ctx context.Context, userConf Configur
 	} else {
 		querier.username = "user"
 	}
+	traceChatf("user is: %v", currentUser.Name)
 	querier.Model = modelConf
-	if querier.debug {
-		ancli.Okf("querier: %v,\n===\nmodels: %v\n",
-			debug.IndentedJsonFmt(querier),
-			debug.IndentedJsonFmt(modelConf))
-
-		ancli.Okf("Out is: %v", userConf.Out)
-	}
+	traceChatf("querier: %v,\n===\nmodels: %v\n",
+		debug.IndentedJsonFmt(querier),
+		debug.IndentedJsonFmt(modelConf))
 	querier.chat = userConf.InitialChat
 	traceChatf("new querier chat attached chat_id=%q messages=%d", querier.chat.ID, len(querier.chat.Messages))
 	// Ensure profile selection is persisted in globalScope/saved conversations.

--- a/internal/text/querier_setup.go
+++ b/internal/text/querier_setup.go
@@ -186,7 +186,8 @@ func NewQuerier[C models.StreamCompleter](ctx context.Context, userConf Configur
 		debug.IndentedJsonFmt(querier),
 		debug.IndentedJsonFmt(modelConf))
 	querier.chat = userConf.InitialChat
-	traceChatf("new querier chat attached chat_id=%q messages=%d", querier.chat.ID, len(querier.chat.Messages))
+	querier.systemPrompt = userConf.SystemPrompt
+	traceChatf("new querier chat attached chat_id=%q messages=%d system_prompt_len=%d", querier.chat.ID, len(querier.chat.Messages), len(querier.systemPrompt))
 	// Ensure profile selection is persisted in globalScope/saved conversations.
 	querier.chat.Profile = userConf.UseProfile
 	querier.Raw = userConf.Raw

--- a/internal/text/querier_setup.go
+++ b/internal/text/querier_setup.go
@@ -29,6 +29,16 @@ func vendorType(fromModel string) (string, string, string, error) {
 		modelVersion := after
 		return "openrouter", "chat", modelVersion, nil
 	}
+	if strings.HasPrefix(fromModel, "berget:") {
+		vendor := "berget"
+		modelVersion := fromModel[7:]
+		parts := strings.Split(modelVersion, "/")
+		if len(parts) > 1 {
+			vendor = parts[0]
+			modelVersion = parts[1]
+		}
+		return "berget", vendor, modelVersion, nil
+	}
 	if strings.Contains(fromModel, "gpt") {
 		return "openai", "gpt", fromModel, nil
 	}

--- a/internal/text/querier_setup_test.go
+++ b/internal/text/querier_setup_test.go
@@ -17,3 +17,35 @@ func TestVendorType_OpenRouter(t *testing.T) {
 		t.Fatalf("modelVersion mismatch: got %q want %q", modelVersion, "openai/gpt-5.2")
 	}
 }
+
+func TestVendorType_Berget(t *testing.T) {
+	vendor, model, modelVersion, err := vendorType("berget:zai-org/GLM-4.7-FP8")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vendor != "berget" {
+		t.Fatalf("vendor mismatch: got %q want %q", vendor, "berget")
+	}
+	if model != "zai-org" {
+		t.Fatalf("model mismatch: got %q want %q", model, "zai-org")
+	}
+	if modelVersion != "GLM-4.7-FP8" {
+		t.Fatalf("modelVersion mismatch: got %q want %q", modelVersion, "GLM-4.7-FP8")
+	}
+}
+
+func TestVendorType_Berget_NoOrg(t *testing.T) {
+	vendor, model, modelVersion, err := vendorType("berget:gemma-4-31B-it")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vendor != "berget" {
+		t.Fatalf("vendor mismatch: got %q want %q", vendor, "berget")
+	}
+	if model != "berget" {
+		t.Fatalf("model mismatch: got %q want %q", model, "berget")
+	}
+	if modelVersion != "gemma-4-31B-it" {
+		t.Fatalf("modelVersion mismatch: got %q want %q", modelVersion, "gemma-4-31B-it")
+	}
+}

--- a/internal/text/querier_test.go
+++ b/internal/text/querier_test.go
@@ -24,6 +24,110 @@ type stubTool struct {
 	output string
 }
 
+func Test_Querier_TextQuery_SystemPrompt(t *testing.T) {
+	t.Run("injects system prompt when chat has no system message", func(t *testing.T) {
+		wantPrompt := "You are a test assistant"
+		var capturedChat pub_models.Chat
+		q := &Querier[*MockQuerier]{
+			systemPrompt: wantPrompt,
+			out:          &strings.Builder{},
+			Model: &MockQuerier{
+				streamFn: func(ctx context.Context, chat pub_models.Chat) (chan models.CompletionEvent, error) {
+					capturedChat = chat
+					ch := make(chan models.CompletionEvent)
+					close(ch)
+					return ch, nil
+				},
+			},
+		}
+		chat := pub_models.Chat{
+			Messages: []pub_models.Message{
+				{Role: "user", Content: "hello"},
+			},
+		}
+		_, err := q.TextQuery(context.Background(), chat)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(capturedChat.Messages) != 2 {
+			t.Fatalf("expected 2 messages, got %d", len(capturedChat.Messages))
+		}
+		if capturedChat.Messages[0].Role != "system" {
+			t.Fatalf("expected first message role system, got %q", capturedChat.Messages[0].Role)
+		}
+		if capturedChat.Messages[0].Content != wantPrompt {
+			t.Fatalf("expected system prompt %q, got %q", wantPrompt, capturedChat.Messages[0].Content)
+		}
+	})
+
+	t.Run("does not inject when chat already has system message", func(t *testing.T) {
+		existingSystem := "existing system message"
+		var capturedChat pub_models.Chat
+		q := &Querier[*MockQuerier]{
+			systemPrompt: "should not appear",
+			out:          &strings.Builder{},
+			Model: &MockQuerier{
+				streamFn: func(ctx context.Context, chat pub_models.Chat) (chan models.CompletionEvent, error) {
+					capturedChat = chat
+					ch := make(chan models.CompletionEvent)
+					close(ch)
+					return ch, nil
+				},
+			},
+		}
+		chat := pub_models.Chat{
+			Messages: []pub_models.Message{
+				{Role: "system", Content: existingSystem},
+				{Role: "user", Content: "hello"},
+			},
+		}
+		_, err := q.TextQuery(context.Background(), chat)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(capturedChat.Messages) != 2 {
+			t.Fatalf("expected 2 messages, got %d", len(capturedChat.Messages))
+		}
+		if capturedChat.Messages[0].Role != "system" {
+			t.Fatalf("expected first message role system, got %q", capturedChat.Messages[0].Role)
+		}
+		if capturedChat.Messages[0].Content != existingSystem {
+			t.Fatalf("expected original system message %q, got %q", existingSystem, capturedChat.Messages[0].Content)
+		}
+	})
+
+	t.Run("does not inject when systemPrompt is empty", func(t *testing.T) {
+		var capturedChat pub_models.Chat
+		q := &Querier[*MockQuerier]{
+			systemPrompt: "",
+			out:          &strings.Builder{},
+			Model: &MockQuerier{
+				streamFn: func(ctx context.Context, chat pub_models.Chat) (chan models.CompletionEvent, error) {
+					capturedChat = chat
+					ch := make(chan models.CompletionEvent)
+					close(ch)
+					return ch, nil
+				},
+			},
+		}
+		chat := pub_models.Chat{
+			Messages: []pub_models.Message{
+				{Role: "user", Content: "hello"},
+			},
+		}
+		_, err := q.TextQuery(context.Background(), chat)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(capturedChat.Messages) != 1 {
+			t.Fatalf("expected 1 message, got %d", len(capturedChat.Messages))
+		}
+		if capturedChat.Messages[0].Role != "user" {
+			t.Fatalf("expected user message, got %q", capturedChat.Messages[0].Role)
+		}
+	})
+}
+
 func (s stubTool) Call(pub_models.Input) (string, error) {
 	return s.output, nil
 }

--- a/internal/vendors/anthropic/claude_stream_test.go
+++ b/internal/vendors/anthropic/claude_stream_test.go
@@ -222,7 +222,7 @@ data: {"type": "message_stop"}
 	}
 
 	var got strings.Builder
-	gotThinking := ""
+	var gotThinking strings.Builder
 	sawSignatureDelta := false
 OUTER:
 	for {
@@ -237,11 +237,11 @@ OUTER:
 			case string:
 				got.WriteString(sel)
 			case models.ReasoningEvent:
-				gotThinking += sel.Content
+				gotThinking.WriteString(sel.Content)
 			case models.NoopEvent:
 				// signature_delta produces a NoopEvent; detect it indirectly
 				// by checking that we have thinking content already accumulated
-				if gotThinking != "" {
+				if gotThinking.String() != "" {
 					sawSignatureDelta = true
 				}
 			case error:
@@ -256,8 +256,8 @@ OUTER:
 	if got.String() != want {
 		t.Fatalf("expected text: %q, got: %q", want, got.String())
 	}
-	if gotThinking != wantThinking {
-		t.Fatalf("expected thinking: %q, got: %q", wantThinking, gotThinking)
+	if gotThinking.String() != wantThinking {
+		t.Fatalf("expected thinking: %q, got: %q", wantThinking, gotThinking.String())
 	}
 	if !sawSignatureDelta {
 		t.Fatal("expected to see a NoopEvent from signature_delta after thinking content")

--- a/internal/vendors/berget/berget.go
+++ b/internal/vendors/berget/berget.go
@@ -1,0 +1,51 @@
+package berget
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/baalimago/clai/internal/text/generic"
+
+	pub_models "github.com/baalimago/clai/pkg/text/models"
+)
+
+var Default = Berget{
+	Model:       "gemma-4-31B-it",
+	Temperature: 0.7,
+	TopP:        1.0,
+	URL:         ChatURL,
+}
+
+type Berget struct {
+	generic.StreamCompleter
+	Model            string  `json:"model"`
+	FrequencyPenalty float64 `json:"frequency_penalty"`
+	MaxTokens        *int    `json:"max_tokens"` // Use a pointer to allow null value
+	PresencePenalty  float64 `json:"presence_penalty"`
+	Temperature      float64 `json:"temperature"`
+	TopP             float64 `json:"top_p"`
+	URL              string  `json:"url"`
+}
+
+const ChatURL = "https://api.berget.ai/v1/chat/completions"
+
+func (g *Berget) Setup() error {
+	err := g.StreamCompleter.Setup("BERGET_API_KEY", ChatURL, "BERGET_DEBUG")
+	if err != nil {
+		return fmt.Errorf("failed to setup stream completer: %w", err)
+	}
+
+	modelName := strings.TrimPrefix(g.Model, "berget:")
+	g.StreamCompleter.Model = modelName
+	g.StreamCompleter.FrequencyPenalty = &g.FrequencyPenalty
+	g.StreamCompleter.MaxTokens = g.MaxTokens
+	g.StreamCompleter.Temperature = &g.Temperature
+	g.StreamCompleter.TopP = &g.TopP
+	toolChoice := "auto"
+	g.ToolChoice = &toolChoice
+	return nil
+}
+
+func (g *Berget) RegisterTool(tool pub_models.LLMTool) {
+	g.InternalRegisterTool(tool)
+}

--- a/internal/vendors/berget/berget_test.go
+++ b/internal/vendors/berget/berget_test.go
@@ -1,0 +1,45 @@
+package berget
+
+import "testing"
+
+func TestSetupConfigMapping(t *testing.T) {
+	v := Default
+	fp := 0.1
+	v.FrequencyPenalty = fp
+	mt := 777
+	v.MaxTokens = &mt
+	v.Temperature = 0.9
+	v.TopP = 0.95
+	v.Model = "berget:gemma-custom"
+
+	t.Setenv("BERGET_API_KEY", "k")
+	if err := v.Setup(); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+	if v.StreamCompleter.Model != "gemma-custom" {
+		t.Errorf("expected model to be trimmed of berget: prefix, got %q", v.StreamCompleter.Model)
+	}
+	if v.StreamCompleter.FrequencyPenalty == nil || *v.StreamCompleter.FrequencyPenalty != v.FrequencyPenalty {
+		t.Errorf("frequency penalty not mapped, got %#v want %v", v.StreamCompleter.FrequencyPenalty, v.FrequencyPenalty)
+	}
+	if v.StreamCompleter.MaxTokens == nil || *v.StreamCompleter.MaxTokens != *v.MaxTokens {
+		t.Errorf("max tokens not mapped, got %#v want %v", v.StreamCompleter.MaxTokens, *v.MaxTokens)
+	}
+	if v.StreamCompleter.Temperature == nil || *v.StreamCompleter.Temperature != v.Temperature {
+		t.Errorf("temperature not mapped, got %#v want %v", v.StreamCompleter.Temperature, v.Temperature)
+	}
+	if v.StreamCompleter.TopP == nil || *v.StreamCompleter.TopP != v.TopP {
+		t.Errorf("top_p not mapped, got %#v want %v", v.StreamCompleter.TopP, v.TopP)
+	}
+	if v.ToolChoice == nil || *v.ToolChoice != "auto" {
+		t.Errorf("tool choice expected 'auto', got %#v", v.ToolChoice)
+	}
+}
+
+func TestSetupFailsWhenAPIKeyMissing(t *testing.T) {
+	v := Default
+	t.Setenv("BERGET_API_KEY", "")
+	if err := v.Setup(); err == nil {
+		t.Fatalf("expected error when BERGET_API_KEY is missing")
+	}
+}

--- a/internal/vendors/openrouter/catalog_fetcher.go
+++ b/internal/vendors/openrouter/catalog_fetcher.go
@@ -24,7 +24,7 @@ type OpenRouterModelCatalog struct {
 func NewModelCatalog(apiKey string) (OpenRouterModelCatalog, error) {
 	debug := misc.Truthy(os.Getenv("DEBUG")) || misc.Truthy(os.Getenv("DEBUG_OPENROUTER_MODEL_CATALOG"))
 	if debug {
-		ancli.Noticef("setting up openrouter model catalog with api key: %v...(redacted)", apiKey[:5])
+		ancli.Noticef("setting up openrouter model catalog with api key: %v...(redacted)\n", apiKey[:5])
 	}
 	return OpenRouterModelCatalog{
 		debug: debug,

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -21,6 +21,7 @@ type Agent struct {
 	tools          []models.LLMTool
 	mcpServers     []models.McpServer
 	cfgDir         string
+	toolGlobs      []string
 	maxToolCalls   *int
 	responseFormat *models.ResponseFormat
 
@@ -101,6 +102,14 @@ func WithOutputTo(out io.Writer) Option {
 	}
 }
 
+// WithToolGlobs sets freetext glob patterns to filter which tools are registered.
+// Supports wildcards like "mcp_*", "mcp_playwright_*", or exact names like "cat".
+func WithToolGlobs(globs ...string) Option {
+	return func(a *Agent) {
+		a.toolGlobs = globs
+	}
+}
+
 // WithResponseFormat configures structured output for the agent.
 // Supports "json_object" and "json_schema" types.
 func WithResponseFormat(rf models.ResponseFormat) Option {
@@ -111,15 +120,16 @@ func WithResponseFormat(rf models.ResponseFormat) Option {
 
 func (a *Agent) asInternalConfig() text.Configurations {
 	return text.Configurations{
-		Model:           a.model,
-		SystemPrompt:    a.prompt,
-		ConfigDir:       a.cfgDir,
-		UseTools:        true,
-		SaveReplyAsConv: true,
-		McpServers:      a.mcpServers,
-		Tools:           a.tools,
-		MaxToolCalls:    a.maxToolCalls,
-		ResponseFormat:  a.responseFormat,
+		Model:              a.model,
+		SystemPrompt:       a.prompt,
+		ConfigDir:          a.cfgDir,
+		UseTools:           true,
+		SaveReplyAsConv:    true,
+		McpServers:         a.mcpServers,
+		Tools:              a.tools,
+		MaxToolCalls:       a.maxToolCalls,
+		RequestedToolGlobs: a.toolGlobs,
+		ResponseFormat:     a.responseFormat,
 	}
 }
 

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -47,12 +47,14 @@ func TestNew(t *testing.T) {
 		prompt := "test-prompt"
 		tools := []models.LLMTool{&mockTool{}}
 		mcpServers := []models.McpServer{{Name: "test-mcp"}}
+		toolGlobs := []string{"mcp_test_*", "cat"}
 
 		a := New(
 			WithModel(model),
 			WithPrompt(prompt),
 			WithTools(tools),
 			WithMcpServers(mcpServers),
+			WithToolGlobs(toolGlobs...),
 		)
 
 		if a.model != model {
@@ -66,6 +68,9 @@ func TestNew(t *testing.T) {
 		}
 		if !reflect.DeepEqual(a.mcpServers, mcpServers) {
 			t.Errorf("expected mcpServers %v, got %v", mcpServers, a.mcpServers)
+		}
+		if !reflect.DeepEqual(a.toolGlobs, toolGlobs) {
+			t.Errorf("expected toolGlobs %v, got %v", toolGlobs, a.toolGlobs)
 		}
 	})
 
@@ -153,11 +158,13 @@ func TestAgent_Setup(t *testing.T) {
 func TestAgent_asInternalConfig(t *testing.T) {
 	tools := []models.LLMTool{&mockTool{}}
 	mcpServers := []models.McpServer{{Name: "test-mcp"}}
+	toolGlobs := []string{"mcp_*", "cat"}
 	a := New(
 		WithModel("test-model"),
 		WithPrompt("test-prompt"),
 		WithTools(tools),
 		WithMcpServers(mcpServers),
+		WithToolGlobs(toolGlobs...),
 	)
 	a.cfgDir = "/tmp/test"
 
@@ -177,6 +184,9 @@ func TestAgent_asInternalConfig(t *testing.T) {
 	}
 	if !reflect.DeepEqual(conf.McpServers, mcpServers) {
 		t.Errorf("expected mcpServers %v, got %v", mcpServers, conf.McpServers)
+	}
+	if !reflect.DeepEqual(conf.RequestedToolGlobs, toolGlobs) {
+		t.Errorf("expected RequestedToolGlobs %v, got %v", toolGlobs, conf.RequestedToolGlobs)
 	}
 	if !conf.UseTools {
 		t.Error("expected UseTools to be true")


### PR DESCRIPTION
Could I have instead implemented a generic chat model where you can tweak by changing URL? Yes.

But I got some sponsoring for sakfråga.se so I figured I'd add first class support. The next vendor will not be
added like this though, but rather be added in a generic way.