### PR TITLE
feat: Table upgrades - filter + am table items

### DIFF
--- a/internal/chat/handler_list_chat.go
+++ b/internal/chat/handler_list_chat.go
@@ -206,7 +206,7 @@ func (cq *ChatHandler) listChats(ctx context.Context, paginator *ChatIndexPagina
 			}
 			return withSummary, nil
 		},
-		10,
+		utils.ThemeTableItems(),
 		true,
 		[]utils.TableAction{},
 		cq.out,
@@ -344,7 +344,7 @@ func (cq *ChatHandler) deleteMessageInChat(chat pub_models.Chat) error {
 			}
 			return withSummary, nil
 		},
-		10,
+		utils.ThemeTableItems(),
 		false,
 		[]utils.TableAction{},
 		cq.out,
@@ -387,7 +387,7 @@ func (cq *ChatHandler) editMessageInChat(chat pub_models.Chat) error {
 			}
 			return withSummary, nil
 		},
-		10,
+		utils.ThemeTableItems(),
 		true,
 		[]utils.TableAction{},
 		cq.out,

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -164,6 +164,7 @@ func InitCmd() error {
 					return nil, fmt.Errorf("failed to ensure skills config: %w", err)
 				}
 				cfgs = append(cfgs, config{name: "skills.json", filePath: filepath.Join(dir, "skills.json")})
+				cfgs = append(cfgs, config{name: "theme.json", filePath: filepath.Join(dir, "theme.json")})
 				return cfgs, nil
 			},
 			itemSelectActions: nil,
@@ -244,7 +245,7 @@ func selectCategory(categories []setupCategory) (setupCategory, error) {
 		func(i int, category setupCategory) (string, error) {
 			return fmt.Sprintf("%d. %s", i, category.name), nil
 		},
-		10,
+		utils.ThemeTableItems(),
 		true,
 		[]utils.TableAction{},
 		os.Stdout,
@@ -358,7 +359,7 @@ func selectConfigItem(category setupCategory, cfgs []config) error {
 		func(i int, cfg config) (string, error) {
 			return fmt.Sprintf("%d. %s", i, cfg.name), nil
 		},
-		10,
+		utils.ThemeTableItems(),
 		true,
 		customTableActions,
 		os.Stdout,

--- a/internal/setup/setup_actions.go
+++ b/internal/setup/setup_actions.go
@@ -225,7 +225,7 @@ func actionReconfigureStringFieldWithEditor(cfg config, fieldName string) error 
 			func(i int, t string) (string, error) {
 				return fmt.Sprintf("%v. %v", i, t), nil
 			},
-			10,
+			utils.ThemeTableItems(),
 			true,
 			nil,
 			os.Stdout,

--- a/internal/setup/skills_setup_test.go
+++ b/internal/setup/skills_setup_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/baalimago/clai/internal/skills"
 )
 
-func TestGeneralConfigLoadIncludesSkillsConfig(t *testing.T) {
+func TestGeneralConfigLoadIncludesSkillsAndThemeConfig(t *testing.T) {
 	dir := t.TempDir()
 	category := setupCategory{
 		name: "general config",
@@ -21,6 +21,7 @@ func TestGeneralConfigLoadIncludesSkillsConfig(t *testing.T) {
 				return nil, err
 			}
 			cfgs = append(cfgs, config{name: "skills.json", filePath: filepath.Join(dir, "skills.json")})
+			cfgs = append(cfgs, config{name: "theme.json", filePath: filepath.Join(dir, "theme.json")})
 			return cfgs, nil
 		},
 	}
@@ -32,15 +33,21 @@ func TestGeneralConfigLoadIncludesSkillsConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load() error = %v", err)
 	}
-	found := false
+	foundSkills := false
+	foundTheme := false
 	for _, cfg := range cfgs {
 		if cfg.name == "skills.json" {
-			found = true
-			break
+			foundSkills = true
+		}
+		if cfg.name == "theme.json" {
+			foundTheme = true
 		}
 	}
-	if !found {
+	if !foundSkills {
 		t.Fatalf("expected skills.json in %+v", cfgs)
+	}
+	if !foundTheme {
+		t.Fatalf("expected theme.json in %+v", cfgs)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "skills.json")); err != nil {
 		t.Fatalf("expected skills.json to exist: %v", err)

--- a/internal/utils/table.go
+++ b/internal/utils/table.go
@@ -67,15 +67,18 @@ func (pf paginatorFuncs[T]) findPage(start, offset int) ([]T, error) {
 }
 
 type table[T any] struct {
-	debug         bool
-	page          int
-	pageSize      int
-	lastPage      int
-	selectionType string
-	paginator     Paginator[T]
-	rowFormater   func(int, T) (string, error)
-	tableActions  []TableAction
-	out           io.Writer
+	debug             bool
+	page              int
+	pageSize          int
+	lastPage          int
+	selectionType     string
+	paginator         Paginator[T]
+	originalPaginator Paginator[T]
+	filterString      string
+	filteredIndices   []int
+	rowFormater       func(int, T) (string, error)
+	tableActions      []TableAction
+	out               io.Writer
 }
 
 var clearTermToFn = ClearTermTo
@@ -161,14 +164,15 @@ func SelectFromTable[T any](
 	fmt.Fprintf(out, "%v\n", Colorize(ThemePrimaryColor(), line))
 
 	tab := table[T]{
-		page:          0,
-		pageSize:      pageSize,
-		lastPage:      0,
-		selectionType: selectionType,
-		paginator:     paginator,
-		rowFormater:   rowFormater,
-		tableActions:  additionalTableActions,
-		out:           out,
+		page:              0,
+		pageSize:          pageSize,
+		lastPage:          0,
+		selectionType:     selectionType,
+		paginator:         paginator,
+		originalPaginator: paginator,
+		rowFormater:       rowFormater,
+		tableActions:      additionalTableActions,
+		out:               out,
 	}
 	tab.lastPage = tab.pageCount()
 	baseActions := []TableAction{tab.prevPage(), tab.nextPage(), tab.back(), tab.quit()}
@@ -246,7 +250,13 @@ func (t *table[T]) promptLine() string {
 	if actions != "" {
 		parts = append(parts, actions)
 	}
+	if t.filterString != "" {
+		parts = append(parts, fmt.Sprintf("filter: %q", t.filterString))
+	}
 	if t.pageCount() == 0 {
+		if t.filteredIndices != nil && t.paginator.totalAm() == 0 {
+			return fmt.Sprintf("(%s, no matches): ", strings.Join(parts, ", "))
+		}
 		return fmt.Sprintf("(%s): ", strings.Join(parts, ", "))
 	}
 	parts = append(parts, fmt.Sprintf("page %v/%v", t.page, t.pageCount()))
@@ -282,6 +292,15 @@ func (t *table[T]) selectNumbers() ([]int, error) {
 		return nil, fmt.Errorf("failed to read table selection: %w", err)
 	}
 
+	// Handle filter prefix: /<term> applies filter, / alone clears it
+	if strings.HasPrefix(choice, "/") {
+		t.filterString = choice[1:]
+		if err := t.applyFilter(); err != nil {
+			return nil, fmt.Errorf("failed to apply filter: %w", err)
+		}
+		return nil, nil
+	}
+
 	// See if the choice is a table action, if so, run it and return
 	for _, action := range t.tableActions {
 		additionalHotkeyMatch := false
@@ -304,6 +323,15 @@ func (t *table[T]) selectNumbers() ([]int, error) {
 	selectedNumbers, err := t.parseNumbersFromString(choice)
 	if err != nil {
 		return selectedNumbers, fmt.Errorf("failed to parse selected numbers from choice %q: %w", choice, err)
+	}
+
+	// Translate filtered indices back to original indices
+	if t.filteredIndices != nil {
+		translated := make([]int, len(selectedNumbers))
+		for i, num := range selectedNumbers {
+			translated[i] = t.filteredIndices[num]
+		}
+		selectedNumbers = translated
 	}
 
 	return selectedNumbers, nil
@@ -390,6 +418,54 @@ func (t *table[T]) multiPartParse(maybeRange string) ([]int, error) {
 		selectedNumbers = append(selectedNumbers, i)
 	}
 	return selectedNumbers, nil
+}
+
+// applyFilter rebuilds the filtered view from the current filterString.
+// An empty filterString clears the filter. The original paginator is never
+// modified; filtering replaces t.paginator with a SlicePaginator over the
+// matching subset and records t.filteredIndices for reverse index translation.
+func (t *table[T]) applyFilter() error {
+	if t.filterString == "" {
+		t.paginator = t.originalPaginator
+		t.filteredIndices = nil
+		t.page = 0
+		t.lastPage = t.pageCount()
+		return nil
+	}
+
+	totalAm := t.originalPaginator.totalAm()
+	if totalAm == 0 {
+		t.filteredIndices = nil
+		t.paginator = SlicePaginator([]T{})
+		t.page = 0
+		t.lastPage = t.pageCount()
+		return nil
+	}
+
+	allItems, err := t.originalPaginator.findPage(0, totalAm)
+	if err != nil {
+		return fmt.Errorf("failed to get items for filtering: %w", err)
+	}
+
+	lower := strings.ToLower(t.filterString)
+	matchedIndices := make([]int, 0, len(allItems))
+	matchedItems := make([]T, 0, len(allItems))
+	for i, item := range allItems {
+		formatted, formatErr := t.rowFormater(i, item)
+		if formatErr != nil {
+			continue
+		}
+		if strings.Contains(strings.ToLower(formatted), lower) {
+			matchedIndices = append(matchedIndices, i)
+			matchedItems = append(matchedItems, item)
+		}
+	}
+
+	t.filteredIndices = matchedIndices
+	t.paginator = SlicePaginator(matchedItems)
+	t.page = 0
+	t.lastPage = t.pageCount()
+	return nil
 }
 
 func (t *table[T]) parseNumbersFromString(choice string) ([]int, error) {

--- a/internal/utils/table_test.go
+++ b/internal/utils/table_test.go
@@ -900,6 +900,451 @@ func TestSlicePaginator(t *testing.T) {
 	}
 }
 
+func Test_table_applyFilter(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	t.Run("empty string clears filter and restores original paginator", func(t *testing.T) {
+		orig := testPaginator{total: 3, items: []int{10, 20, 30}}
+		tab := table[int]{
+			paginator:         orig,
+			originalPaginator: orig,
+			filterString:      "",
+			filteredIndices:   []int{0, 2},
+			pageSize:          10,
+			rowFormater:       func(i, item int) (string, error) { return fmt.Sprintf("%d=%d", i, item), nil },
+		}
+
+		if err := tab.applyFilter(); err != nil {
+			t.Fatalf("applyFilter() unexpected error: %v", err)
+		}
+		if tab.filteredIndices != nil {
+			t.Fatal("filteredIndices not nil after clearing")
+		}
+		if tab.paginator.totalAm() != 3 {
+			t.Fatalf("total after clear = %d, want 3", tab.paginator.totalAm())
+		}
+	})
+
+	t.Run("filters items by case-insensitive substring match on rendered text", func(t *testing.T) {
+		items := []string{"Alpha", "Bravo", "Charlie", "alpha-beta"}
+		paginator := SlicePaginator(items)
+		tab := table[string]{
+			paginator:         paginator,
+			originalPaginator: paginator,
+			pageSize:          10,
+			filterString:      "alpha",
+			rowFormater:       func(i int, item string) (string, error) { return item, nil },
+		}
+
+		if err := tab.applyFilter(); err != nil {
+			t.Fatalf("applyFilter() unexpected error: %v", err)
+		}
+
+		// Alpha (idx 0) and alpha-beta (idx 3) should match
+		wantIndices := []int{0, 3}
+		if !reflect.DeepEqual(tab.filteredIndices, wantIndices) {
+			t.Fatalf("filteredIndices = %v, want %v", tab.filteredIndices, wantIndices)
+		}
+
+		gotItems, err := tab.paginator.findPage(0, 10)
+		if err != nil {
+			t.Fatalf("findPage() error: %v", err)
+		}
+		wantItems := []string{"Alpha", "alpha-beta"}
+		if !reflect.DeepEqual(gotItems, wantItems) {
+			t.Fatalf("filtered items = %v, want %v", gotItems, wantItems)
+		}
+
+		if tab.page != 0 {
+			t.Fatalf("page = %d, want 0 (reset on filter)", tab.page)
+		}
+		if tab.paginator.totalAm() != 2 {
+			t.Fatalf("total = %d, want 2", tab.paginator.totalAm())
+		}
+	})
+
+	t.Run("no matches results in empty paginator and empty filteredIndices", func(t *testing.T) {
+		items := []string{"Alpha", "Bravo"}
+		paginator := SlicePaginator(items)
+		tab := table[string]{
+			paginator:         paginator,
+			originalPaginator: paginator,
+			pageSize:          10,
+			filterString:      "xyz",
+			rowFormater:       func(i int, item string) (string, error) { return item, nil },
+		}
+
+		if err := tab.applyFilter(); err != nil {
+			t.Fatalf("applyFilter() error: %v", err)
+		}
+
+		if len(tab.filteredIndices) != 0 {
+			t.Fatalf("filteredIndices = %v, want empty", tab.filteredIndices)
+		}
+		if tab.paginator.totalAm() != 0 {
+			t.Fatalf("total = %d, want 0", tab.paginator.totalAm())
+		}
+	})
+
+	t.Run("rowFormater errors are skipped gracefully", func(t *testing.T) {
+		items := []string{"one", "boom", "two"}
+		paginator := SlicePaginator(items)
+		tab := table[string]{
+			paginator:         paginator,
+			originalPaginator: paginator,
+			pageSize:          10,
+			filterString:      "t",
+			rowFormater: func(i int, item string) (string, error) {
+				if item == "boom" {
+					return "", errors.New("boom")
+				}
+				return item, nil
+			},
+		}
+
+		if err := tab.applyFilter(); err != nil {
+			t.Fatalf("applyFilter() error: %v", err)
+		}
+
+		// Only "two" contains 't' and formats successfully
+		want := []int{2}
+		if !reflect.DeepEqual(tab.filteredIndices, want) {
+			t.Fatalf("filteredIndices = %v, want %v", tab.filteredIndices, want)
+		}
+	})
+
+	t.Run("returns error when original paginator fails", func(t *testing.T) {
+		badPaginator := testPaginator{total: 1, findErr: errors.New("read error")}
+		tab := table[int]{
+			paginator:         badPaginator,
+			originalPaginator: badPaginator,
+			pageSize:          10,
+			filterString:      "test",
+			rowFormater:       func(i, item int) (string, error) { return "ok", nil },
+		}
+
+		err := tab.applyFilter()
+		if err == nil {
+			t.Fatal("applyFilter() error = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "failed to get items for filtering") {
+			t.Fatalf("error = %q, want filtering context", err.Error())
+		}
+	})
+
+	t.Run("clearing filter after one was active restores all items", func(t *testing.T) {
+		items := []string{"Alpha", "Bravo"}
+		paginator := SlicePaginator(items)
+		tab := table[string]{
+			paginator:         paginator,
+			originalPaginator: paginator,
+			pageSize:          10,
+			filterString:      "Alpha",
+			rowFormater:       func(i int, item string) (string, error) { return item, nil },
+		}
+
+		// First apply filter
+		if err := tab.applyFilter(); err != nil {
+			t.Fatalf("first applyFilter() error: %v", err)
+		}
+		if tab.paginator.totalAm() != 1 {
+			t.Fatalf("filtered total = %d, want 1", tab.paginator.totalAm())
+		}
+
+		// Then clear
+		tab.filterString = ""
+		if err := tab.applyFilter(); err != nil {
+			t.Fatalf("clear applyFilter() error: %v", err)
+		}
+		if tab.paginator.totalAm() != 2 {
+			t.Fatalf("cleared total = %d, want 2", tab.paginator.totalAm())
+		}
+		if tab.filteredIndices != nil {
+			t.Fatal("filteredIndices not nil after clear")
+		}
+	})
+
+	t.Run("filtering empty paginator returns empty", func(t *testing.T) {
+		paginator := SlicePaginator([]string{})
+		tab := table[string]{
+			paginator:         paginator,
+			originalPaginator: paginator,
+			pageSize:          10,
+			filterString:      "alpha",
+			rowFormater:       func(i int, item string) (string, error) { return item, nil },
+		}
+
+		if err := tab.applyFilter(); err != nil {
+			t.Fatalf("applyFilter() error: %v", err)
+		}
+		if tab.paginator.totalAm() != 0 {
+			t.Fatalf("total = %d, want 0", tab.paginator.totalAm())
+		}
+		if tab.filteredIndices != nil {
+			t.Fatal("filteredIndices should be nil for empty paginator")
+		}
+	})
+}
+
+func Test_table_selectNumbers_filterPrefix(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	t.Run("/term sets filter and returns nil so loop continues", func(t *testing.T) {
+		inputs := []string{"/test", "0"}
+		restoreReadUserInput := UseReadUserInputForTests(func() (string, error) {
+			if len(inputs) == 0 {
+				return "", fmt.Errorf("no more test inputs")
+			}
+			next := inputs[0]
+			inputs = inputs[1:]
+			return next, nil
+		})
+		defer restoreReadUserInput()
+
+		items := []string{"first", "second", "test-item", "other"}
+		paginator := SlicePaginator(items)
+		tab := table[string]{
+			page:              0,
+			pageSize:          10,
+			lastPage:          0,
+			paginator:         paginator,
+			originalPaginator: paginator,
+			rowFormater:       func(i int, item string) (string, error) { return item, nil },
+			tableActions:      nil,
+			out:               new(bytes.Buffer),
+		}
+
+		// First call: /test sets filter and returns nil, nil
+		got, err := tab.selectNumbers()
+		if err != nil {
+			t.Fatalf("first selectNumbers() error: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("first call returned %v, want nil (loop continue)", got)
+		}
+		if tab.filterString != "test" {
+			t.Fatalf("filterString = %q, want %q", tab.filterString, "test")
+		}
+		if tab.paginator.totalAm() != 1 {
+			t.Fatalf("filtered total = %d, want 1", tab.paginator.totalAm())
+		}
+
+		// Second call: "0" selects the first filtered item, translated to original index
+		got, err = tab.selectNumbers()
+		if err != nil {
+			t.Fatalf("second selectNumbers() error: %v", err)
+		}
+		want := []int{2}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got = %v, want %v (original index)", got, want)
+		}
+	})
+
+	t.Run("/ alone clears filter", func(t *testing.T) {
+		restoreReadUserInput := UseReadUserInputForTests(func() (string, error) {
+			return "/", nil
+		})
+		defer restoreReadUserInput()
+
+		items := []string{"first", "second"}
+		paginator := SlicePaginator(items)
+		tab := table[string]{
+			page:              0,
+			pageSize:          10,
+			paginator:         SlicePaginator([]string{"first"}),
+			originalPaginator: paginator,
+			filterString:      "first",
+			filteredIndices:   []int{0},
+			rowFormater:       func(i int, item string) (string, error) { return item, nil },
+			out:               new(bytes.Buffer),
+		}
+
+		got, err := tab.selectNumbers()
+		if err != nil {
+			t.Fatalf("selectNumbers() error: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("got = %v, want nil (loop continue)", got)
+		}
+		if tab.filterString != "" {
+			t.Fatalf("filterString = %q, want empty", tab.filterString)
+		}
+		if tab.filteredIndices != nil {
+			t.Fatal("filteredIndices should be nil after clear")
+		}
+		if tab.paginator.totalAm() != 2 {
+			t.Fatalf("restored total = %d, want 2", tab.paginator.totalAm())
+		}
+	})
+
+	t.Run("filtered selection with multiple numbers returns translated indices", func(t *testing.T) {
+		inputs := []string{"/alpha", "0,1"}
+		restoreReadUserInput := UseReadUserInputForTests(func() (string, error) {
+			if len(inputs) == 0 {
+				return "", fmt.Errorf("no more test inputs")
+			}
+			next := inputs[0]
+			inputs = inputs[1:]
+			return next, nil
+		})
+		defer restoreReadUserInput()
+
+		items := []string{"Alpha-zero", "Bravo", "Alpha-one"}
+		paginator := SlicePaginator(items)
+		tab := table[string]{
+			page:              0,
+			pageSize:          10,
+			paginator:         paginator,
+			originalPaginator: paginator,
+			rowFormater:       func(i int, item string) (string, error) { return item, nil },
+			out:               new(bytes.Buffer),
+		}
+
+		// First call: /alpha sets filter
+		got, err := tab.selectNumbers()
+		if err != nil {
+			t.Fatalf("first selectNumbers() error: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("first call returned %v, want nil", got)
+		}
+
+		// Second call: select filtered indices 0 and 1 -> original 0 and 2
+		got, err = tab.selectNumbers()
+		if err != nil {
+			t.Fatalf("second selectNumbers() error: %v", err)
+		}
+		want := []int{0, 2}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("navigation actions work while filter is active", func(t *testing.T) {
+		inputs := []string{"/e", "n", "2"}
+		restoreReadUserInput := UseReadUserInputForTests(func() (string, error) {
+			if len(inputs) == 0 {
+				return "", fmt.Errorf("no more test inputs")
+			}
+			next := inputs[0]
+			inputs = inputs[1:]
+			return next, nil
+		})
+		defer restoreReadUserInput()
+
+		items := []string{"zero", "one", "two", "three", "four", "five", "six", "seven"}
+		paginator := SlicePaginator(items)
+		var out bytes.Buffer
+		tab := table[string]{
+			page:              0,
+			pageSize:          2,
+			paginator:         paginator,
+			originalPaginator: paginator,
+			rowFormater:       func(i int, item string) (string, error) { return item, nil },
+			tableActions:      []TableAction{},
+			out:               &out,
+		}
+		tab.tableActions = append(tab.tableActions, tab.prevPage(), tab.nextPage(), tab.back(), tab.quit())
+
+		// First: /e -> filter items containing 'e' (zero=0, one=1, three=3, five=5, seven=7)
+		got, err := tab.selectNumbers()
+		if err != nil {
+			t.Fatalf("first call: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("first returned %v, want nil", got)
+		}
+		if tab.paginator.totalAm() != 5 {
+			t.Fatalf("filtered total = %d, want 5", tab.paginator.totalAm())
+		}
+
+		// Second: n -> next page
+		got, err = tab.selectNumbers()
+		if err != nil {
+			t.Fatalf("second call: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("second returned %v, want nil", got)
+		}
+		if tab.page != 1 {
+			t.Fatalf("page = %d, want 1 (next from 0)", tab.page)
+		}
+
+		// Third: select 2 on page 1 -> absolute filtered position 2 -> original index (three = 3)
+		got, err = tab.selectNumbers()
+		if err != nil {
+			t.Fatalf("third call: %v", err)
+		}
+		// Filtered indices: [0, 1, 3, 5, 7]; page 1 (index 2+3) -> original 3, 5
+		// Selecting displayed index 2 = absolute filtered position 2 = original index 3
+		want := []int{3}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got = %v, want %v", got, want)
+		}
+	})
+}
+
+func Test_table_promptLine_filter(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	t.Run("shows filter string when filter is active", func(t *testing.T) {
+		tab := table[int]{
+			selectionType: "select",
+			filterString:  "hello",
+			pageSize:      10,
+			paginator:     SlicePaginator([]int{1, 2, 3}),
+		}
+		got := tab.promptLine()
+		if !strings.Contains(got, `filter: "hello"`) {
+			t.Fatalf("promptLine() = %q, want filter indicator", got)
+		}
+	})
+
+	t.Run("shows no matches for active filter with zero results", func(t *testing.T) {
+		tab := table[int]{
+			selectionType:   "select",
+			filterString:    "nothing",
+			filteredIndices: []int{},
+			pageSize:        10,
+			paginator:       SlicePaginator([]int{}),
+		}
+		got := tab.promptLine()
+		if !strings.Contains(got, "no matches") {
+			t.Fatalf("promptLine() = %q, want 'no matches' indicator", got)
+		}
+	})
+
+	t.Run("shows page when filter is active with multiple pages", func(t *testing.T) {
+		tab := table[int]{
+			selectionType:   "select",
+			filterString:    "e",
+			filteredIndices: []int{0, 1, 2, 3, 4, 5},
+			pageSize:        3,
+			page:            0,
+			paginator:       SlicePaginator([]int{10, 20, 30, 40, 50, 60}),
+		}
+		got := tab.promptLine()
+		if !strings.Contains(got, "page 0/1") {
+			t.Fatalf("promptLine() = %q, want page indicator", got)
+		}
+		if !strings.Contains(got, `filter: "e"`) {
+			t.Fatalf("promptLine() = %q, want filter indicator", got)
+		}
+	})
+
+	t.Run("no filter indicator when filter is empty", func(t *testing.T) {
+		tab := table[int]{
+			selectionType: "select",
+			pageSize:      10,
+			paginator:     SlicePaginator([]int{1}),
+		}
+		got := tab.promptLine()
+		if strings.Contains(got, "filter") {
+			t.Fatalf("promptLine() = %q, unexpected filter indicator", got)
+		}
+	})
+}
+
 type errWriter struct{}
 
 func (errWriter) Write(p []byte) (int, error) {

--- a/internal/utils/theme.go
+++ b/internal/utils/theme.go
@@ -29,6 +29,8 @@ type Theme struct {
 	RoleOther     string `json:"roleOther"`
 
 	NotificationBell bool `json:"notificationBell"`
+
+	TableItems int `json:"tableItems"`
 }
 
 func defaultTheme() *Theme {
@@ -45,6 +47,8 @@ func defaultTheme() *Theme {
 		RoleReasoning:    "\u001b[38;2;180;170;150m",
 		RoleOther:        "\u001b[34m",
 		NotificationBell: true,
+
+		TableItems: 10,
 	}
 }
 
@@ -77,6 +81,7 @@ func migrateThemeConfig(configDirPath string) error {
 		RoleTool         string `json:"roleTool"`
 		RoleOther        string `json:"roleOther"`
 		NotificationBell bool   `json:"notificationBell"`
+		TableItems       int    `json:"tableItems"`
 	}
 
 	var conf themeMigration
@@ -133,6 +138,9 @@ func RoleColor(role string) string {
 func ThemePrimaryColor() string   { return globalTheme.Primary }
 func ThemeSecondaryColor() string { return globalTheme.Secondary }
 func ThemeBreadtextColor() string { return globalTheme.Breadtext }
+func ThemeTableItems() int {
+	return globalTheme.TableItems
+}
 
 func NotificationBellEnabled() bool { return globalTheme.NotificationBell }
 

--- a/internal/utils/theme_notification_test.go
+++ b/internal/utils/theme_notification_test.go
@@ -79,3 +79,46 @@ func TestLoadTheme_NotificationBellCanBeDisabled(t *testing.T) {
 		t.Fatal("expected notification bell to remain enabled because zero-valued bools are backfilled from defaults")
 	}
 }
+
+func TestLoadTheme_AppendsTableItemsDefaultForExistingThemeWithoutField(t *testing.T) {
+	confDir := t.TempDir()
+	themePath := filepath.Join(confDir, "theme.json")
+
+	err := os.WriteFile(themePath, []byte(strings.TrimSpace(`
+{
+  "primary": "p",
+  "secondary": "s",
+  "breadtext": "b",
+  "roleSystem": "rs",
+  "roleUser": "ru",
+  "roleTool": "rt",
+  "roleOther": "ro",
+  "notificationBell": true
+}
+`)), 0o644)
+	if err != nil {
+		t.Fatalf("WriteFile(%q): %v", themePath, err)
+	}
+
+	err = LoadTheme(confDir)
+	if err != nil {
+		t.Fatalf("LoadTheme(%q): %v", confDir, err)
+	}
+
+	if got := ThemeTableItems(); got != 10 {
+		t.Fatalf("ThemeTableItems() = %d, want 10", got)
+	}
+
+	themeBytes, err := os.ReadFile(themePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", themePath, err)
+	}
+	testboil.AssertStringContains(t, string(themeBytes), `"tableItems": 10`)
+}
+
+func TestDefaultTheme_HasTableItemsSetTo10(t *testing.T) {
+	th := defaultTheme()
+	if th.TableItems != 10 {
+		t.Fatalf("defaultTheme().TableItems = %d, want 10", th.TableItems)
+	}
+}


### PR DESCRIPTION
Minor changes with quite high QoL boost.

Changes:
* `clai chat list` now has `/<filter-term>` which global searches 
* You can now configure amount of rows shown in `clai setup` -> `0` (general setup) -> `4` (theme` -> tableItems