### PR TITLE
feat: Add file redirection (to compliment stdin pipes)

### DIFF
--- a/internal/utils/prompt.go
+++ b/internal/utils/prompt.go
@@ -24,20 +24,16 @@ func Prompt(stdinReplace string, args []string) (string, error) {
 	if err != nil {
 		panic(err)
 	}
-	var hasPipe bool
-	if fi.Mode()&os.ModeNamedPipe == 0 {
-		hasPipe = false
-	} else {
-		hasPipe = true
-	}
+	// hasStdin is true when stdin is not a terminal (pipe, file redirect, etc.)
+	hasStdin := fi.Mode()&os.ModeCharDevice == 0
 
-	if len(args) == 1 && !hasPipe {
+	if len(args) == 1 && !hasStdin {
 		return "", errors.New("found no prompt, set args or pipe in some string")
 	}
 	// First argument is the command, so we skip it
 	args = args[1:]
 	// If no data is in stdin, simply return args
-	if !hasPipe {
+	if !hasStdin {
 		return strings.Join(args, " "), nil
 	}
 
@@ -49,7 +45,7 @@ func Prompt(stdinReplace string, args []string) (string, error) {
 	// Add the pipeIn to the args if there are no args
 	if len(args) == 0 {
 		args = append(args, strings.Split(pipeIn, " ")...)
-	} else if stdinReplace == "" && hasPipe {
+	} else if stdinReplace == "" && hasStdin {
 		stdinReplace = "{}"
 		args = append(args, "{}")
 	}

--- a/internal/utils/prompt_test.go
+++ b/internal/utils/prompt_test.go
@@ -99,3 +99,35 @@ func TestPrompt(t *testing.T) {
 		})
 	}
 }
+
+func TestPrompt_FileRedirect(t *testing.T) {
+	// Simulate "clai q Here is file: < file" — stdin is a regular file, not a pipe.
+	// This is the case ModeNamedPipe misses but ModeCharDevice==0 catches.
+	oldStdin := os.Stdin
+	t.Cleanup(func() { os.Stdin = oldStdin })
+
+	tmp, err := os.CreateTemp("", "clai-prompt-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+
+	content := "file content here"
+	if _, err := tmp.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tmp.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	os.Stdin = tmp
+
+	prompt, err := Prompt("", []string{"cmd", "prefix"})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	// With no stdinReplace token, stdin is appended after args.
+	if prompt != "prefix file content here" {
+		t.Errorf("Expected 'prefix file content here', got: %q", prompt)
+	}
+}


### PR DESCRIPTION
`Prompt()` detected stdin data by checking `os.ModeNamedPipe`, which only matches pipes (`|`). Shell file
redirection (`< file`) presents stdin as a regular file — `ModeNamedPipe` is unset, so stdin was silently ignored.

Changed detection to `os.ModeCharDevice == 0`, which catches any non-terminal stdin: pipes, file redirects,
 and heredocs. Renamed `hasPipe` → `hasStdin` to reflect the broader semantics.

Added `TestPrompt_FileRedirect` using a temp file to reproduce the exact `Mode` conditions of `<` redirection.