### PR TITLE
fix: Properly set `pkg/agent` output

### DIFF
--- a/internal/vendors/openrouter/catalog_fetcher.go
+++ b/internal/vendors/openrouter/catalog_fetcher.go
@@ -18,7 +18,8 @@ import (
 const modelsEndpoint = "https://openrouter.ai/api/v1/models"
 
 type OpenRouterModelCatalog struct {
-	debug bool
+	debug       bool
+	fetchModels func(context.Context) ([]Model, error)
 }
 
 func NewModelCatalog(apiKey string) (OpenRouterModelCatalog, error) {
@@ -26,12 +27,14 @@ func NewModelCatalog(apiKey string) (OpenRouterModelCatalog, error) {
 	if debug {
 		ancli.Noticef("setting up openrouter model catalog with api key: %v...(redacted)\n", apiKey[:5])
 	}
-	return OpenRouterModelCatalog{
+	cat := OpenRouterModelCatalog{
 		debug: debug,
-	}, nil
+	}
+	cat.fetchModels = cat.liveFetchModels
+	return cat, nil
 }
 
-func (c OpenRouterModelCatalog) fetchModels(
+func (c OpenRouterModelCatalog) liveFetchModels(
 	ctx context.Context,
 ) ([]Model, error) {
 	resp, err := http.Get(modelsEndpoint)
@@ -68,7 +71,7 @@ func (c OpenRouterModelCatalog) FetchModel(ctx context.Context, model string) (c
 	}
 	for _, entry := range d {
 		// This is turbo inefficient, but good enough for now. Ideally we store price snapshot for all models here
-		if strings.Contains(entry.Name, model) {
+		if !strings.Contains(entry.ID, model) {
 			continue
 		}
 		prompt, err := parseOpenRouterPrice(entry.Pricing.Prompt)

--- a/internal/vendors/openrouter/catalog_fetcher_test.go
+++ b/internal/vendors/openrouter/catalog_fetcher_test.go
@@ -1,6 +1,7 @@
 package openrouter
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -22,5 +23,58 @@ func TestParseOpenRouterPriceMalformed(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "parse price") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFetchModelReturnsCorrectPricing(t *testing.T) {
+	// Verify FetchModel matches against entry.ID (not entry.Name) and
+	// returns pricing for the matching model, not the first in the list.
+	//
+	// The catalog is ordered so that a model whose pricing differs from
+	// the target appears first.  If the matcher picks the wrong entry
+	// (e.g. because of the inverted-condition bug or because it matches
+	// on Name instead of ID), this test will catch it.
+	cat := OpenRouterModelCatalog{}
+
+	// catalogsFromJSON simulates what fetchModels returns: a slice of
+	// Model entries with an Inkling-like model first (pricing ~$1/$4/$0.17
+	// per MTok) and the target Kimi K3 second (pricing ~$3/$15/$0.3 per
+	// MTok).  The function under test must return the Kimi pricing.
+	cat.fetchModels = func(ctx context.Context) ([]Model, error) {
+		return []Model{
+			{
+				ID:   "thinkingmachines/inkling",
+				Name: "Thinking Machines: Inkling",
+				Pricing: ModelPricing{
+					Prompt:         "0.000001",
+					Completion:     "0.00000405",
+					InputCacheRead: "0.00000017",
+				},
+			},
+			{
+				ID:   "moonshotai/kimi-k3",
+				Name: "MoonshotAI: Kimi K3",
+				Pricing: ModelPricing{
+					Prompt:         "0.000003",
+					Completion:     "0.000015",
+					InputCacheRead: "0.0000003",
+				},
+			},
+		}, nil
+	}
+
+	got, err := cat.FetchModel(context.Background(), "moonshotai/kimi-k3")
+	if err != nil {
+		t.Fatalf("FetchModel: %v", err)
+	}
+
+	if got.InputUSDPerToken != 0.000003 {
+		t.Fatalf("InputUSDPerToken: got %v, want 0.000003", got.InputUSDPerToken)
+	}
+	if got.OutputUSDPerToken != 0.000015 {
+		t.Fatalf("OutputUSDPerToken: got %v, want 0.000015", got.OutputUSDPerToken)
+	}
+	if got.InputCachedUSDPerToken != 0.0000003 {
+		t.Fatalf("InputCachedUSDPerToken: got %v, want 0.0000003", got.InputCachedUSDPerToken)
 	}
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -130,6 +130,7 @@ func (a *Agent) asInternalConfig() text.Configurations {
 		MaxToolCalls:       a.maxToolCalls,
 		RequestedToolGlobs: a.toolGlobs,
 		ResponseFormat:     a.responseFormat,
+		Out:                a.out,
 	}
 }
 

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -3,9 +3,11 @@ package agent
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -155,6 +157,52 @@ func TestAgent_Setup(t *testing.T) {
 	})
 }
 
+func TestAgent_Setup_receives_Out_in_config(t *testing.T) {
+	// When WithOutputTo is used, the custom writer must reach
+	// the querierCreator via Configurations.Out.
+	custom := new(stringsBuilderWriter)
+	var capturedOut io.Writer
+
+	a := New(WithOutputTo(custom))
+	a.cfgDir = t.TempDir()
+	a.querierCreator = func(ctx context.Context, conf text.Configurations) (priv_models.Querier, error) {
+		capturedOut = conf.Out
+		return &mockChatQuerier{}, nil
+	}
+
+	err := a.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("Setup failed: %v", err)
+	}
+
+	if capturedOut != custom {
+		t.Errorf("expected Configurations.Out to be the custom writer, got %v", capturedOut)
+	}
+}
+
+func TestAgent_Setup_receives_stdout_when_no_WithOutputTo(t *testing.T) {
+	// The defaultConf sets out: os.Stdout. Verify that when no
+	// WithOutputTo is passed, the querierCreator receives os.Stdout
+	// (not nil), preserving backward compatibility.
+	var capturedOut io.Writer
+
+	a := New()
+	a.cfgDir = t.TempDir()
+	a.querierCreator = func(ctx context.Context, conf text.Configurations) (priv_models.Querier, error) {
+		capturedOut = conf.Out
+		return &mockChatQuerier{}, nil
+	}
+
+	err := a.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("Setup failed: %v", err)
+	}
+
+	if capturedOut != os.Stdout {
+		t.Errorf("expected Configurations.Out to be os.Stdout by default, got %v", capturedOut)
+	}
+}
+
 func TestAgent_asInternalConfig(t *testing.T) {
 	tools := []models.LLMTool{&mockTool{}}
 	mcpServers := []models.McpServer{{Name: "test-mcp"}}
@@ -193,6 +241,45 @@ func TestAgent_asInternalConfig(t *testing.T) {
 	}
 	if !conf.SaveReplyAsConv {
 		t.Error("expected SaveReplyAsConv to be true")
+	}
+	// Verify Out is os.Stdout by default (the Agent's defaultConf sets out: os.Stdout).
+	// This preserves backward-compatible behavior: with no WithOutputTo,
+	// output goes to stdout.
+	if conf.Out != os.Stdout {
+		t.Errorf("expected Out to be os.Stdout by default, got %v", conf.Out)
+	}
+}
+
+func TestAgent_WithOutputTo_propagates(t *testing.T) {
+	// Verify that WithOutputTo propagates the custom writer to
+	// the internal Configurations so the querier can use it.
+	custom := new(stringsBuilderWriter)
+	a := New(WithOutputTo(custom))
+	conf := a.asInternalConfig()
+	if conf.Out != custom {
+		t.Errorf("expected Out to be the custom writer, got %v", conf.Out)
+	}
+}
+
+// stringsBuilderWriter is a minimal io.Writer backed by a strings.Builder for tests.
+type stringsBuilderWriter struct{ strings.Builder }
+
+func (w *stringsBuilderWriter) Write(p []byte) (int, error) {
+	return w.Builder.Write(p)
+}
+
+func (w *stringsBuilderWriter) String() string { return w.Builder.String() }
+
+func TestTypedQuerier_WithOutputTo_suppresses_stdout(t *testing.T) {
+	// A TypedQuerier with WithOutputTo(customWriter) must route its
+	// agent's output to that writer, never to os.Stdout.
+	custom := new(stringsBuilderWriter)
+	tq := NewTyped[struct{}](
+		WithOutputTo(custom),
+	).agent
+	conf := tq.asInternalConfig()
+	if conf.Out != custom {
+		t.Errorf("TypedQuerier did not propagate Out to internal config: got %v", conf.Out)
 	}
 }
 


### PR DESCRIPTION
In [sakfråga](https://codeberg.org/baalimago/sakfraga) I run 50 concurrent LLMs, which produce
_alot_ of output. Best to have these muted, post debugging phase.