### PR TITLE
feat: `pkg/agent` upgrades

### DIFF
--- a/internal/chat/index.go
+++ b/internal/chat/index.go
@@ -14,6 +14,12 @@ import (
 
 const chatIndexFileName = "chat_index.cache"
 
+// SkipIndex disables all chat index I/O when true. Embedded consumers (e.g.,
+// kinoview) that never use CLI list/search/dirscope features set this to
+// eliminate the memory and disk overhead of reading, rebuilding, and writing
+// the chat_index.cache on every conversation save.
+var SkipIndex bool
+
 // chatIndexVersion is bumped when the cache schema changes incompatibly.
 //
 //	2 — GroupKey field added (content-hash grouping)
@@ -108,6 +114,9 @@ func chatIndexRowFromChat(chat pub_models.Chat) chatIndexRow {
 }
 
 func readChatIndex(convDir string) ([]chatIndexRow, error) {
+	if SkipIndex {
+		return []chatIndexRow{}, nil
+	}
 	b, err := os.ReadFile(chatIndexPath(convDir))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -222,6 +231,9 @@ func rebuildChatIndex(convDir string, fromVersion int, reason string) ([]chatInd
 }
 
 func writeChatIndex(convDir string, rows []chatIndexRow) error {
+	if SkipIndex {
+		return nil
+	}
 	slices.SortFunc(rows, func(a, b chatIndexRow) int {
 		return b.Created.Compare(a.Created)
 	})
@@ -237,6 +249,9 @@ func writeChatIndex(convDir string, rows []chatIndexRow) error {
 }
 
 func upsertChatIndex(convDir string, chat pub_models.Chat) error {
+	if SkipIndex {
+		return nil
+	}
 	rows, err := readChatIndex(convDir)
 	if err != nil {
 		return fmt.Errorf("failed to read chat index for upsert: %w", err)
@@ -260,6 +275,9 @@ func upsertChatIndex(convDir string, chat pub_models.Chat) error {
 }
 
 func NewChatIndexPaginator(convDir string) (*ChatIndexPaginator, error) {
+	if SkipIndex {
+		return &ChatIndexPaginator{rows: []chatIndexRow{}}, nil
+	}
 	rows, err := readChatIndex(convDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read chat index paginator rows: %w", err)

--- a/internal/chat/index_test.go
+++ b/internal/chat/index_test.go
@@ -379,3 +379,112 @@ func TestNewChatIndexPaginator_RebuildsFromExistingChatFiles(t *testing.T) {
 		t.Fatalf("page IDs = [%s %s], want [new old]", page[0].ID, page[1].ID)
 	}
 }
+
+// SkipIndex tests — verify that all index operations become no-ops when
+// SkipIndex is true, eliminating I/O and memory overhead for embedded
+// consumers.
+
+func TestSkipIndex_ReadChatIndexReturnsEmpty(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Write a chat file and an index — readChatIndex should ignore both.
+	ch := pub_models.Chat{ID: "a", Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}
+	b, _ := json.Marshal(ch)
+	os.WriteFile(filepath.Join(tmp, "a.json"), b, 0o644)
+	writeChatIndex(tmp, []chatIndexRow{{ID: "a", FirstUserMessage: "hello"}})
+
+	SkipIndex = true
+	t.Cleanup(func() { SkipIndex = false })
+
+	rows, err := readChatIndex(tmp)
+	if err != nil {
+		t.Fatalf("readChatIndex: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("expected 0 rows, got %d", len(rows))
+	}
+}
+
+func TestSkipIndex_WriteChatIndexNoOp(t *testing.T) {
+	tmp := t.TempDir()
+
+	SkipIndex = true
+	t.Cleanup(func() { SkipIndex = false })
+
+	rows := []chatIndexRow{{ID: "a", FirstUserMessage: "hello"}}
+	if err := writeChatIndex(tmp, rows); err != nil {
+		t.Fatalf("writeChatIndex: %v", err)
+	}
+
+	// Verify no file was created.
+	if _, err := os.Stat(chatIndexPath(tmp)); !os.IsNotExist(err) {
+		t.Fatal("chat_index.cache should not exist when SkipIndex is true")
+	}
+}
+
+func TestSkipIndex_UpsertChatIndexNoOp(t *testing.T) {
+	tmp := t.TempDir()
+
+	SkipIndex = true
+	t.Cleanup(func() { SkipIndex = false })
+
+	ch := pub_models.Chat{ID: "a", Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}
+	if err := upsertChatIndex(tmp, ch); err != nil {
+		t.Fatalf("upsertChatIndex: %v", err)
+	}
+
+	// Verify no index file was created.
+	if _, err := os.Stat(chatIndexPath(tmp)); !os.IsNotExist(err) {
+		t.Fatal("chat_index.cache should not exist when SkipIndex is true")
+	}
+}
+
+func TestSkipIndex_NewChatIndexPaginatorReturnsEmpty(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Write some chat files — paginator should ignore them.
+	ch := pub_models.Chat{ID: "a", Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}
+	b, _ := json.Marshal(ch)
+	os.WriteFile(filepath.Join(tmp, "a.json"), b, 0o644)
+
+	SkipIndex = true
+	t.Cleanup(func() { SkipIndex = false })
+
+	paginator, err := NewChatIndexPaginator(tmp)
+	if err != nil {
+		t.Fatalf("NewChatIndexPaginator: %v", err)
+	}
+	if paginator.Len() != 0 {
+		t.Fatalf("expected 0 rows, got %d", paginator.Len())
+	}
+}
+
+func TestSkipIndex_SaveSkipsIndex(t *testing.T) {
+	tmp := t.TempDir()
+
+	SkipIndex = true
+	t.Cleanup(func() { SkipIndex = false })
+
+	ch := pub_models.Chat{
+		ID:      "my_chat",
+		Created: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+		Messages: []pub_models.Message{
+			{Role: "user", Content: "hello"},
+			{Role: "assistant", Content: "reply"},
+		},
+	}
+	if err := Save(tmp, ch); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Chat file must exist.
+	chatPath := filepath.Join(tmp, ch.ID+".json")
+	if _, err := os.Stat(chatPath); os.IsNotExist(err) {
+		t.Fatal("chat file should exist when SkipIndex is true")
+	}
+
+	// Index file must not exist.
+	if _, err := os.Stat(chatIndexPath(tmp)); !os.IsNotExist(err) {
+		t.Fatal("chat_index.cache should not exist when SkipIndex is true")
+	}
+}

--- a/internal/cost/manager.go
+++ b/internal/cost/manager.go
@@ -13,30 +13,6 @@ import (
 	"github.com/baalimago/go_away_boilerplate/pkg/misc"
 )
 
-func usageDelta(current pub_models.Usage, previous *pub_models.Usage) pub_models.Usage {
-	if previous == nil {
-		return current
-	}
-
-	delta := pub_models.Usage{
-		PromptTokens:     max(current.PromptTokens-previous.PromptTokens, 0),
-		CompletionTokens: max(current.CompletionTokens-previous.CompletionTokens, 0),
-		TotalTokens:      max(current.TotalTokens-previous.TotalTokens, 0),
-		PromptTokensDetails: pub_models.PromptTokensDetails{
-			CachedTokens: max(current.PromptTokensDetails.CachedTokens-previous.PromptTokensDetails.CachedTokens, 0),
-			AudioTokens:  max(current.PromptTokensDetails.AudioTokens-previous.PromptTokensDetails.AudioTokens, 0),
-		},
-		CompletionTokensDetails: pub_models.CompletionTokensDetails{
-			ReasoningTokens:          max(current.CompletionTokensDetails.ReasoningTokens-previous.CompletionTokensDetails.ReasoningTokens, 0),
-			AudioTokens:              max(current.CompletionTokensDetails.AudioTokens-previous.CompletionTokensDetails.AudioTokens, 0),
-			AcceptedPredictionTokens: max(current.CompletionTokensDetails.AcceptedPredictionTokens-previous.CompletionTokensDetails.AcceptedPredictionTokens, 0),
-			RejectedPredictionTokens: max(current.CompletionTokensDetails.RejectedPredictionTokens-previous.CompletionTokensDetails.RejectedPredictionTokens, 0),
-		},
-	}
-
-	return delta
-}
-
 type ModelCatalogFetcher interface {
 	FetchModel(ctx context.Context, model string) (ModelPriceScheme, error)
 }
@@ -217,7 +193,12 @@ func (m *Manager) Enrich(chat pub_models.Chat) (pub_models.Chat, error) {
 	if chat.TokenUsage == nil {
 		return pub_models.Chat{}, errors.New("token usage is not yet set")
 	}
-	usage := usageDelta(*chat.TokenUsage, latestRecordedUsage(chat.Queries))
+	// LLM APIs are stateless: every query re-sends and re-bills the entire
+	// conversation so far. chat.TokenUsage holds the last API call's per-call
+	// usage (input = the full transcript sent this turn, output = this reply),
+	// so each query is billed in full. Summing the per-query costs then matches
+	// what the provider bills for the whole conversation.
+	usage := *chat.TokenUsage
 	estimate, err := m.estimateUSD(&usage)
 	if err != nil {
 		return pub_models.Chat{}, fmt.Errorf("enrich chat with cost estimate: %w", err)
@@ -247,12 +228,4 @@ func (m *Manager) Enrich(chat pub_models.Chat) (pub_models.Chat, error) {
 		ancli.Noticef("chat now has: %v query entries", len(chat.Queries))
 	}
 	return chat, nil
-}
-
-func latestRecordedUsage(queries []pub_models.QueryCost) *pub_models.Usage {
-	if len(queries) == 0 {
-		return nil
-	}
-	usage := queries[len(queries)-1].Usage
-	return &usage
 }

--- a/internal/cost/manager_test.go
+++ b/internal/cost/manager_test.go
@@ -2,6 +2,7 @@ package cost
 
 import (
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -213,7 +214,13 @@ func TestManagerEnrich_AppendsConfiguredModelForNewTurn(t *testing.T) {
 	}
 }
 
-func TestManagerEnrich_AccumulatedUsageAppendsIncrementalCostOnly(t *testing.T) {
+// TestManagerEnrich_BillsFullPerCallUsage verifies that every query records the
+// full cost of its own API call. LLM APIs are stateless: each query re-sends and
+// re-bills the entire conversation so far, so chat.TokenUsage (the last call's
+// per-call usage) must be billed in full rather than diffed against the previous
+// query. Summing the per-query costs then matches what the provider dashboard
+// bills for the whole conversation.
+func TestManagerEnrich_BillsFullPerCallUsage(t *testing.T) {
 	mgr := Manager{
 		model: "model-b",
 		price: &ModelPriceScheme{
@@ -254,10 +261,18 @@ func TestManagerEnrich_AccumulatedUsageAppendsIncrementalCostOnly(t *testing.T) 
 	if len(got.Queries) != 2 {
 		t.Fatalf("queries len: got %d want %d", len(got.Queries), 2)
 	}
-	if got.Queries[1].CostUSD != 0.016 {
-		t.Fatalf("query[1] cost: got %v want %v", got.Queries[1].CostUSD, 0.016)
+	// Full per-call cost: 10*0.001 + 7*0.002 = 0.024, not the token delta.
+	wantCost := 10*0.001 + 7*0.002
+	if math.Abs(got.Queries[1].CostUSD-wantCost) > 1e-12 {
+		t.Fatalf("query[1] cost: got %v want %v", got.Queries[1].CostUSD, wantCost)
 	}
-	if got.Queries[1].Usage.PromptTokens != 4 || got.Queries[1].Usage.CompletionTokens != 6 || got.Queries[1].Usage.TotalTokens != 10 {
-		t.Fatalf("query[1] usage delta: got %+v", got.Queries[1].Usage)
+	if got.Queries[1].Usage.PromptTokens != 10 || got.Queries[1].Usage.CompletionTokens != 7 || got.Queries[1].Usage.TotalTokens != 17 {
+		t.Fatalf("query[1] usage: got %+v want full per-call usage", got.Queries[1].Usage)
+	}
+
+	// Conversation total is the sum of each query's full per-call cost.
+	wantTotal := 0.012 + wantCost
+	if math.Abs(got.TotalCostUSD()-wantTotal) > 1e-12 {
+		t.Fatalf("chat total cost: got %v want %v", got.TotalCostUSD(), wantTotal)
 	}
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/baalimago/clai/internal"
+	"github.com/baalimago/clai/internal/chat"
 	priv_models "github.com/baalimago/clai/internal/models"
 	"github.com/baalimago/clai/internal/text"
 	"github.com/baalimago/clai/pkg/text/models"
@@ -135,6 +136,11 @@ func (a *Agent) asInternalConfig() text.Configurations {
 }
 
 func (a *Agent) Setup(ctx context.Context) error {
+	// Embedded consumers (kinoview, etc.) never use CLI list/search/dirscope
+	// features; the chat index is pure overhead that causes OOM on 32-bit ARM
+	// when the conversation directory is large.
+	chat.SkipIndex = true
+
 	if _, err := os.Stat(a.cfgDir); os.IsNotExist(err) {
 		os.Mkdir(a.cfgDir, 0o755)
 	}

--- a/pkg/agent/typed.go
+++ b/pkg/agent/typed.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"sort"
 
 	"github.com/baalimago/clai/pkg/text/models"
@@ -14,6 +15,60 @@ import (
 type TypedResponse[T any] interface {
 	Setup(context.Context) error
 	Query(context.Context, models.Chat) (T, error)
+}
+
+type Metadata struct {
+	TokenUsage       *models.Usage
+	ChatID           string
+	ConversationPath string
+}
+
+// TypedMetadataResponse is the interface for LLM queries that return a typed result
+// parsed from the assistant message JSON.
+type TypedMetadataResponse[T any] interface {
+	Setup(context.Context) error
+	Query(context.Context, models.Chat) (T, Metadata, error)
+}
+
+// TypedMetadataQuerier wraps an Agent and adds typed JSON parsing on top of Query,
+// returning parsed results plus metadata (token usage, chat ID, conversation path).
+type TypedMetadataQuerier[T any] struct {
+	agent *Agent
+}
+
+// NewTypedMetadata creates a TypedMetadataQuerier that wraps an agent configured
+// with the given options. The agent's response format defaults to json_object;
+// callers may override it via WithResponseFormat.
+func NewTypedMetadata[T any](options ...Option) *TypedMetadataQuerier[T] {
+	opts := append([]Option{WithResponseFormat(models.ResponseFormat{Type: "json_object"})}, options...)
+	a := New(opts...)
+	return &TypedMetadataQuerier[T]{agent: &a}
+}
+
+func (tmq *TypedMetadataQuerier[T]) Setup(ctx context.Context) error {
+	return tmq.agent.Setup(ctx)
+}
+
+func (tmq *TypedMetadataQuerier[T]) Query(ctx context.Context, chat models.Chat) (T, Metadata, error) {
+	var zero T
+	resp, err := tmq.agent.Query(ctx, chat)
+	if err != nil {
+		return zero, Metadata{}, fmt.Errorf("typed metadata query: %w", err)
+	}
+	msg, _, err := resp.LastOfRole("assistant")
+	if err != nil {
+		return zero, Metadata{}, fmt.Errorf("typed metadata query: %w", err)
+	}
+	result, err := parseTyped[T](msg.Content)
+	if err != nil {
+		return zero, Metadata{}, err
+	}
+	meta := Metadata{
+		TokenUsage:       resp.TokenUsage,
+		ChatID:           resp.ID,
+		ConversationPath: filepath.Join(tmq.agent.cfgDir, "conversations", resp.ID+".json"),
+	}
+	return result, meta, nil
 }
 
 // TypedQuerier wraps an Agent and adds typed JSON parsing on top of Query.

--- a/pkg/agent/typed.go
+++ b/pkg/agent/typed.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"github.com/baalimago/clai/pkg/text/models"
 )
@@ -21,6 +22,10 @@ type Metadata struct {
 	TokenUsage       *models.Usage
 	ChatID           string
 	ConversationPath string
+	Model            string             // configured model of the run — survives price-fetch timeout
+	CostUSD          float64            // sum of per-query costs (resp.TotalCostUSD)
+	CalledAt         time.Time          // when the query completed
+	Queries          []models.QueryCost // per-API-call token + cost + model breakdown
 }
 
 // TypedMetadataResponse is the interface for LLM queries that return a typed result
@@ -51,22 +56,32 @@ func (tmq *TypedMetadataQuerier[T]) Setup(ctx context.Context) error {
 
 func (tmq *TypedMetadataQuerier[T]) Query(ctx context.Context, chat models.Chat) (T, Metadata, error) {
 	var zero T
+	callTime := time.Now().UTC()
 	resp, err := tmq.agent.Query(ctx, chat)
 	if err != nil {
 		return zero, Metadata{}, fmt.Errorf("typed metadata query: %w", err)
 	}
-	msg, _, err := resp.LastOfRole("assistant")
-	if err != nil {
-		return zero, Metadata{}, fmt.Errorf("typed metadata query: %w", err)
-	}
-	result, err := parseTyped[T](msg.Content)
-	if err != nil {
-		return zero, Metadata{}, err
-	}
+	// Build meta immediately after a successful (billed) Query so that
+	// usage rides every subsequent branch — even when LastOfRole or
+	// parseTyped fail. Malformed-JSON responses still burn tokens and
+	// must be accounted for; dropping usage here produces the illusion
+	// of zero-cost failures (R1-06).
 	meta := Metadata{
 		TokenUsage:       resp.TokenUsage,
 		ChatID:           resp.ID,
 		ConversationPath: filepath.Join(tmq.agent.cfgDir, "conversations", resp.ID+".json"),
+		Model:            tmq.agent.model,
+		CostUSD:          resp.TotalCostUSD(),
+		CalledAt:         callTime,
+		Queries:          resp.Queries,
+	}
+	msg, _, err := resp.LastOfRole("assistant")
+	if err != nil {
+		return zero, meta, fmt.Errorf("typed metadata query: %w", err)
+	}
+	result, err := parseTyped[T](msg.Content)
+	if err != nil {
+		return zero, meta, err
 	}
 	return result, meta, nil
 }

--- a/pkg/agent/typed_test.go
+++ b/pkg/agent/typed_test.go
@@ -173,6 +173,26 @@ func TestTypedMetadataQuerier_Query(t *testing.T) {
 				CompletionTokens: 50,
 				TotalTokens:      150,
 			},
+			Queries: []models.QueryCost{
+				{
+					Model:   "gpt-5.2",
+					CostUSD: 0.001,
+					Usage: models.Usage{
+						PromptTokens:     60,
+						CompletionTokens: 30,
+						TotalTokens:      90,
+					},
+				},
+				{
+					Model:   "gpt-5.2",
+					CostUSD: 0.002,
+					Usage: models.Usage{
+						PromptTokens:     40,
+						CompletionTokens: 20,
+						TotalTokens:      60,
+					},
+				},
+			},
 			Messages: []models.Message{
 				{
 					Role:    "assistant",
@@ -181,7 +201,7 @@ func TestTypedMetadataQuerier_Query(t *testing.T) {
 			},
 		}
 
-		a := New(WithConfigDir("/tmp/clai"))
+		a := New(WithConfigDir("/tmp/clai"), WithModel("gpt-5-mini"))
 		a.querier = &stubChatQuerier{chat: chat}
 		tmq := NewTypedMetadata[simple]()
 		tmq.agent = &a
@@ -205,6 +225,18 @@ func TestTypedMetadataQuerier_Query(t *testing.T) {
 		expectedPath := "/tmp/clai/conversations/chat-abc123.json"
 		if meta.ConversationPath != expectedPath {
 			t.Fatalf("expected ConversationPath='%s', got '%s'", expectedPath, meta.ConversationPath)
+		}
+		if meta.Model != "gpt-5-mini" {
+			t.Fatalf("expected Model='gpt-5-mini' (configured model), got '%s'", meta.Model)
+		}
+		if meta.CostUSD != 0.003 {
+			t.Fatalf("expected CostUSD=0.003 (sum of queries), got %f", meta.CostUSD)
+		}
+		if meta.CalledAt.IsZero() {
+			t.Fatal("expected CalledAt to be non-zero")
+		}
+		if len(meta.Queries) != 2 {
+			t.Fatalf("expected 2 Queries, got %d", len(meta.Queries))
 		}
 	})
 
@@ -268,6 +300,35 @@ func TestTypedMetadataQuerier_Query(t *testing.T) {
 		}
 	})
 
+	t.Run("model from configured agent when queries empty", func(t *testing.T) {
+		chat := models.Chat{
+			ID:         "chat-no-queries",
+			TokenUsage: &models.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+			Messages: []models.Message{
+				{Role: "assistant", Content: `{"name":"no-queries"}`},
+			},
+		}
+
+		a := New(WithModel("gpt-5-mini"))
+		a.querier = &stubChatQuerier{chat: chat}
+		tmq := NewTypedMetadata[simple]()
+		tmq.agent = &a
+
+		_, meta, err := tmq.Query(context.Background(), models.Chat{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if meta.Model != "gpt-5-mini" {
+			t.Fatalf("expected Model='gpt-5-mini' (configured model), got '%s'", meta.Model)
+		}
+		if meta.CostUSD != 0.0 {
+			t.Fatalf("expected CostUSD=0 when no queries, got %f", meta.CostUSD)
+		}
+		if len(meta.Queries) != 0 {
+			t.Fatalf("expected 0 Queries, got %d", len(meta.Queries))
+		}
+	})
+
 	t.Run("no valid json in assistant message", func(t *testing.T) {
 		chat := models.Chat{
 			ID: "chat-bad-json",
@@ -287,6 +348,108 @@ func TestTypedMetadataQuerier_Query(t *testing.T) {
 		_, _, err := tmq.Query(context.Background(), models.Chat{})
 		if err == nil {
 			t.Fatal("expected error when assistant message has no valid JSON")
+		}
+	})
+
+	t.Run("usage recorded on parse failure", func(t *testing.T) {
+		// R1-06: when parseTyped fails after a successful (billed) Query,
+		// Metadata must still carry the billed usage — malformed-JSON
+		// responses burn tokens that must be accounted for.
+		chat := models.Chat{
+			ID: "chat-parse-fail",
+			TokenUsage: &models.Usage{
+				PromptTokens:     200,
+				CompletionTokens: 100,
+				TotalTokens:      300,
+			},
+			Queries: []models.QueryCost{
+				{
+					Model:   "gpt-5.2",
+					CostUSD: 0.005,
+					Usage: models.Usage{
+						PromptTokens:     200,
+						CompletionTokens: 100,
+						TotalTokens:      300,
+					},
+				},
+			},
+			Messages: []models.Message{
+				{
+					Role:    "assistant",
+					Content: "{invalid json",
+				},
+			},
+		}
+
+		a := New(WithModel("gpt-5-mini"))
+		a.querier = &stubChatQuerier{chat: chat}
+		tmq := NewTypedMetadata[simple]()
+		tmq.agent = &a
+
+		_, meta, err := tmq.Query(context.Background(), models.Chat{})
+		if err == nil {
+			t.Fatal("expected error when parse fails")
+		}
+		if meta.TokenUsage == nil {
+			t.Fatal("expected non-nil TokenUsage on parse failure — billed tokens must be recorded")
+		}
+		if meta.TokenUsage.TotalTokens != 300 {
+			t.Errorf("expected TotalTokens=300, got %d", meta.TokenUsage.TotalTokens)
+		}
+		if meta.CostUSD != 0.005 {
+			t.Errorf("expected CostUSD=0.005, got %f", meta.CostUSD)
+		}
+		if meta.CalledAt.IsZero() {
+			t.Fatal("expected CalledAt to be non-zero on parse failure")
+		}
+		if meta.Model != "gpt-5-mini" {
+			t.Errorf("expected Model='gpt-5-mini', got '%s'", meta.Model)
+		}
+	})
+
+	t.Run("usage recorded on missing assistant", func(t *testing.T) {
+		// R1-06: when LastOfRole("assistant") fails after a successful
+		// (billed) Query, Metadata must still carry the billed usage.
+		chat := models.Chat{
+			ID: "chat-no-assist",
+			TokenUsage: &models.Usage{
+				PromptTokens:     50,
+				CompletionTokens: 25,
+				TotalTokens:      75,
+			},
+			Queries: []models.QueryCost{
+				{
+					Model:   "gpt-5.2",
+					CostUSD: 0.002,
+					Usage: models.Usage{
+						PromptTokens:     50,
+						CompletionTokens: 25,
+						TotalTokens:      75,
+					},
+				},
+			},
+			Messages: []models.Message{
+				{Role: "user", Content: "hello"},
+			},
+		}
+
+		a := New(WithModel("gpt-5-mini"))
+		a.querier = &stubChatQuerier{chat: chat}
+		tmq := NewTypedMetadata[simple]()
+		tmq.agent = &a
+
+		_, meta, err := tmq.Query(context.Background(), models.Chat{})
+		if err == nil {
+			t.Fatal("expected error when no assistant message")
+		}
+		if meta.TokenUsage == nil {
+			t.Fatal("expected non-nil TokenUsage on LastOfRole failure — billed tokens must be recorded")
+		}
+		if meta.TokenUsage.TotalTokens != 75 {
+			t.Errorf("expected TotalTokens=75, got %d", meta.TokenUsage.TotalTokens)
+		}
+		if meta.CostUSD != 0.002 {
+			t.Errorf("expected CostUSD=0.002, got %f", meta.CostUSD)
 		}
 	})
 }

--- a/pkg/agent/typed_test.go
+++ b/pkg/agent/typed_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/baalimago/clai/pkg/text/models"
@@ -159,12 +160,147 @@ func TestTypedQuerier_Query_ReadsFromAssistantRole(t *testing.T) {
 	}
 }
 
-// stubChatQuerier returns a predefined chat.
+func TestTypedMetadataQuerier_Query(t *testing.T) {
+	type simple struct {
+		Name string `json:"name"`
+	}
+
+	t.Run("returns typed result with metadata", func(t *testing.T) {
+		chat := models.Chat{
+			ID: "chat-abc123",
+			TokenUsage: &models.Usage{
+				PromptTokens:     100,
+				CompletionTokens: 50,
+				TotalTokens:      150,
+			},
+			Messages: []models.Message{
+				{
+					Role:    "assistant",
+					Content: `{"name":"meta-test"}`,
+				},
+			},
+		}
+
+		a := New(WithConfigDir("/tmp/clai"))
+		a.querier = &stubChatQuerier{chat: chat}
+		tmq := NewTypedMetadata[simple]()
+		tmq.agent = &a
+
+		result, meta, err := tmq.Query(context.Background(), models.Chat{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Name != "meta-test" {
+			t.Fatalf("expected Name='meta-test', got '%s'", result.Name)
+		}
+		if meta.ChatID != "chat-abc123" {
+			t.Fatalf("expected ChatID='chat-abc123', got '%s'", meta.ChatID)
+		}
+		if meta.TokenUsage == nil {
+			t.Fatal("expected non-nil TokenUsage")
+		}
+		if meta.TokenUsage.TotalTokens != 150 {
+			t.Fatalf("expected TotalTokens=150, got %d", meta.TokenUsage.TotalTokens)
+		}
+		expectedPath := "/tmp/clai/conversations/chat-abc123.json"
+		if meta.ConversationPath != expectedPath {
+			t.Fatalf("expected ConversationPath='%s', got '%s'", expectedPath, meta.ConversationPath)
+		}
+	})
+
+	t.Run("nil token usage", func(t *testing.T) {
+		chat := models.Chat{
+			ID:         "chat-no-usage",
+			TokenUsage: nil,
+			Messages: []models.Message{
+				{
+					Role:    "assistant",
+					Content: `{"name":"no-usage"}`,
+				},
+			},
+		}
+
+		a := New()
+		a.querier = &stubChatQuerier{chat: chat}
+		tmq := NewTypedMetadata[simple]()
+		tmq.agent = &a
+
+		_, meta, err := tmq.Query(context.Background(), models.Chat{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if meta.TokenUsage != nil {
+			t.Fatalf("expected nil TokenUsage, got %+v", meta.TokenUsage)
+		}
+	})
+
+	t.Run("agent query error", func(t *testing.T) {
+		a := New()
+		a.querier = &stubChatQuerier{err: fmt.Errorf("boom")}
+		tmq := NewTypedMetadata[simple]()
+		tmq.agent = &a
+
+		_, _, err := tmq.Query(context.Background(), models.Chat{})
+		if err == nil {
+			t.Fatal("expected error when agent.Query fails")
+		}
+	})
+
+	t.Run("no assistant message", func(t *testing.T) {
+		chat := models.Chat{
+			ID: "chat-no-assist",
+			Messages: []models.Message{
+				{
+					Role:    "user",
+					Content: "hello",
+				},
+			},
+		}
+
+		a := New()
+		a.querier = &stubChatQuerier{chat: chat}
+		tmq := NewTypedMetadata[simple]()
+		tmq.agent = &a
+
+		_, _, err := tmq.Query(context.Background(), models.Chat{})
+		if err == nil {
+			t.Fatal("expected error when no assistant message exists")
+		}
+	})
+
+	t.Run("no valid json in assistant message", func(t *testing.T) {
+		chat := models.Chat{
+			ID: "chat-bad-json",
+			Messages: []models.Message{
+				{
+					Role:    "assistant",
+					Content: "sorry, no json here",
+				},
+			},
+		}
+
+		a := New()
+		a.querier = &stubChatQuerier{chat: chat}
+		tmq := NewTypedMetadata[simple]()
+		tmq.agent = &a
+
+		_, _, err := tmq.Query(context.Background(), models.Chat{})
+		if err == nil {
+			t.Fatal("expected error when assistant message has no valid JSON")
+		}
+	})
+}
+
+// stubChatQuerier returns a predefined chat, or an error if err is set.
 type stubChatQuerier struct {
 	chat models.Chat
+	err  error
 }
 
 func (s *stubChatQuerier) Query(ctx context.Context) error { return nil }
 func (s *stubChatQuerier) TextQuery(ctx context.Context, chat models.Chat) (models.Chat, error) {
+	if s.err != nil {
+		return models.Chat{}, s.err
+	}
 	return s.chat, nil
 }


### PR DESCRIPTION
For [sakfråga](https://codeberg.org/baalimago/sakfraga) I will be burning _alot_ of tokens. So token efficiency is of utmost
value, and token/intelligence maxing. So with this I should be able to calibrate correctly.

Changes:
  * New interface `pkg/agent.TypedMetadataResponse` + agent `pkg/agent.TypedMedatadataQuerier`
  * Fixed billing issue where we would undercount costs by only showing delta, as opposed to full price
  * Disable index while clai is in agent mode, causes OOM and provides no value