### PR TITLE
feat: Changes to better align with the skills community

### DIFF
--- a/architecture/skills.md
+++ b/architecture/skills.md
@@ -185,6 +185,8 @@ Initial shape:
 
 `globalSkillDirs` is a list of absolute or user-home-relative directories. Each listed directory is scanned as a root containing `<skill-name>/SKILL.md` children.
 
+By default, `globalSkillDirs` contains `~/.agents/skills`, which resolves to `/home/<user>/.agents/skills` for the active user.
+
 `projectSkillDirs` is a list of relative directory patterns, evaluated from the current working directory upward toward the filesystem root. For each ancestor directory, clai checks each configured relative path and scans any existing match as a project skill root.
 
 `trust_all_skills` disables interactive trust prompting and automatically trusts every discovered skill for activation eligibility. Even when this flag is enabled, clai still records the trusted path+hash entries so the trust cache remains warm if the flag is later disabled.
@@ -238,7 +240,7 @@ A skill is **valid** when:
 - `SKILL.md` exists
 - frontmatter, if present, parses successfully according to the MVP constrained format
 - the directory name is non-empty
-- the body is non-empty after normalization
+- the required `description` metadata is non-empty after normalization
 
 A skill is **invalid** when parsing fails or required structural conditions are not met. Invalid skills are skipped and reported in the discovery logs.
 
@@ -538,7 +540,7 @@ Initial contents:
 ```json
 {
   "enabled": false,
-  "globalSkillDirs": [],
+  "globalSkillDirs": ["~/.agents/skills"],
   "projectSkillDirs": ["./agents/skills", ".claude/skills"],
   "trust_all_skills": false,
   "maxActivatedSkills": 10

--- a/architecture/skills.md
+++ b/architecture/skills.md
@@ -49,7 +49,7 @@ Examples:
 Each `SKILL.md` file contains:
 
 1. optional frontmatter delimited by `---`
-2. markdown instruction body
+2. an optional markdown instruction body
 
 Example:
 
@@ -90,7 +90,7 @@ The parser records the following frontmatter fields from a constrained line-orie
 
 Unknown fields are preserved in parsed metadata for inspection/debugging but have no runtime effect.
 
-The frontmatter contract for MVP is intentionally limited and does not require full YAML compliance. It supports the metadata surface listed below using simple `key: value` lines plus compact list forms already exercised by clai. Shell-style preprocessing and richer YAML constructs such as nested objects, anchors, multiline scalars, or arbitrary type inference are out of scope.
+The frontmatter contract for MVP is intentionally limited and does not require full YAML compliance. It supports the metadata surface listed below using simple `key: value` lines, compact list forms, and literal (`|`) or folded (`>`) multiline scalar values. Shell-style preprocessing and richer YAML constructs such as nested objects, anchors, and arbitrary type inference are out of scope.
 
 ## Discovery roots
 

--- a/internal/skills/config_test.go
+++ b/internal/skills/config_test.go
@@ -15,6 +15,9 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if len(cfg.ProjectSkillDirs) != 2 || cfg.ProjectSkillDirs[0] != "./agents/skills" || cfg.ProjectSkillDirs[1] != ".claude/skills" {
 		t.Fatalf("unexpected project dirs: %#v", cfg.ProjectSkillDirs)
 	}
+	if len(cfg.GlobalSkillDirs) != 1 || cfg.GlobalSkillDirs[0] != "~/.agents/skills" {
+		t.Fatalf("unexpected global dirs: %#v", cfg.GlobalSkillDirs)
+	}
 	if cfg.MaxActivatedSkills != 10 {
 		t.Fatalf("unexpected max activated skills: %d", cfg.MaxActivatedSkills)
 	}

--- a/internal/skills/parse.go
+++ b/internal/skills/parse.go
@@ -20,9 +20,6 @@ func parseSkill(class, root, dir string) (Skill, *InvalidSkill) {
 	if err != nil {
 		return Skill{}, &InvalidSkill{Class: class, Root: root, Dir: dir, Path: path, Err: err, Diagnostics: parsed.Diagnostics}
 	}
-	if strings.TrimSpace(parsed.NormalizedBody) == "" {
-		return Skill{}, &InvalidSkill{Class: class, Root: root, Dir: dir, Path: path, Err: fmt.Errorf("empty skill body"), Diagnostics: parsed.Diagnostics}
-	}
 	if strings.TrimSpace(parsed.Metadata.Description) == "" {
 		return Skill{}, &InvalidSkill{Class: class, Root: root, Dir: dir, Path: path, Err: fmt.Errorf("missing required description"), Diagnostics: parsed.Diagnostics}
 	}
@@ -69,6 +66,12 @@ func parseMarkdownWithFrontmatter(content string) (ParsedSkill, error) {
 		}
 		key = strings.TrimSpace(key)
 		val = strings.TrimSpace(val)
+		if val == "|" || val == ">" {
+			value, next := parseBlockScalar(lines, idx+1, val)
+			assignMetadata(&parsed, key, value, idx+1)
+			idx = next
+			continue
+		}
 		if val == "" {
 			items, next := parseIndentedList(lines, idx+1)
 			if len(items) > 0 {
@@ -87,6 +90,30 @@ func parseMarkdownWithFrontmatter(content string) (ParsedSkill, error) {
 	parsed.RawBody = body
 	parsed.NormalizedBody = strings.TrimSpace(body)
 	return parsed, nil
+}
+
+func parseBlockScalar(lines []string, start int, style string) (string, int) {
+	items := make([]string, 0)
+	i := start
+	for i < len(lines) {
+		line := lines[i]
+		if strings.TrimSpace(line) == "---" && !hasIndent(line) {
+			break
+		}
+		if strings.TrimSpace(line) != "" && !hasIndent(line) {
+			break
+		}
+		items = append(items, strings.TrimLeft(line, " \t"))
+		i++
+	}
+	if style == ">" {
+		return strings.Join(items, " "), i
+	}
+	return strings.Join(items, "\n"), i
+}
+
+func hasIndent(line string) bool {
+	return strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t")
 }
 
 func parseIndentedList(lines []string, start int) ([]string, int) {

--- a/internal/skills/parse_test.go
+++ b/internal/skills/parse_test.go
@@ -22,6 +22,30 @@ func TestParseMarkdownWithFrontmatterSupportsIndentedLists(t *testing.T) {
 	}
 }
 
+func TestParseMarkdownWithFrontmatterSupportsLiteralBlockScalar(t *testing.T) {
+	parsed, err := parseMarkdownWithFrontmatter("---\ndescription: |\n  First line.\n  Second line.\n---\nBody")
+	if err != nil {
+		t.Fatalf("parseMarkdownWithFrontmatter() error = %v", err)
+	}
+	if got, want := parsed.Metadata.Description, "First line.\nSecond line."; got != want {
+		t.Fatalf("description = %q, want %q", got, want)
+	}
+}
+
+func TestParseSkillAcceptsFrontmatterOnlySkill(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "frontmatter-only")
+	writeSkill(t, filepath.Join(dir, "SKILL.md"), "---\ndescription: A descriptor-only skill.\n---\n")
+
+	skill, invalid := parseSkill("default", root, dir)
+	if invalid != nil {
+		t.Fatalf("parseSkill() invalid = %#v", invalid)
+	}
+	if skill.Parsed.NormalizedBody != "" {
+		t.Fatalf("NormalizedBody = %q, want empty", skill.Parsed.NormalizedBody)
+	}
+}
+
 func TestParseSkillPreservesInvalidReason(t *testing.T) {
 	root := t.TempDir()
 	dir := filepath.Join(root, "broken")

--- a/internal/skills/types.go
+++ b/internal/skills/types.go
@@ -22,7 +22,7 @@ type Config struct {
 
 var defaultConfig = Config{
 	Enabled:            false,
-	GlobalSkillDirs:    []string{},
+	GlobalSkillDirs:    []string{"~/.agents/skills"},
 	ProjectSkillDirs:   []string{"./agents/skills", ".claude/skills"},
 	TrustAllSkills:     false,
 	MaxActivatedSkills: 10,


### PR DESCRIPTION
I added some skills with `npx skills ...` which didn't parse correctly due to the limited yaml parsing
implementation (I don't want a yaml lib!). Fixed now.

Changes:
  * Made yaml parsing more rich to support common skills hosted by the skills community
  * Added `~/.agents/skills` as default skills directory so skills automatically are imported