### PR TITLE
feat: Add most recent token usage

### DIFF
--- a/architecture/chat.md
+++ b/architecture/chat.md
@@ -51,7 +51,10 @@ type Chat struct {
     // chats or conversations without a user message.
     GroupKey string `json:"group_key,omitempty"`
 
-    Messages []Message `json:"messages"`
+    Messages         []Message   `json:"messages"`
+    TokenUsage       *Usage      `json:"usage,omitempty"`
+    RecentTokenUsage *Usage      `json:"recent_usage,omitempty"`
+    Queries          []QueryCost `json:"queries,omitempty"`
 }
 ```
 
@@ -60,6 +63,9 @@ Notes:
 - `ID` is used as the filename.
 - `Profile` can be persisted on the chat and is used to “stick” the last-used profile when continuing/using a conversation.
 - `Messages` is an ordered transcript.
+- `TokenUsage` contains the billable usage for all model calls in the latest session.
+- `RecentTokenUsage` contains only the final model call. This value estimates the context size of the next request.
+- `Queries` contains the usage and cost for each recorded session.
 
 ### `pkg/text/models.Message`
 
@@ -147,6 +153,42 @@ Subsequent queries can be threaded using:
 
 - `-re` (reply to global previous query)
 - `-dre` (reply to directory-scoped previous query)
+
+### `chat dir` and `chat dirv2`
+
+Both commands show information for the conversation that is bound to the current directory. They use `globalScope.json` when no directory binding exists.
+
+`clai chat dir` keeps the original text and JSON formats. This format does not show `RecentTokenUsage`.
+
+`clai chat dirv2` adds total and recent usage. In raw mode (`-r`), it returns this structure:
+
+```json
+{
+  "version": 2,
+  "scope": "dir",
+  "chat_id": "example-chat-id",
+  "profile": "default",
+  "updated": "2026-08-03T12:00:00Z",
+  "conversation_created": "2026-08-03T11:00:00Z",
+  "replies_by_role": {"assistant": 2, "user": 2},
+  "token_usage": {
+    "recent": {"uncached_input": 1200, "cached_input": 8000, "output": 300, "total": 9500},
+    "total": {"uncached_input": 2400, "cached_input": 15000, "output": 600, "total": 18000}
+  },
+  "cost_usd": 0.12
+}
+```
+
+The token fields have these meanings:
+
+- `uncached_input`: input tokens that were not read from the provider cache.
+- `cached_input`: input tokens that were read from the provider cache.
+- `output`: output tokens from the model.
+- `total`: the provider-reported total token count.
+
+The `token_usage.total` object sums all recorded query usage. The `token_usage.recent` object contains the final model call.
+
+The v2 format has one numeric cost field. It does not include the duplicate v1 cost strings, price fields, or top-level token fields.
 
 ### `chat continue` (bind a chat to the current directory)
 

--- a/architecture/colours.md
+++ b/architecture/colours.md
@@ -112,6 +112,10 @@ Implementation:
 - `main.go:triggerCompletionNotification()`
 - `internal/utils.NotificationBellEnabled()`
 
+Raw `chat dir` and `chat dirv2` output does not include BEL. Model output with `-rf` or `-response-format` also excludes BEL.
+
+Structured output blocks all intermediate display output. These rules keep the JSON valid for tools such as `jq`.
+
 ## Customization
 
 To customize colours, edit:

--- a/architecture/dirscope.md
+++ b/architecture/dirscope.md
@@ -300,6 +300,14 @@ discovery). All three tools are defined as `pub_models.LLMTool`s whose `Call()` 
 dispatched internally by the tool executor (it needs the resolving config dir and the session CWD), like
 `load_skill`.
 
+## Directory chat information
+
+`clai chat dir` reads the current directory binding and prints the stable v1 format. It uses the global scope when no binding exists.
+
+`clai chat dirv2` uses the same resolution order. It adds nested `token_usage.total` and `token_usage.recent` objects.
+
+The v2 raw format removes the duplicate top-level token, cost-string, and price fields. See [chat.md](./chat.md#chat-dir-and-chat-dirv2) for the schema.
+
 ## `[d]ir` table filter
 
 `clai chat list` stays the single listing entrypoint; the directory filter is an interactive **toggle button**

--- a/architecture/dre.md
+++ b/architecture/dre.md
@@ -50,7 +50,12 @@ Once `chatID` is resolved:
 
 1. Load `<configDir>/conversations/<chatID>.json`.
 2. Select the last message in the transcript.
-3. Print via `utils.AttemptPrettyPrint(..., raw)`.
+3. If raw mode is active, remove `ReasoningContent` from the display copy.
+4. Print via `utils.AttemptPrettyPrint(..., raw)`.
+
+`clai -r dre` prints only the final message content. It does not print reasoning or the completion notification bell.
+
+Stored reasoning remains in the conversation file.
 
 ## Error handling / exit codes
 

--- a/architecture/help.md
+++ b/architecture/help.md
@@ -47,6 +47,13 @@ This is the deep-ish help for profile concepts and usage.
    - config dir + cache dir paths
 3. Prints to stdout.
 
+The general help lists both directory-information commands:
+
+- `clai chat dir` keeps the stable v1 output.
+- `clai chat dirv2` provides total and recent token usage.
+
+`clai chat help` lists the same commands and includes raw-mode examples.
+
 ## Exit behavior
 
 Returns `utils.ErrUserInitiatedExit`, so the process exits with code 0.

--- a/architecture/query.md
+++ b/architecture/query.md
@@ -133,4 +133,5 @@ This allows subsequent `-dre` queries from the same directory to continue the co
 
 - **Default (animated)**: tokens stream to stdout character-by-character, then the full message is pretty-printed (via `glow` if installed)
 - **Raw (`-r`)**: tokens stream directly, no post-processing formatting
+- **Structured (`-rf`/`-response-format`)**: blocks streaming and prints only the final structured response, followed by one newline. It suppresses reasoning, tool activity, skill-discovery logs, lookback notices, formatting, and BEL.
 - **Cmd mode (`cmd` command)**: output is treated as a shell command; user is prompted to execute it

--- a/examples.md
+++ b/examples.md
@@ -32,6 +32,21 @@ clai -dre query "Apply it to this repo"
 
 See: [`query.md`](./architecture/query.md), [`chat.md`](./architecture/chat.md), [`dre.md`](./architecture/dre.md).
 
+## Blocking structured output
+
+Use the included review schema to produce JSON that you can send directly to `jq`:
+
+```bash
+go run . -rf examples/response-format-review.json query \
+  "Review the current changes. Return a summary, a findings list, and an approval decision." | jq
+```
+
+The `-rf` flag blocks streaming output. Standard output contains only the final structured response and one trailing newline.
+
+Reasoning, tool activity, skill-discovery logs, lookback notices, formatting, and the completion notification bell do not appear in this output.
+
+Errors still go to standard error.
+
 ## Auto-append shell context
 
 ```bash

--- a/examples/response-format-review.json
+++ b/examples/response-format-review.json
@@ -1,0 +1,31 @@
+{
+  "type": "json_schema",
+  "json_schema": {
+    "name": "review_result",
+    "description": "A structured code review result.",
+    "strict": true,
+    "schema": {
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "approved": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "summary",
+        "findings",
+        "approved"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/internal/chat/handler.go
+++ b/internal/chat/handler.go
@@ -80,6 +80,10 @@ func (q *ChatHandler) Query(ctx context.Context) error {
 	return q.actOnSubCmd(ctx)
 }
 
+func (q *ChatHandler) SuppressCompletionNotification() bool {
+	return q.raw && (q.subCmd == "dir" || q.subCmd == "dirv2")
+}
+
 func (cq *ChatHandler) actOnSubCmd(ctx context.Context) error {
 	if cq.debug {
 		ancli.PrintOK(fmt.Sprintf("chat: %+v\n", cq))

--- a/internal/chat/handler.go
+++ b/internal/chat/handler.go
@@ -30,7 +30,8 @@ Commands:
   c|continue <chatID> <prompt>    Continue an existing chat with the given chat ID. Prompt is optional
   d|delete   <chatID>             Delete the chat with the given chat ID.
   l|list                          List all existing chats.
-  dir                             Show chat info for CWD (dir binding or global globalScope).
+  dir                             Show legacy chat info for CWD (stable v1 output).
+  dirv2                           Show chat info with total and recent token usage.
 
 The chatID is the 5 first words of the prompt joined by underscores. Easiest
 way to get the chatID is to list all chats with 'clai chat list'. You may also select
@@ -44,6 +45,8 @@ Examples:
   - clai chat continue my_chat_id
   - clai chat continue 3
   - clai chat delete my_chat_id
+  - clai chat dir
+  - clai -r chat dirv2
 `
 
 const (
@@ -90,8 +93,13 @@ func (cq *ChatHandler) actOnSubCmd(ctx context.Context) error {
 		return cq.deleteFromPrompt()
 	case "query", "q":
 		return errors.New("not yet implemented")
-	case "dir":
-		err := cq.dirInfo()
+	case "dir", "dirv2":
+		var err error
+		if cq.subCmd == "dirv2" {
+			err = cq.dirInfoV2()
+		} else {
+			err = cq.dirInfo()
+		}
 		if errors.Is(err, fs.ErrNotExist) {
 			return errors.New("failed to print any chat information as there was no bound chats found. This is unusual, check if replies are enabled")
 		}

--- a/internal/chat/handler_dir.go
+++ b/internal/chat/handler_dir.go
@@ -16,30 +16,47 @@ import (
 )
 
 type chatDirInfo struct {
-	Scope                string         `json:"scope"`
-	ChatID               string         `json:"chat_id"`
-	Profile              string         `json:"profile,omitempty"`
-	Updated              string         `json:"updated,omitempty"`
-	ConversationCreated  string         `json:"conversation_created,omitempty"`
-	RepliesByRole        map[string]int `json:"replies_by_role"`
-	InputTokens          int            `json:"input_tokens"`
-	NonCachedInputTokens int            `json:"non_cached_input_tokens"`
-	CachedTokens         int            `json:"cached_tokens"`
-	OutputTokens         int            `json:"output_tokens"`
-	// Lifetime totals across all recorded queries (fall back to TokenUsage).
-	TotalInputTokens  int `json:"total_input_tokens"`
-	TotalCachedTokens int `json:"total_cached_tokens"`
-	TotalOutputTokens int `json:"total_output_tokens"`
-	TotalTokens       int `json:"total_tokens"`
-	// Most recent session's usage (chat.TokenUsage).
-	RecentInputTokens  int              `json:"recent_input_tokens"`
-	RecentCachedTokens int              `json:"recent_cached_tokens"`
-	RecentOutputTokens int              `json:"recent_output_tokens"`
-	RecentTokens       int              `json:"recent_tokens"`
-	CostUSD            float64          `json:"cost_usd,omitempty"`
-	Cost               string           `json:"cost,omitempty"`
-	Price              chatDirPriceInfo `json:"price"`
-	initialMessage     string           `json:"-"`
+	Scope                string            `json:"scope"`
+	ChatID               string            `json:"chat_id"`
+	Profile              string            `json:"profile,omitempty"`
+	Updated              string            `json:"updated,omitempty"`
+	ConversationCreated  string            `json:"conversation_created,omitempty"`
+	RepliesByRole        map[string]int    `json:"replies_by_role"`
+	InputTokens          int               `json:"input_tokens"`
+	NonCachedInputTokens int               `json:"non_cached_input_tokens"`
+	CachedTokens         int               `json:"cached_tokens"`
+	OutputTokens         int               `json:"output_tokens"`
+	CostUSD              float64           `json:"cost_usd,omitempty"`
+	Cost                 string            `json:"cost,omitempty"`
+	Price                chatDirPriceInfo  `json:"price"`
+	initialMessage       string            `json:"-"`
+	recentUsage          *pub_models.Usage `json:"-"`
+	totalUsage           *pub_models.Usage `json:"-"`
+}
+
+type chatDirInfoV2 struct {
+	Version             int                 `json:"version"`
+	Scope               string              `json:"scope"`
+	ChatID              string              `json:"chat_id"`
+	Profile             string              `json:"profile,omitempty"`
+	Updated             string              `json:"updated,omitempty"`
+	ConversationCreated string              `json:"conversation_created,omitempty"`
+	RepliesByRole       map[string]int      `json:"replies_by_role"`
+	TokenUsage          chatDirTokenUsageV2 `json:"token_usage"`
+	CostUSD             float64             `json:"cost_usd"`
+	initialMessage      string              `json:"-"`
+}
+
+type chatDirTokenUsageV2 struct {
+	Recent chatDirTokenCountV2 `json:"recent"`
+	Total  chatDirTokenCountV2 `json:"total"`
+}
+
+type chatDirTokenCountV2 struct {
+	UncachedInput int `json:"uncached_input"`
+	CachedInput   int `json:"cached_input"`
+	Output        int `json:"output"`
+	Total         int `json:"total"`
 }
 
 type chatDirPriceInfo struct {
@@ -96,15 +113,28 @@ tokens used:
 	input: %v
 	cached: %v
 	output: %v
-most recent:
-	input: %v
-	cached: %v
-	output: %v
 price details:
 	input: %v
 	cached: %v
 	output: %v
 	total: %v
+`
+
+const prettyDirInfoV2Format = `scope: %v
+chat id: %v
+prompt: %v%v
+replies by role:
+%v
+total cost: %v
+token usage:
+	total:
+		input: %v
+		cached: %v
+		output: %v
+	recent:
+		input: %v
+		cached: %v
+		output: %v
 `
 
 func (cq *ChatHandler) dirInfo() error {
@@ -122,42 +152,111 @@ func (cq *ChatHandler) dirInfo() error {
 		return nil
 	}
 
-	profileOut := ""
-	if info.Profile != "" {
-		profileOut = fmt.Sprintf("\nprofile: %v", info.Profile)
-	}
-	roles := make([]string, 0, len(info.RepliesByRole))
-	for r := range info.RepliesByRole {
-		roles = append(roles, r)
-	}
-	sort.Strings(roles)
-	rolesOut := strings.Builder{}
-	for i, r := range roles {
-		fmt.Fprintf(&rolesOut, "  %s: %v", r, info.RepliesByRole[r])
-		if i != len(roles)-1 {
-			fmt.Fprintf(&rolesOut, "\n")
-		}
-	}
 	fmt.Fprintf(
 		cq.out, prettyDirInfoFormat,
 		info.Scope,
 		info.ChatID,
 		info.initialPrompt(),
-		profileOut,
-		rolesOut.String(),
+		profileOutput(info.Profile),
+		repliesOutput(info.RepliesByRole),
 		info.costString(),
-		abbrevTokens(info.TotalInputTokens),
-		abbrevTokens(info.TotalCachedTokens),
-		abbrevTokens(info.TotalOutputTokens),
-		abbrevTokens(info.RecentInputTokens),
-		abbrevTokens(info.RecentCachedTokens),
-		abbrevTokens(info.RecentOutputTokens),
+		info.InputTokens,
+		info.CachedTokens,
+		info.OutputTokens,
 		info.Price.Input,
 		info.Price.Cached,
 		info.Price.Output,
 		info.priceTotalString(),
 	)
 	return nil
+}
+
+func (cq *ChatHandler) dirInfoV2() error {
+	legacy, err := cq.resolveChatDirInfo()
+	if err != nil {
+		return fmt.Errorf("resolve chat dir info v2: %w", err)
+	}
+	info := newChatDirInfoV2(legacy)
+
+	if cq.raw {
+		b, err := json.Marshal(info)
+		if err != nil {
+			return fmt.Errorf("marshal chat dir info v2: %w", err)
+		}
+		fmt.Fprintln(cq.out, string(b))
+		return nil
+	}
+
+	fmt.Fprintf(
+		cq.out, prettyDirInfoV2Format,
+		info.Scope,
+		info.ChatID,
+		legacy.initialPrompt(),
+		profileOutput(info.Profile),
+		repliesOutput(info.RepliesByRole),
+		legacy.costString(),
+		abbrevTokens(info.TokenUsage.Total.UncachedInput+info.TokenUsage.Total.CachedInput),
+		abbrevTokens(info.TokenUsage.Total.CachedInput),
+		abbrevTokens(info.TokenUsage.Total.Output),
+		abbrevTokens(info.TokenUsage.Recent.UncachedInput+info.TokenUsage.Recent.CachedInput),
+		abbrevTokens(info.TokenUsage.Recent.CachedInput),
+		abbrevTokens(info.TokenUsage.Recent.Output),
+	)
+	return nil
+}
+
+func profileOutput(profile string) string {
+	if profile == "" {
+		return ""
+	}
+	return fmt.Sprintf("\nprofile: %v", profile)
+}
+
+func repliesOutput(replies map[string]int) string {
+	roles := make([]string, 0, len(replies))
+	for role := range replies {
+		roles = append(roles, role)
+	}
+	sort.Strings(roles)
+	var out strings.Builder
+	for i, role := range roles {
+		fmt.Fprintf(&out, "  %s: %v", role, replies[role])
+		if i != len(roles)-1 {
+			out.WriteByte('\n')
+		}
+	}
+	return out.String()
+}
+
+func newChatDirInfoV2(info chatDirInfo) chatDirInfoV2 {
+	return chatDirInfoV2{
+		Version:             2,
+		Scope:               info.Scope,
+		ChatID:              info.ChatID,
+		Profile:             info.Profile,
+		Updated:             info.Updated,
+		ConversationCreated: info.ConversationCreated,
+		RepliesByRole:       info.RepliesByRole,
+		TokenUsage: chatDirTokenUsageV2{
+			Recent: tokenCountV2(info.recentUsage),
+			Total:  tokenCountV2(info.totalUsage),
+		},
+		CostUSD:        info.CostUSD,
+		initialMessage: info.initialMessage,
+	}
+}
+
+func tokenCountV2(usage *pub_models.Usage) chatDirTokenCountV2 {
+	if usage == nil {
+		return chatDirTokenCountV2{}
+	}
+	cached := usage.PromptTokensDetails.CachedTokens
+	return chatDirTokenCountV2{
+		UncachedInput: max(usage.PromptTokens-cached, 0),
+		CachedInput:   cached,
+		Output:        usage.CompletionTokens,
+		Total:         usage.TotalTokens,
+	}
 }
 
 func (cdi chatDirInfo) costString() string {
@@ -238,22 +337,15 @@ func (cq *ChatHandler) infoFromChat(scope, chatID string, c pub_models.Chat) cha
 		cdi.CachedTokens = c.TokenUsage.PromptTokensDetails.CachedTokens
 		cdi.NonCachedInputTokens = max(c.TokenUsage.PromptTokens-cdi.CachedTokens, 0)
 		cdi.OutputTokens = c.TokenUsage.CompletionTokens
-		cdi.RecentInputTokens = c.TokenUsage.PromptTokens
-		cdi.RecentCachedTokens = c.TokenUsage.PromptTokensDetails.CachedTokens
-		cdi.RecentOutputTokens = c.TokenUsage.CompletionTokens
-		cdi.RecentTokens = c.TokenUsage.TotalTokens
 	}
+	cdi.recentUsage = chatRecentUsage(c)
 	if len(c.Queries) > 0 {
 		total := aggregateQueryUsage(c.Queries)
-		cdi.TotalInputTokens = total.PromptTokens
-		cdi.TotalCachedTokens = total.PromptTokensDetails.CachedTokens
-		cdi.TotalOutputTokens = total.CompletionTokens
-		cdi.TotalTokens = total.TotalTokens
+		cdi.totalUsage = &total
 	} else if c.TokenUsage != nil {
-		cdi.TotalInputTokens = c.TokenUsage.PromptTokens
-		cdi.TotalCachedTokens = c.TokenUsage.PromptTokensDetails.CachedTokens
-		cdi.TotalOutputTokens = c.TokenUsage.CompletionTokens
-		cdi.TotalTokens = c.TokenUsage.TotalTokens
+		cdi.totalUsage = c.TokenUsage
+	} else {
+		cdi.totalUsage = c.RecentTokenUsage
 	}
 	if c.HasCostEstimates() {
 		cdi.Price, cdi.CostUSD = aggregateQueryPriceInfo(c.Queries)

--- a/internal/chat/handler_dir.go
+++ b/internal/chat/handler_dir.go
@@ -16,20 +16,30 @@ import (
 )
 
 type chatDirInfo struct {
-	Scope                string           `json:"scope"`
-	ChatID               string           `json:"chat_id"`
-	Profile              string           `json:"profile,omitempty"`
-	Updated              string           `json:"updated,omitempty"`
-	ConversationCreated  string           `json:"conversation_created,omitempty"`
-	RepliesByRole        map[string]int   `json:"replies_by_role"`
-	InputTokens          int              `json:"input_tokens"`
-	NonCachedInputTokens int              `json:"non_cached_input_tokens"`
-	CachedTokens         int              `json:"cached_tokens"`
-	OutputTokens         int              `json:"output_tokens"`
-	CostUSD              float64          `json:"cost_usd,omitempty"`
-	Cost                 string           `json:"cost,omitempty"`
-	Price                chatDirPriceInfo `json:"price"`
-	initialMessage       string           `json:"-"`
+	Scope                string         `json:"scope"`
+	ChatID               string         `json:"chat_id"`
+	Profile              string         `json:"profile,omitempty"`
+	Updated              string         `json:"updated,omitempty"`
+	ConversationCreated  string         `json:"conversation_created,omitempty"`
+	RepliesByRole        map[string]int `json:"replies_by_role"`
+	InputTokens          int            `json:"input_tokens"`
+	NonCachedInputTokens int            `json:"non_cached_input_tokens"`
+	CachedTokens         int            `json:"cached_tokens"`
+	OutputTokens         int            `json:"output_tokens"`
+	// Lifetime totals across all recorded queries (fall back to TokenUsage).
+	TotalInputTokens  int `json:"total_input_tokens"`
+	TotalCachedTokens int `json:"total_cached_tokens"`
+	TotalOutputTokens int `json:"total_output_tokens"`
+	TotalTokens       int `json:"total_tokens"`
+	// Most recent session's usage (chat.TokenUsage).
+	RecentInputTokens  int              `json:"recent_input_tokens"`
+	RecentCachedTokens int              `json:"recent_cached_tokens"`
+	RecentOutputTokens int              `json:"recent_output_tokens"`
+	RecentTokens       int              `json:"recent_tokens"`
+	CostUSD            float64          `json:"cost_usd,omitempty"`
+	Cost               string           `json:"cost,omitempty"`
+	Price              chatDirPriceInfo `json:"price"`
+	initialMessage     string           `json:"-"`
 }
 
 type chatDirPriceInfo struct {
@@ -86,6 +96,10 @@ tokens used:
 	input: %v
 	cached: %v
 	output: %v
+most recent:
+	input: %v
+	cached: %v
+	output: %v
 price details:
 	input: %v
 	cached: %v
@@ -132,9 +146,12 @@ func (cq *ChatHandler) dirInfo() error {
 		profileOut,
 		rolesOut.String(),
 		info.costString(),
-		info.InputTokens,
-		info.CachedTokens,
-		info.OutputTokens,
+		abbrevTokens(info.TotalInputTokens),
+		abbrevTokens(info.TotalCachedTokens),
+		abbrevTokens(info.TotalOutputTokens),
+		abbrevTokens(info.RecentInputTokens),
+		abbrevTokens(info.RecentCachedTokens),
+		abbrevTokens(info.RecentOutputTokens),
 		info.Price.Input,
 		info.Price.Cached,
 		info.Price.Output,
@@ -221,6 +238,22 @@ func (cq *ChatHandler) infoFromChat(scope, chatID string, c pub_models.Chat) cha
 		cdi.CachedTokens = c.TokenUsage.PromptTokensDetails.CachedTokens
 		cdi.NonCachedInputTokens = max(c.TokenUsage.PromptTokens-cdi.CachedTokens, 0)
 		cdi.OutputTokens = c.TokenUsage.CompletionTokens
+		cdi.RecentInputTokens = c.TokenUsage.PromptTokens
+		cdi.RecentCachedTokens = c.TokenUsage.PromptTokensDetails.CachedTokens
+		cdi.RecentOutputTokens = c.TokenUsage.CompletionTokens
+		cdi.RecentTokens = c.TokenUsage.TotalTokens
+	}
+	if len(c.Queries) > 0 {
+		total := aggregateQueryUsage(c.Queries)
+		cdi.TotalInputTokens = total.PromptTokens
+		cdi.TotalCachedTokens = total.PromptTokensDetails.CachedTokens
+		cdi.TotalOutputTokens = total.CompletionTokens
+		cdi.TotalTokens = total.TotalTokens
+	} else if c.TokenUsage != nil {
+		cdi.TotalInputTokens = c.TokenUsage.PromptTokens
+		cdi.TotalCachedTokens = c.TokenUsage.PromptTokensDetails.CachedTokens
+		cdi.TotalOutputTokens = c.TokenUsage.CompletionTokens
+		cdi.TotalTokens = c.TokenUsage.TotalTokens
 	}
 	if c.HasCostEstimates() {
 		cdi.Price, cdi.CostUSD = aggregateQueryPriceInfo(c.Queries)

--- a/internal/chat/handler_dir_test.go
+++ b/internal/chat/handler_dir_test.go
@@ -426,6 +426,102 @@ func TestChatHandler_dirInfo_Raw_PriceBreakdownAggregatesAllQueries(t *testing.T
 	}
 }
 
+func TestChatHandler_dirInfo_Raw_TokenSections(t *testing.T) {
+	confDir := t.TempDir()
+	if err := utils.CreateConfigDir(confDir); err != nil {
+		t.Fatalf("CreateConfigDir: %v", err)
+	}
+
+	wd := t.TempDir()
+	oldWd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+	if err := os.Chdir(wd); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+
+	convDir := filepath.Join(confDir, "conversations")
+	ch := pub_models.Chat{
+		ID:      "globalScopeTokenSections",
+		Created: time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC),
+		Messages: []pub_models.Message{
+			{Role: "user", Content: "hi"},
+			{Role: "assistant", Content: "ok"},
+		},
+		// Last session usage: larger than any single recorded query below.
+		TokenUsage: &pub_models.Usage{
+			PromptTokens:     30,
+			CompletionTokens: 10,
+			TotalTokens:      40,
+			PromptTokensDetails: pub_models.PromptTokensDetails{
+				CachedTokens: 10,
+			},
+		},
+		Queries: []pub_models.QueryCost{
+			{
+				Usage: pub_models.Usage{
+					PromptTokens:     12,
+					CompletionTokens: 3,
+					TotalTokens:      15,
+					PromptTokensDetails: pub_models.PromptTokensDetails{
+						CachedTokens: 5,
+					},
+				},
+			},
+			{
+				Usage: pub_models.Usage{
+					PromptTokens:     30,
+					CompletionTokens: 10,
+					TotalTokens:      40,
+					PromptTokensDetails: pub_models.PromptTokensDetails{
+						CachedTokens: 10,
+					},
+				},
+			},
+		},
+	}
+	if err := Save(convDir, ch); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	cqInit := &ChatHandler{confDir: confDir, convDir: convDir}
+	if err := cqInit.SaveDirScope("", ch.ID); err != nil {
+		t.Fatalf("SaveDirScope: %v", err)
+	}
+
+	var out bytes.Buffer
+	cq := &ChatHandler{confDir: confDir, convDir: convDir, raw: true, out: &out}
+
+	if err := cq.dirInfo(); err != nil {
+		t.Fatalf("dirInfo: %v", err)
+	}
+
+	var got chatDirInfo
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v, out=%q", err, out.String())
+	}
+
+	// Existing fields keep last-session semantics (chat.TokenUsage), so shell
+	// integrations parsing the old keys stay backward compatible.
+	if got.InputTokens != 30 || got.CachedTokens != 10 || got.OutputTokens != 10 {
+		t.Fatalf("existing token fields should stay last-session, got input=%d cached=%d output=%d", got.InputTokens, got.CachedTokens, got.OutputTokens)
+	}
+
+	// New total_* fields: lifetime sum across all queries (12+30, 3+10, 5+10).
+	if got.TotalInputTokens != 42 || got.TotalCachedTokens != 15 || got.TotalOutputTokens != 13 {
+		t.Fatalf("total token fields: got input=%d cached=%d output=%d, want 42/15/13", got.TotalInputTokens, got.TotalCachedTokens, got.TotalOutputTokens)
+	}
+	if got.TotalTokens != 55 {
+		t.Fatalf("total_tokens: got %d want 55", got.TotalTokens)
+	}
+
+	// New recent_* fields: last session (chat.TokenUsage).
+	if got.RecentInputTokens != 30 || got.RecentCachedTokens != 10 || got.RecentOutputTokens != 10 {
+		t.Fatalf("recent token fields: got input=%d cached=%d output=%d, want 30/10/10", got.RecentInputTokens, got.RecentCachedTokens, got.RecentOutputTokens)
+	}
+	if got.RecentTokens != 40 {
+		t.Fatalf("recent_tokens: got %d want 40", got.RecentTokens)
+	}
+}
+
 func TestChatHandler_dirInfo_Pretty_IncludesTokenAndPriceBreakdown(t *testing.T) {
 	confDir := t.TempDir()
 	if err := utils.CreateConfigDir(confDir); err != nil {
@@ -487,14 +583,95 @@ func TestChatHandler_dirInfo_Pretty_IncludesTokenAndPriceBreakdown(t *testing.T)
 	printed := out.String()
 	for _, want := range []string{
 		"tokens used:",
-		"input: 21",
-		"cached: 4",
-		"output: 9",
+		"input: 0.021K",
+		"cached: 0.004K",
+		"output: 0.009K",
+		"most recent:",
 		"price details:",
 		"input:",
 		"cached:",
 		"output:",
 		"total:",
+	} {
+		if !strings.Contains(printed, want) {
+			t.Fatalf("expected %q in output, got: %q", want, printed)
+		}
+	}
+	// The two token sections must appear in order: lifetime total first, then
+	// the most recent session, before the price details block.
+	tokensIdx := strings.Index(printed, "tokens used:")
+	recentIdx := strings.Index(printed, "most recent:")
+	priceIdx := strings.Index(printed, "price details:")
+	if tokensIdx == -1 || recentIdx == -1 || priceIdx == -1 {
+		t.Fatalf("missing token sections, got: %q", printed)
+	}
+	if !(tokensIdx < recentIdx && recentIdx < priceIdx) {
+		t.Fatalf("token sections out of order, got: %q", printed)
+	}
+}
+
+func TestChatHandler_dirInfo_Pretty_AbbreviatesTokenCounts(t *testing.T) {
+	confDir := t.TempDir()
+	if err := utils.CreateConfigDir(confDir); err != nil {
+		t.Fatalf("CreateConfigDir: %v", err)
+	}
+
+	wd := t.TempDir()
+	oldWd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+	if err := os.Chdir(wd); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+
+	convDir := filepath.Join(confDir, "conversations")
+	ch := pub_models.Chat{
+		ID:      "globalScopeBigTokens",
+		Created: time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC),
+		Messages: []pub_models.Message{
+			{Role: "user", Content: "hi"},
+			{Role: "assistant", Content: "ok"},
+		},
+		TokenUsage: &pub_models.Usage{
+			PromptTokens:     3717276,
+			CompletionTokens: 1234567,
+			TotalTokens:      4951843,
+			PromptTokensDetails: pub_models.PromptTokensDetails{
+				CachedTokens: 500000,
+			},
+		},
+		Queries: []pub_models.QueryCost{
+			{
+				Usage: pub_models.Usage{
+					PromptTokens:     3717276,
+					CompletionTokens: 1234567,
+					TotalTokens:      4951843,
+					PromptTokensDetails: pub_models.PromptTokensDetails{
+						CachedTokens: 500000,
+					},
+				},
+			},
+		},
+	}
+	if err := Save(convDir, ch); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	cqInit := &ChatHandler{confDir: confDir, convDir: convDir}
+	if err := cqInit.SaveDirScope("", ch.ID); err != nil {
+		t.Fatalf("SaveDirScope: %v", err)
+	}
+
+	var out bytes.Buffer
+	cq := &ChatHandler{confDir: confDir, convDir: convDir, raw: false, out: &out}
+
+	if err := cq.dirInfo(); err != nil {
+		t.Fatalf("dirInfo: %v", err)
+	}
+
+	printed := out.String()
+	for _, want := range []string{
+		"input: 3.7M",
+		"cached: 500K",
+		"output: 1.2M",
 	} {
 		if !strings.Contains(printed, want) {
 			t.Fatalf("expected %q in output, got: %q", want, printed)

--- a/internal/chat/handler_dir_test.go
+++ b/internal/chat/handler_dir_test.go
@@ -14,6 +14,12 @@ import (
 	pub_models "github.com/baalimago/clai/pkg/text/models"
 )
 
+func TestChatHelpDocumentsDirV2(t *testing.T) {
+	if !strings.Contains(chatUsage, "dirv2") {
+		t.Fatalf("chat help does not document dirv2")
+	}
+}
+
 func TestChatHandler_dirInfo_NoDirScopeNoPrevQuery(t *testing.T) {
 	confDir := t.TempDir()
 	if err := utils.CreateConfigDir(confDir); err != nil {
@@ -426,7 +432,56 @@ func TestChatHandler_dirInfo_Raw_PriceBreakdownAggregatesAllQueries(t *testing.T
 	}
 }
 
-func TestChatHandler_dirInfo_Raw_TokenSections(t *testing.T) {
+func TestChatHandler_dirInfo_V1RemainsBackwardCompatible(t *testing.T) {
+	confDir := t.TempDir()
+	if err := utils.CreateConfigDir(confDir); err != nil {
+		t.Fatalf("CreateConfigDir: %v", err)
+	}
+	convDir := filepath.Join(confDir, "conversations")
+	chat := pub_models.Chat{
+		ID:       globalScopeChatID,
+		Created:  time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC),
+		Messages: []pub_models.Message{{Role: "user", Content: "hi"}},
+		TokenUsage: &pub_models.Usage{
+			PromptTokens:     21,
+			CompletionTokens: 9,
+			TotalTokens:      30,
+		},
+		RecentTokenUsage: &pub_models.Usage{PromptTokens: 18, CompletionTokens: 3, TotalTokens: 21},
+	}
+	if err := Save(convDir, chat); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	var out bytes.Buffer
+	cq := &ChatHandler{confDir: confDir, convDir: convDir, raw: true, out: &out}
+	if err := cq.dirInfo(); err != nil {
+		t.Fatalf("dirInfo raw: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(out.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal: %v, out=%q", err, out.String())
+	}
+	if raw["input_tokens"] != float64(21) || raw["output_tokens"] != float64(9) {
+		t.Fatalf("legacy token fields changed: %s", out.String())
+	}
+	for _, key := range []string{"version", "token_usage", "total_input_tokens", "recent_input_tokens"} {
+		if _, exists := raw[key]; exists {
+			t.Fatalf("v1 output contains v2 field %q: %s", key, out.String())
+		}
+	}
+
+	out.Reset()
+	cq.raw = false
+	if err := cq.dirInfo(); err != nil {
+		t.Fatalf("dirInfo pretty: %v", err)
+	}
+	if !strings.Contains(out.String(), "input: 21") || strings.Contains(out.String(), "recent:") || strings.Contains(out.String(), "most recent:") {
+		t.Fatalf("v1 pretty output changed: %q", out.String())
+	}
+}
+
+func TestChatHandler_dirInfoV2_Raw_CleanTokenUsageSchema(t *testing.T) {
 	confDir := t.TempDir()
 	if err := utils.CreateConfigDir(confDir); err != nil {
 		t.Fatalf("CreateConfigDir: %v", err)
@@ -447,7 +502,6 @@ func TestChatHandler_dirInfo_Raw_TokenSections(t *testing.T) {
 			{Role: "user", Content: "hi"},
 			{Role: "assistant", Content: "ok"},
 		},
-		// Last session usage: larger than any single recorded query below.
 		TokenUsage: &pub_models.Usage{
 			PromptTokens:     30,
 			CompletionTokens: 10,
@@ -456,8 +510,17 @@ func TestChatHandler_dirInfo_Raw_TokenSections(t *testing.T) {
 				CachedTokens: 10,
 			},
 		},
+		RecentTokenUsage: &pub_models.Usage{
+			PromptTokens:     30,
+			CompletionTokens: 4,
+			TotalTokens:      34,
+			PromptTokensDetails: pub_models.PromptTokensDetails{
+				CachedTokens: 10,
+			},
+		},
 		Queries: []pub_models.QueryCost{
 			{
+				CostUSD: 0.1,
 				Usage: pub_models.Usage{
 					PromptTokens:     12,
 					CompletionTokens: 3,
@@ -468,6 +531,7 @@ func TestChatHandler_dirInfo_Raw_TokenSections(t *testing.T) {
 				},
 			},
 			{
+				CostUSD: 0.2,
 				Usage: pub_models.Usage{
 					PromptTokens:     30,
 					CompletionTokens: 10,
@@ -490,39 +554,65 @@ func TestChatHandler_dirInfo_Raw_TokenSections(t *testing.T) {
 	var out bytes.Buffer
 	cq := &ChatHandler{confDir: confDir, convDir: convDir, raw: true, out: &out}
 
-	if err := cq.dirInfo(); err != nil {
-		t.Fatalf("dirInfo: %v", err)
+	if err := cq.dirInfoV2(); err != nil {
+		t.Fatalf("dirInfoV2: %v", err)
 	}
 
-	var got chatDirInfo
+	var got map[string]any
 	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
 		t.Fatalf("unmarshal: %v, out=%q", err, out.String())
 	}
-
-	// Existing fields keep last-session semantics (chat.TokenUsage), so shell
-	// integrations parsing the old keys stay backward compatible.
-	if got.InputTokens != 30 || got.CachedTokens != 10 || got.OutputTokens != 10 {
-		t.Fatalf("existing token fields should stay last-session, got input=%d cached=%d output=%d", got.InputTokens, got.CachedTokens, got.OutputTokens)
+	if got["version"] != float64(2) {
+		t.Fatalf("version: got %#v want 2", got["version"])
+	}
+	if math.Abs(got["cost_usd"].(float64)-0.3) > 1e-9 {
+		t.Fatalf("cost_usd: got %#v want 0.3", got["cost_usd"])
+	}
+	allowed := map[string]bool{
+		"version": true, "scope": true, "chat_id": true, "profile": true,
+		"updated": true, "conversation_created": true, "replies_by_role": true,
+		"token_usage": true, "cost_usd": true,
+	}
+	for key := range got {
+		if !allowed[key] {
+			t.Fatalf("v2 output contains unknown top-level field %q: %s", key, out.String())
+		}
+	}
+	for _, key := range []string{
+		"cost", "price", "input_tokens", "non_cached_input_tokens", "cached_tokens", "output_tokens",
+		"total_input_tokens", "total_cached_tokens", "total_output_tokens", "total_tokens",
+		"recent_input_tokens", "recent_cached_tokens", "recent_output_tokens", "recent_tokens",
+	} {
+		if _, exists := got[key]; exists {
+			t.Fatalf("v2 output contains legacy field %q: %s", key, out.String())
+		}
 	}
 
-	// New total_* fields: lifetime sum across all queries (12+30, 3+10, 5+10).
-	if got.TotalInputTokens != 42 || got.TotalCachedTokens != 15 || got.TotalOutputTokens != 13 {
-		t.Fatalf("total token fields: got input=%d cached=%d output=%d, want 42/15/13", got.TotalInputTokens, got.TotalCachedTokens, got.TotalOutputTokens)
+	tokenUsage, ok := got["token_usage"].(map[string]any)
+	if !ok {
+		t.Fatalf("token_usage: got %#v", got["token_usage"])
 	}
-	if got.TotalTokens != 55 {
-		t.Fatalf("total_tokens: got %d want 55", got.TotalTokens)
+	recent, ok := tokenUsage["recent"].(map[string]any)
+	if !ok {
+		t.Fatalf("token_usage.recent: got %#v", tokenUsage["recent"])
 	}
-
-	// New recent_* fields: last session (chat.TokenUsage).
-	if got.RecentInputTokens != 30 || got.RecentCachedTokens != 10 || got.RecentOutputTokens != 10 {
-		t.Fatalf("recent token fields: got input=%d cached=%d output=%d, want 30/10/10", got.RecentInputTokens, got.RecentCachedTokens, got.RecentOutputTokens)
+	total, ok := tokenUsage["total"].(map[string]any)
+	if !ok {
+		t.Fatalf("token_usage.total: got %#v", tokenUsage["total"])
 	}
-	if got.RecentTokens != 40 {
-		t.Fatalf("recent_tokens: got %d want 40", got.RecentTokens)
+	for key, want := range map[string]float64{"uncached_input": 20, "cached_input": 10, "output": 4, "total": 34} {
+		if recent[key] != want {
+			t.Fatalf("token_usage.recent.%s: got %#v want %v", key, recent[key], want)
+		}
+	}
+	for key, want := range map[string]float64{"uncached_input": 27, "cached_input": 15, "output": 13, "total": 55} {
+		if total[key] != want {
+			t.Fatalf("token_usage.total.%s: got %#v want %v", key, total[key], want)
+		}
 	}
 }
 
-func TestChatHandler_dirInfo_Pretty_IncludesTokenAndPriceBreakdown(t *testing.T) {
+func TestChatHandler_dirInfoV2_Pretty_IncludesTotalAndRecentUsage(t *testing.T) {
 	confDir := t.TempDir()
 	if err := utils.CreateConfigDir(confDir); err != nil {
 		t.Fatalf("CreateConfigDir: %v", err)
@@ -576,41 +666,34 @@ func TestChatHandler_dirInfo_Pretty_IncludesTokenAndPriceBreakdown(t *testing.T)
 	cq.raw = false
 	cq.out = &out
 
-	if err := cq.dirInfo(); err != nil {
-		t.Fatalf("dirInfo: %v", err)
+	if err := cq.dirInfoV2(); err != nil {
+		t.Fatalf("dirInfoV2: %v", err)
 	}
 
 	printed := out.String()
 	for _, want := range []string{
-		"tokens used:",
+		"token usage:",
+		"total:",
 		"input: 0.021K",
 		"cached: 0.004K",
 		"output: 0.009K",
-		"most recent:",
-		"price details:",
-		"input:",
-		"cached:",
-		"output:",
-		"total:",
+		"recent:",
 	} {
 		if !strings.Contains(printed, want) {
 			t.Fatalf("expected %q in output, got: %q", want, printed)
 		}
 	}
-	// The two token sections must appear in order: lifetime total first, then
-	// the most recent session, before the price details block.
-	tokensIdx := strings.Index(printed, "tokens used:")
-	recentIdx := strings.Index(printed, "most recent:")
-	priceIdx := strings.Index(printed, "price details:")
-	if tokensIdx == -1 || recentIdx == -1 || priceIdx == -1 {
-		t.Fatalf("missing token sections, got: %q", printed)
+	if strings.Contains(printed, "price details:") {
+		t.Fatalf("v2 pretty output contains legacy price details: %q", printed)
 	}
-	if !(tokensIdx < recentIdx && recentIdx < priceIdx) {
+	totalIdx := strings.Index(printed, "total:")
+	recentIdx := strings.Index(printed, "recent:")
+	if totalIdx == -1 || recentIdx == -1 || totalIdx >= recentIdx {
 		t.Fatalf("token sections out of order, got: %q", printed)
 	}
 }
 
-func TestChatHandler_dirInfo_Pretty_AbbreviatesTokenCounts(t *testing.T) {
+func TestChatHandler_dirInfoV2_Pretty_AbbreviatesTokenCounts(t *testing.T) {
 	confDir := t.TempDir()
 	if err := utils.CreateConfigDir(confDir); err != nil {
 		t.Fatalf("CreateConfigDir: %v", err)
@@ -663,8 +746,8 @@ func TestChatHandler_dirInfo_Pretty_AbbreviatesTokenCounts(t *testing.T) {
 	var out bytes.Buffer
 	cq := &ChatHandler{confDir: confDir, convDir: convDir, raw: false, out: &out}
 
-	if err := cq.dirInfo(); err != nil {
-		t.Fatalf("dirInfo: %v", err)
+	if err := cq.dirInfoV2(); err != nil {
+		t.Fatalf("dirInfoV2: %v", err)
 	}
 
 	printed := out.String()
@@ -677,4 +760,30 @@ func TestChatHandler_dirInfo_Pretty_AbbreviatesTokenCounts(t *testing.T) {
 			t.Fatalf("expected %q in output, got: %q", want, printed)
 		}
 	}
+}
+
+func TestChatRecentUsagePrecedence(t *testing.T) {
+	t.Run("explicit recent call usage", func(t *testing.T) {
+		chat := pub_models.Chat{
+			TokenUsage:       &pub_models.Usage{TotalTokens: 120},
+			RecentTokenUsage: &pub_models.Usage{TotalTokens: 85},
+		}
+
+		got := chatRecentUsage(chat)
+		if got == nil || got.TotalTokens != 85 {
+			t.Fatalf("recent usage mismatch: got %+v", got)
+		}
+	})
+
+	t.Run("last query fallback", func(t *testing.T) {
+		chat := pub_models.Chat{Queries: []pub_models.QueryCost{
+			{Usage: pub_models.Usage{TotalTokens: 10}},
+			{Usage: pub_models.Usage{TotalTokens: 34}},
+		}}
+
+		got := chatRecentUsage(chat)
+		if got == nil || got.TotalTokens != 34 {
+			t.Fatalf("recent query fallback mismatch: got %+v", got)
+		}
+	})
 }

--- a/internal/chat/handler_list_chat.go
+++ b/internal/chat/handler_list_chat.go
@@ -23,17 +23,31 @@ import (
 	"github.com/baalimago/go_away_boilerplate/pkg/table"
 )
 
-const chatInfoPrintHeight = 16
+const chatInfoPrintHeight = 19
+
+// abbrevTokens renders a token count with a compact SI-style suffix:
+//   - 0         -> "0"
+//   - 42        -> "0.042K"
+//   - 1234      -> "1K"
+//   - 1234000   -> "1.2M"
+func abbrevTokens(v int) string {
+	if v == 0 {
+		return "0"
+	}
+	if v >= 1_000_000 {
+		return fmt.Sprintf("%.1fM", float64(v)/1_000_000.0)
+	}
+	if v >= 1000 {
+		return fmt.Sprintf("%dK", v/1000)
+	}
+	return fmt.Sprintf("%.3fK", float64(v)/1000.0)
+}
 
 func chatListTokenStr(item pub_models.Chat) string {
 	if item.TokenUsage == nil {
 		return "N/A"
 	}
-	v := item.TokenUsage.TotalTokens
-	if v >= 1000 {
-		return fmt.Sprintf("%dK", v/1000)
-	}
-	return fmt.Sprintf("%.3fK", float64(v)/1000.0)
+	return abbrevTokens(item.TokenUsage.TotalTokens)
 }
 
 func chatListCostStr(item pub_models.Chat) string {
@@ -43,14 +57,45 @@ func chatListCostStr(item pub_models.Chat) string {
 	return cost.FormatUSD(item.TotalCostUSD())
 }
 
+// chatTotalTokens returns the lifetime token spend: the sum of every recorded
+// query, falling back to the persisted TokenUsage when no queries are recorded.
+func chatTotalTokens(chat pub_models.Chat) int {
+	if len(chat.Queries) > 0 {
+		return aggregateQueryTotalTokens(chat.Queries)
+	}
+	if chat.TokenUsage != nil {
+		return chat.TokenUsage.TotalTokens
+	}
+	return 0
+}
+
+// chatRecentTokens returns the most recent session's token usage
+// (chat.TokenUsage). It is the best gauge for how close the conversation is to
+// the model's context window. Falls back to the last recorded query.
+func chatRecentTokens(chat pub_models.Chat) int {
+	if chat.TokenUsage != nil {
+		return chat.TokenUsage.TotalTokens
+	}
+	if len(chat.Queries) > 0 {
+		return chat.Queries[len(chat.Queries)-1].Usage.TotalTokens
+	}
+	return 0
+}
+
+// chatTokenSection renders the "token usage:" block of the chat info view:
+// one line for the lifetime total, one for the most recent session.
+func chatTokenSection(chat pub_models.Chat) (string, string) {
+	if chat.TokenUsage == nil && len(chat.Queries) == 0 {
+		return "N/A", "N/A"
+	}
+	return abbrevTokens(chatTotalTokens(chat)), abbrevTokens(chatRecentTokens(chat))
+}
+
 func chatIndexTokenStr(item chatIndexRow) string {
 	if item.TotalTokens <= 0 {
 		return "N/A"
 	}
-	if item.TotalTokens >= 1000 {
-		return fmt.Sprintf("%dK", item.TotalTokens/1000)
-	}
-	return fmt.Sprintf("%.3fK", float64(item.TotalTokens)/1000.0)
+	return abbrevTokens(item.TotalTokens)
 }
 
 func chatIndexCostStr(item chatIndexRow) string {
@@ -823,6 +868,17 @@ func (cq *ChatHandler) printChatInfoCommon(w io.Writer, chat pub_models.Chat, gr
 	if _, err := fmt.Fprintf(w, "%s %s\n", costKey, table.Colorize(bread, chatListCostStr(chat))); err != nil {
 		return fmt.Errorf("write total cost: %w", err)
 	}
+	tokenTotalStr, tokenRecentStr := chatTokenSection(chat)
+	tokenUsageKey := table.Colorize(utils.TableTheme().Primary, "token usage:")
+	if _, err := fmt.Fprintf(w, "%s\n", tokenUsageKey); err != nil {
+		return fmt.Errorf("write token usage key: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "\ttotal: %s\n", table.Colorize(bread, tokenTotalStr)); err != nil {
+		return fmt.Errorf("write token usage total: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "\tmost recent: %s\n", table.Colorize(bread, tokenRecentStr)); err != nil {
+		return fmt.Errorf("write token usage recent: %w", err)
+	}
 	if _, err := fmt.Fprintf(w, "%s\n", amRepliesKey); err != nil {
 		return fmt.Errorf("write am replies key: %w", err)
 	}
@@ -918,6 +974,23 @@ func editorEditString(toEdit string) (string, error) {
 	return string(b), nil
 }
 
+// messagePickerRow renders one row of the edit/delete message picker. It
+// reuses messageDisplayText so assistant tool-call turns (persisted with empty
+// Content, model-safe) are shown as reconstructed "Call: ..." lines instead of
+// blank rows, matching the conversation view.
+func messagePickerRow(i int, t pub_models.Message) (string, error) {
+	disp := messageDisplayText(t)
+	prefix := fmt.Sprintf(editMessageTblFormat, i, t.Role, utf8.RuneCountInString(disp), "")
+	return table.WidthAppropriateStringTrunc(disp, prefix, 25)
+}
+
+// messageEditorText returns the text that must be placed in $EDITOR. Tool-call
+// assistant turns intentionally have empty Content in the model-safe history,
+// so use the same derived display text as the picker and chat preview.
+func messageEditorText(m pub_models.Message) string {
+	return messageDisplayText(m)
+}
+
 // selectMessagesAt shows the conversation's message picker opened at startPage
 // and returns the selection plus the page it was made on.
 func (cq *ChatHandler) selectMessagesAt(chat pub_models.Chat, onlyOneSelect bool, startPage int) ([]int, int, error) {
@@ -925,12 +998,7 @@ func (cq *ChatHandler) selectMessagesAt(chat pub_models.Chat, onlyOneSelect bool
 	tb := table.New(
 		table.SlicePaginator(chat.Messages),
 		func(i int, t pub_models.Message) (string, error) {
-			prefix := fmt.Sprintf(editMessageTblFormat, i, t.Role, utf8.RuneCount([]byte(t.Content)), "")
-			withSummary, err := table.WidthAppropriateStringTrunc(t.Content, prefix, 25)
-			if err != nil {
-				return "", fmt.Errorf("failed to get widthAppropriateChatSummary: %w", err)
-			}
-			return withSummary, nil
+			return messagePickerRow(i, t)
 		},
 	).
 		WithHeader(head).
@@ -1002,7 +1070,7 @@ func (cq *ChatHandler) editMessageInChat(chat pub_models.Chat) error {
 		}
 		selectedNumber := selectedNumbers[0]
 		selectedMessage := chat.Messages[selectedNumber]
-		editedString, err := editorEditString(selectedMessage.Content)
+		editedString, err := editorEditString(messageEditorText(selectedMessage))
 		if err != nil {
 			return fmt.Errorf("failed to escapeEdit string: %w", err)
 		}

--- a/internal/chat/handler_list_chat.go
+++ b/internal/chat/handler_list_chat.go
@@ -66,26 +66,40 @@ func chatTotalTokens(chat pub_models.Chat) int {
 	if chat.TokenUsage != nil {
 		return chat.TokenUsage.TotalTokens
 	}
+	if chat.RecentTokenUsage != nil {
+		return chat.RecentTokenUsage.TotalTokens
+	}
 	return 0
 }
 
-// chatRecentTokens returns the most recent session's token usage
-// (chat.TokenUsage). It is the best gauge for how close the conversation is to
-// the model's context window. Falls back to the last recorded query.
-func chatRecentTokens(chat pub_models.Chat) int {
+// chatRecentUsage returns the final model call's usage. Chats saved before
+// recent_usage was introduced fall back to the latest available session/query
+// usage, which can include multiple calls when tools were used.
+func chatRecentUsage(chat pub_models.Chat) *pub_models.Usage {
+	if chat.RecentTokenUsage != nil {
+		return chat.RecentTokenUsage
+	}
 	if chat.TokenUsage != nil {
-		return chat.TokenUsage.TotalTokens
+		return chat.TokenUsage
 	}
 	if len(chat.Queries) > 0 {
-		return chat.Queries[len(chat.Queries)-1].Usage.TotalTokens
+		return &chat.Queries[len(chat.Queries)-1].Usage
 	}
-	return 0
+	return nil
+}
+
+func chatRecentTokens(chat pub_models.Chat) int {
+	usage := chatRecentUsage(chat)
+	if usage == nil {
+		return 0
+	}
+	return usage.TotalTokens
 }
 
 // chatTokenSection renders the "token usage:" block of the chat info view:
-// one line for the lifetime total, one for the most recent session.
+// one line for the lifetime total, one for the most recent model call.
 func chatTokenSection(chat pub_models.Chat) (string, string) {
-	if chat.TokenUsage == nil && len(chat.Queries) == 0 {
+	if chat.TokenUsage == nil && chat.RecentTokenUsage == nil && len(chat.Queries) == 0 {
 		return "N/A", "N/A"
 	}
 	return abbrevTokens(chatTotalTokens(chat)), abbrevTokens(chatRecentTokens(chat))
@@ -984,11 +998,10 @@ func messagePickerRow(i int, t pub_models.Message) (string, error) {
 	return table.WidthAppropriateStringTrunc(disp, prefix, 25)
 }
 
-// messageEditorText returns the text that must be placed in $EDITOR. Tool-call
-// assistant turns intentionally have empty Content in the model-safe history,
-// so use the same derived display text as the picker and chat preview.
+// messageEditorText returns only persisted text. Display-only reconstructions
+// of tool calls and reasoning must not be written back into message Content.
 func messageEditorText(m pub_models.Message) string {
-	return messageDisplayText(m)
+	return m.Content
 }
 
 // selectMessagesAt shows the conversation's message picker opened at startPage

--- a/internal/chat/handler_list_chat_test.go
+++ b/internal/chat/handler_list_chat_test.go
@@ -261,6 +261,83 @@ func TestChatListTokensOrNA(t *testing.T) {
 	}
 }
 
+func TestTokenAbbreviationTiers(t *testing.T) {
+	cases := []struct {
+		name  string
+		total int
+		want  string
+	}{
+		{"zero", 0, "0"},
+		{"sub-thousand", 42, "0.042K"},
+		{"thousand", 1234, "1K"},
+		{"hundred-thousand", 123400, "123K"},
+		{"million", 1234000, "1.2M"},
+		{"exact million", 1000000, "1.0M"},
+		{"ten million", 12345678, "12.3M"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := abbrevTokens(tc.total); got != tc.want {
+				t.Fatalf("abbrevTokens(%d) = %q, want %q", tc.total, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestChatIndexTokenStr_UsesMillions(t *testing.T) {
+	if got := chatIndexTokenStr(chatIndexRow{TotalTokens: 1234000}); got != "1.2M" {
+		t.Fatalf("chatIndexTokenStr(1,234,000) = %q, want %q", got, "1.2M")
+	}
+	if got := chatIndexTokenStr(chatIndexRow{TotalTokens: 0}); got != "N/A" {
+		t.Fatalf("chatIndexTokenStr(0) = %q, want %q", got, "N/A")
+	}
+}
+
+// TestMessagePickerRow_ShowsAssistantContent guards the edit/delete picker
+// against blank assistant rows: assistant tool-call turns are persisted with an
+// empty Content (model-safe), so the picker must reconstruct a readable line
+// from ToolCalls via messageDisplayText, exactly like the conversation view.
+func TestMessagePickerRow_ShowsAssistantContent(t *testing.T) {
+	toolTurn := pub_models.Message{
+		Role: "assistant",
+		ToolCalls: []pub_models.Call{
+			{Name: "cat", Inputs: &pub_models.Input{"file": "main.go"}},
+		},
+	}
+	row, err := messagePickerRow(2, toolTurn)
+	if err != nil {
+		t.Fatalf("messagePickerRow: %v", err)
+	}
+	if !strings.Contains(row, "Call:") || !strings.Contains(row, "cat") {
+		t.Fatalf("tool-call turn should reconstruct the call, got: %q", row)
+	}
+
+	textTurn := pub_models.Message{Role: "assistant", Content: "the answer is 42"}
+	row, err = messagePickerRow(3, textTurn)
+	if err != nil {
+		t.Fatalf("messagePickerRow: %v", err)
+	}
+	if !strings.Contains(row, "the answer is 42") {
+		t.Fatalf("text turn should show its content, got: %q", row)
+	}
+}
+
+func TestMessageEditorText_ShowsStoredAndDerivedAssistantContent(t *testing.T) {
+	textTurn := pub_models.Message{Role: "assistant", Content: "the answer is 42"}
+	if got := messageEditorText(textTurn); got != "the answer is 42" {
+		t.Fatalf("text turn editor content = %q, want %q", got, "the answer is 42")
+	}
+
+	toolTurn := pub_models.Message{
+		Role:      "assistant",
+		ToolCalls: []pub_models.Call{{Name: "cat", Inputs: &pub_models.Input{"file": "main.go"}}},
+	}
+	got := messageEditorText(toolTurn)
+	if !strings.Contains(got, "Call:") || !strings.Contains(got, "cat") {
+		t.Fatalf("tool-call turn editor content = %q, want reconstructed call", got)
+	}
+}
+
 func TestActOnChat_enter_continues(t *testing.T) {
 	confDir := t.TempDir()
 	if err := utils.CreateConfigDir(confDir); err != nil {
@@ -381,6 +458,66 @@ func TestPrintChatInfo_ShowsCost(t *testing.T) {
 	out.Reset()
 	if err := cq.printChatInfo(&out, chatWithoutCost, ""); err != nil {
 		t.Fatalf("printChatInfo without cost: %v", err)
+	}
+	if !strings.Contains(out.String(), "N/A") {
+		t.Fatalf("expected N/A in output, got: %q", out.String())
+	}
+}
+
+func TestPrintChatInfo_TokenUsage(t *testing.T) {
+	confDir := t.TempDir()
+	if err := utils.CreateConfigDir(confDir); err != nil {
+		t.Fatalf("CreateConfigDir: %v", err)
+	}
+	oldConf := os.Getenv("CLAI_CONFIG_DIR")
+	if err := os.Setenv("CLAI_CONFIG_DIR", confDir); err != nil {
+		t.Fatalf("set CLAI_CONFIG_DIR: %v", err)
+	}
+	defer func() {
+		if err := os.Setenv("CLAI_CONFIG_DIR", oldConf); err != nil {
+			t.Fatalf("restore CLAI_CONFIG_DIR: %v", err)
+		}
+	}()
+
+	chatWithTokens := pub_models.Chat{
+		ID:       "chat-with-tokens",
+		Created:  time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+		Messages: []pub_models.Message{{Role: "user", Content: "hello"}},
+		// Last session: the most recent gauge.
+		TokenUsage: &pub_models.Usage{TotalTokens: 45000},
+		Queries: []pub_models.QueryCost{
+			{Usage: pub_models.Usage{TotalTokens: 1000}},
+			{Usage: pub_models.Usage{TotalTokens: 2000}},
+			{Usage: pub_models.Usage{TotalTokens: 45000}},
+		},
+	}
+	chatWithoutTokens := pub_models.Chat{
+		ID:       "chat-without-tokens",
+		Created:  time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+		Messages: []pub_models.Message{{Role: "user", Content: "hello"}},
+	}
+
+	var out strings.Builder
+	cq := &ChatHandler{out: &out}
+	if err := cq.printChatInfo(&out, chatWithTokens, ""); err != nil {
+		t.Fatalf("printChatInfo with tokens: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "token usage:") {
+		t.Fatalf("expected token usage section, got: %q", got)
+	}
+	// Values are colorized, so assert on the value substrings (same pattern as
+	// TestPrintChatInfo_ShowsCost asserting "$14.53").
+	if !strings.Contains(got, "48K") {
+		t.Fatalf("expected lifetime total 48K (1000+2000+45000), got: %q", got)
+	}
+	if !strings.Contains(got, "45K") {
+		t.Fatalf("expected most recent 45K, got: %q", got)
+	}
+
+	out.Reset()
+	if err := cq.printChatInfo(&out, chatWithoutTokens, ""); err != nil {
+		t.Fatalf("printChatInfo without tokens: %v", err)
 	}
 	if !strings.Contains(out.String(), "N/A") {
 		t.Fatalf("expected N/A in output, got: %q", out.String())

--- a/internal/chat/handler_list_chat_test.go
+++ b/internal/chat/handler_list_chat_test.go
@@ -322,19 +322,19 @@ func TestMessagePickerRow_ShowsAssistantContent(t *testing.T) {
 	}
 }
 
-func TestMessageEditorText_ShowsStoredAndDerivedAssistantContent(t *testing.T) {
+func TestMessageEditorText_UsesOnlyStoredContent(t *testing.T) {
 	textTurn := pub_models.Message{Role: "assistant", Content: "the answer is 42"}
 	if got := messageEditorText(textTurn); got != "the answer is 42" {
 		t.Fatalf("text turn editor content = %q, want %q", got, "the answer is 42")
 	}
 
-	toolTurn := pub_models.Message{
-		Role:      "assistant",
-		ToolCalls: []pub_models.Call{{Name: "cat", Inputs: &pub_models.Input{"file": "main.go"}}},
+	structuredTurn := pub_models.Message{
+		Role:             "assistant",
+		ReasoningContent: "private reasoning",
+		ToolCalls:        []pub_models.Call{{Name: "cat", Inputs: &pub_models.Input{"file": "main.go"}}},
 	}
-	got := messageEditorText(toolTurn)
-	if !strings.Contains(got, "Call:") || !strings.Contains(got, "cat") {
-		t.Fatalf("tool-call turn editor content = %q, want reconstructed call", got)
+	if got := messageEditorText(structuredTurn); got != "" {
+		t.Fatalf("structured turn editor content = %q, want empty stored content", got)
 	}
 }
 

--- a/internal/chat/index.go
+++ b/internal/chat/index.go
@@ -74,12 +74,27 @@ func chatIndexPath(convDir string) string {
 	return path.Join(convDir, chatIndexFileName)
 }
 
-func aggregateQueryTotalTokens(queries []pub_models.QueryCost) int {
-	total := 0
+// aggregateQueryUsage sums the full token usage across every recorded query.
+// LLM APIs are stateless: each query bills the entire transcript at that time,
+// so summing yields the lifetime token spend for the conversation.
+func aggregateQueryUsage(queries []pub_models.QueryCost) pub_models.Usage {
+	var total pub_models.Usage
 	for _, query := range queries {
-		total += query.Usage.TotalTokens
+		total.PromptTokens += query.Usage.PromptTokens
+		total.CompletionTokens += query.Usage.CompletionTokens
+		total.TotalTokens += query.Usage.TotalTokens
+		total.PromptTokensDetails.CachedTokens += query.Usage.PromptTokensDetails.CachedTokens
+		total.PromptTokensDetails.AudioTokens += query.Usage.PromptTokensDetails.AudioTokens
+		total.CompletionTokensDetails.ReasoningTokens += query.Usage.CompletionTokensDetails.ReasoningTokens
+		total.CompletionTokensDetails.AudioTokens += query.Usage.CompletionTokensDetails.AudioTokens
+		total.CompletionTokensDetails.AcceptedPredictionTokens += query.Usage.CompletionTokensDetails.AcceptedPredictionTokens
+		total.CompletionTokensDetails.RejectedPredictionTokens += query.Usage.CompletionTokensDetails.RejectedPredictionTokens
 	}
 	return total
+}
+
+func aggregateQueryTotalTokens(queries []pub_models.QueryCost) int {
+	return aggregateQueryUsage(queries).TotalTokens
 }
 
 func chatIndexRowFromChat(chat pub_models.Chat) chatIndexRow {

--- a/internal/chat/replay.go
+++ b/internal/chat/replay.go
@@ -52,5 +52,8 @@ func replayDirScoped(raw bool) error {
 		return errors.New("directory-scoped conversation has no messages")
 	}
 	mostRecentMsg := c.Messages[len(c.Messages)-1]
+	if raw {
+		mostRecentMsg.ReasoningContent = ""
+	}
 	return utils.AttemptPrettyPrint(nil, mostRecentMsg, "system", raw)
 }

--- a/internal/chat/replay_test.go
+++ b/internal/chat/replay_test.go
@@ -1,0 +1,59 @@
+package chat
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/baalimago/clai/internal/utils"
+	pub_models "github.com/baalimago/clai/pkg/text/models"
+	"github.com/baalimago/go_away_boilerplate/pkg/testboil"
+)
+
+func TestReplayDirScoped_RawOmitsReasoning(t *testing.T) {
+	confDir := t.TempDir()
+	if err := utils.CreateConfigDir(confDir); err != nil {
+		t.Fatalf("CreateConfigDir: %v", err)
+	}
+	t.Setenv("CLAI_CONFIG_DIR", confDir)
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+
+	chat := pub_models.Chat{
+		ID: "raw-dre-reasoning",
+		Messages: []pub_models.Message{{
+			Role:             "assistant",
+			Content:          `{"answer":"done"}`,
+			ReasoningContent: "private chain of thought",
+		}},
+	}
+	convDir := filepath.Join(confDir, "conversations")
+	if err := Save(convDir, chat); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := (&ChatHandler{confDir: confDir, convDir: convDir}).SaveDirScope("", chat.ID); err != nil {
+		t.Fatalf("SaveDirScope: %v", err)
+	}
+
+	var replayErr error
+	stdout := testboil.CaptureStdout(t, func(t *testing.T) {
+		replayErr = Replay(true, true)
+	})
+	if replayErr != nil {
+		t.Fatalf("Replay: %v", replayErr)
+	}
+	if strings.Contains(stdout, "thinking") || strings.Contains(stdout, "private chain of thought") {
+		t.Fatalf("raw dre output contains reasoning: %q", stdout)
+	}
+	if stdout != "{\"answer\":\"done\"}\n" {
+		t.Fatalf("raw dre output: got %q", stdout)
+	}
+}

--- a/internal/chat/reply.go
+++ b/internal/chat/reply.go
@@ -23,13 +23,14 @@ func SaveAsPreviousQuery(claiConfDir string, chat pub_models.Chat) error {
 		}
 	}
 	globalScopeChat := pub_models.Chat{
-		Created:    time.Now(),
-		ID:         globalScopeChatID,
-		Profile:    chat.Profile,
-		OriginDir:  chat.OriginDir,
-		Messages:   chat.Messages,
-		TokenUsage: chat.TokenUsage,
-		Queries:    chat.Queries,
+		Created:          time.Now(),
+		ID:               globalScopeChatID,
+		Profile:          chat.Profile,
+		OriginDir:        chat.OriginDir,
+		Messages:         chat.Messages,
+		TokenUsage:       chat.TokenUsage,
+		RecentTokenUsage: chat.RecentTokenUsage,
+		Queries:          chat.Queries,
 	}
 	// This check avoids storing queries without any replies, which would most likely
 	// flood the conversations needlessly. Only promote to a fresh conversation when
@@ -45,13 +46,14 @@ func SaveAsPreviousQuery(claiConfDir string, chat pub_models.Chat) error {
 			return fmt.Errorf("generate promoted conversation id: %w", err)
 		}
 		convChat := pub_models.Chat{
-			Created:    time.Now(),
-			ID:         convID,
-			Profile:    chat.Profile,
-			OriginDir:  chat.OriginDir,
-			Messages:   chat.Messages,
-			TokenUsage: chat.TokenUsage,
-			Queries:    chat.Queries,
+			Created:          time.Now(),
+			ID:               convID,
+			Profile:          chat.Profile,
+			OriginDir:        chat.OriginDir,
+			Messages:         chat.Messages,
+			TokenUsage:       chat.TokenUsage,
+			RecentTokenUsage: chat.RecentTokenUsage,
+			Queries:          chat.Queries,
 		}
 		traceChatf("save previous query conversation path=%q conv_id=%q", convPath, convChat.ID)
 		err = Save(convPath, convChat)

--- a/internal/chat/reply_test.go
+++ b/internal/chat/reply_test.go
@@ -19,7 +19,8 @@ func TestSaveAsPreviousQuery_PreservesQueries(t *testing.T) {
 			{Role: "user", Content: "hello"},
 			{Role: "assistant", Content: "hi"},
 		},
-		TokenUsage: &pub_models.Usage{TotalTokens: 12},
+		TokenUsage:       &pub_models.Usage{TotalTokens: 12},
+		RecentTokenUsage: &pub_models.Usage{TotalTokens: 7},
 		Queries: []pub_models.QueryCost{
 			{CreatedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC), CostUSD: 0.42, Model: "openai/gpt-4.1-mini"},
 		},
@@ -39,6 +40,9 @@ func TestSaveAsPreviousQuery_PreservesQueries(t *testing.T) {
 	if got.Queries[0].CostUSD != 0.42 {
 		t.Fatalf("query cost mismatch: got %v", got.Queries[0].CostUSD)
 	}
+	if got.RecentTokenUsage == nil || got.RecentTokenUsage.TotalTokens != 7 {
+		t.Fatalf("recent token usage mismatch: got %+v", got.RecentTokenUsage)
+	}
 
 	entries, err := os.ReadDir(filepath.Join(confDir, "conversations"))
 	if err != nil {
@@ -55,6 +59,9 @@ func TestSaveAsPreviousQuery_PreservesQueries(t *testing.T) {
 		}
 		if len(conv.Queries) != 1 {
 			t.Fatalf("conversation queries length mismatch: got %d", len(conv.Queries))
+		}
+		if conv.RecentTokenUsage == nil || conv.RecentTokenUsage.TotalTokens != 7 {
+			t.Fatalf("conversation recent token usage mismatch: got %+v", conv.RecentTokenUsage)
 		}
 		foundConversation = true
 	}

--- a/internal/completion.go
+++ b/internal/completion.go
@@ -90,7 +90,7 @@ var completionPromptCommands = map[string]struct{}{
 	"g":     {},
 }
 
-var completionChatSubcommands = []string{"continue", "delete", "help", "list"}
+var completionChatSubcommands = []string{"continue", "delete", "dir", "dirv2", "help", "list"}
 
 var completionGlobalFlags = []completionFlagSpec{
 	{Name: "-I", TakesValue: true},

--- a/internal/completion_test.go
+++ b/internal/completion_test.go
@@ -60,8 +60,8 @@ func TestCompletionEngineComplete(t *testing.T) {
 			{
 				name:        "chat subcommands",
 				line:        []string{"clai", "chat", ""},
-				wantValues:  []string{"continue", "delete", "help", "list"},
-				wantKinds:   repeatKind(completionResultKindPlain, 4),
+				wantValues:  []string{"continue", "delete", "dir", "dirv2", "help", "list"},
+				wantKinds:   repeatKind(completionResultKindPlain, 6),
 				wantReplace: "",
 			},
 			{

--- a/internal/dre.go
+++ b/internal/dre.go
@@ -24,6 +24,10 @@ func (q dreQuerier) Query(ctx context.Context) error {
 	return nil
 }
 
+func (q dreQuerier) SuppressCompletionNotification() bool {
+	return q.raw
+}
+
 var _ models.Querier = (*dreQuerier)(nil)
 
 func setupDRE(mode Mode, postFlagConf Configurations, _ []string) (models.Querier, error) {

--- a/internal/dre_test.go
+++ b/internal/dre_test.go
@@ -1,0 +1,12 @@
+package internal
+
+import "testing"
+
+func TestDREQuerier_RawSuppressesCompletionNotification(t *testing.T) {
+	if !(dreQuerier{raw: true}).SuppressCompletionNotification() {
+		t.Fatal("raw dre must suppress the completion notification")
+	}
+	if (dreQuerier{raw: false}).SuppressCompletionNotification() {
+		t.Fatal("formatted dre must keep the completion notification")
+	}
+}

--- a/internal/setup.go
+++ b/internal/setup.go
@@ -225,6 +225,7 @@ func setupTextQuerierWithConf(ctx context.Context, mode Mode, confDir string, fl
 		tConf.ChatMode = true
 	}
 	logSkillDiscovery := shouldLogSkillDiscovery(mode, args)
+	structuredOutput := false
 
 	// At the moment, the configurations are based on the config file. But
 	// the configuration presecende is flags > file > default. So, we need
@@ -236,6 +237,8 @@ func setupTextQuerierWithConf(ctx context.Context, mode Mode, confDir string, fl
 		if err := tConf.LoadResponseFormat(flagSet.ResponseFormatPath); err != nil {
 			return nil, nil, fmt.Errorf("response format: %w", err)
 		}
+		structuredOutput = true
+		logSkillDiscovery = false
 	}
 
 	if misc.Truthy(os.Getenv("DEBUG")) {
@@ -280,6 +283,10 @@ func setupTextQuerierWithConf(ctx context.Context, mode Mode, confDir string, fl
 			knownToolNames = append(knownToolNames, name)
 		}
 		cacheDir, _ := utils.GetClaiCacheDir()
+		skillLogLevel := skills.ParseLogLevelFromEnv()
+		if structuredOutput {
+			skillLogLevel = skills.LogLevelError
+		}
 		skillMgr, err := skills.Discover(skills.Options{
 			ConfigDir:    confDir,
 			CacheDir:     cacheDir,
@@ -294,7 +301,7 @@ func setupTextQuerierWithConf(ctx context.Context, mode Mode, confDir string, fl
 				answer = strings.ToLower(strings.TrimSpace(answer))
 				return answer == "y" || answer == "yes", nil
 			},
-			LogLevel:       skills.ParseLogLevelFromEnv(),
+			LogLevel:       skillLogLevel,
 			KnownToolNames: knownToolNames,
 		})
 		if err != nil {
@@ -370,8 +377,10 @@ func setupLookback(confDir string, tConf *text.Configurations, flagSet Configura
 	}
 	if desc.HasHistory {
 		tConf.LookbackDescriptor = desc.Block
-		ancli.Noticef("lookback: surfaced %d recent conversation(s) for this directory\n", desc.Shown)
-	} else {
+		if tConf.ResponseFormat == nil {
+			ancli.Noticef("lookback: surfaced %d recent conversation(s) for this directory\n", desc.Shown)
+		}
+	} else if tConf.ResponseFormat == nil {
 		ancli.Noticef("lookback: enabled (no recorded history in this directory yet; search other paths with search_conversations)\n")
 	}
 	return nil

--- a/internal/setup_flags.go
+++ b/internal/setup_flags.go
@@ -116,8 +116,8 @@ func parseFlags(defaults Configurations, args []string) (Configurations, []strin
 	ascShort := fs.String("asc", defaults.ShellContext, "Auto-append shell context by name. Mutually exclusive with add-shell-context.")
 	ascLong := fs.String("add-shell-context", defaults.ShellContext, "Auto-append shell context by name. Mutually exclusive with asc.")
 
-	rfShort := fs.String("rf", defaults.ResponseFormatPath, "Path to a response_format JSON file for structured output.")
-	rfLong := fs.String("response-format", defaults.ResponseFormatPath, "Path to a response_format JSON file for structured output.")
+	rfShort := fs.String("rf", defaults.ResponseFormatPath, "Block streaming and print only the final structured response.")
+	rfLong := fs.String("response-format", defaults.ResponseFormatPath, "Block streaming and print only the final structured response.")
 
 	// Breaking change: -t/-tools are string-only value flags.
 	// Use: -t=* or -t=a,b ("-t" without value is undefined/ignored).

--- a/internal/text/finalizer.go
+++ b/internal/text/finalizer.go
@@ -84,7 +84,7 @@ func (f sessionFinalizer[C]) Finalize(session *QuerySession) {
 	if q.debug {
 		ancli.Noticef("post process querier: %+v", q)
 	}
-	if session.Raw {
+	if session.Raw && !q.structuredOutput {
 		fmt.Fprintln(q.out)
 	}
 
@@ -150,7 +150,11 @@ func (f sessionFinalizer[C]) Finalize(session *QuerySession) {
 	if q.debug {
 		ancli.PrintOK(fmt.Sprintf("Querier.postProcess:\n%v\n", debug.IndentedJsonFmt(q)))
 	}
-	if session.FinalAssistantText == "" {
+	if session.FinalAssistantText == "" || session.Failed {
+		return
+	}
+	if q.structuredOutput {
+		fmt.Fprintln(q.out, stripThinkingBlocks(session.FinalAssistantText))
 		return
 	}
 	q.postProcessOutput(pub_models.Message{

--- a/internal/text/finalizer.go
+++ b/internal/text/finalizer.go
@@ -65,6 +65,15 @@ func accumulateCompletedUsage(completed []CompletedModelCall, final *pub_models.
 	return &total
 }
 
+func mostRecentCompletedUsage(completed []CompletedModelCall, final *pub_models.Usage) *pub_models.Usage {
+	for i := len(completed) - 1; i >= 0; i-- {
+		if completed[i].Usage != nil {
+			return completed[i].Usage
+		}
+	}
+	return final
+}
+
 func (f sessionFinalizer[C]) Finalize(session *QuerySession) {
 	if session == nil || session.Finalized {
 		return
@@ -86,8 +95,9 @@ func (f sessionFinalizer[C]) Finalize(session *QuerySession) {
 			ReasoningContent: session.FinalReasoningText,
 		})
 	}
-	q.chat = session.Chat
 	session.Chat.TokenUsage = accumulateCompletedUsage(session.CompletedCalls, session.FinalUsage)
+	session.Chat.RecentTokenUsage = mostRecentCompletedUsage(session.CompletedCalls, session.FinalUsage)
+	q.chat = session.Chat
 
 	if session.ShouldSaveReply {
 		if q.costManager != nil {

--- a/internal/text/querier.go
+++ b/internal/text/querier.go
@@ -27,6 +27,7 @@ const (
 
 type Querier[C models.StreamCompleter] struct {
 	Raw                     bool
+	structuredOutput        bool
 	chat                    pub_models.Chat
 	callStackLevel          int
 	username                string
@@ -85,6 +86,10 @@ type Querier[C models.StreamCompleter] struct {
 	callUsageRecorder CallUsageRecorder
 	skillLoader       SkillLoader
 	baseTools         map[string]pub_models.LLMTool
+}
+
+func (q *Querier[C]) SuppressCompletionNotification() bool {
+	return q.structuredOutput
 }
 
 type SkillLoader interface {
@@ -226,7 +231,7 @@ func (q *Querier[C]) handleTokenForSession(session *QuerySession, token string) 
 	}
 	session.AppendPendingText(token)
 	q.fullMsg = session.PendingTextString()
-	if !q.debug {
+	if !q.debug && !q.structuredOutput {
 		fmt.Fprint(w, token)
 	}
 }
@@ -239,12 +244,18 @@ func (q *Querier[C]) closeReasoningIfOpen(session *QuerySession) {
 		return
 	}
 	q.reasoningActive = false
-	if !q.debug {
+	if !q.debug && !q.structuredOutput {
 		w := q.out
 		if w == nil {
 			w = os.Stdout
 		}
 		fmt.Fprint(w, table.Colorize(utils.RoleColor("reasoning"), "\n[/thinking]\n"))
+	}
+	if q.structuredOutput {
+		session.PendingReasoning.WriteString(q.reasoningBuf.String())
+		q.fullMsg = session.PendingTextString()
+		q.reasoningBuf.Reset()
+		return
 	}
 	reasoningWrapped := "[thinking]" + q.reasoningBuf.String() + "\n[/thinking]\n"
 	if session.PendingTextString() == "" {

--- a/internal/text/querier_setup.go
+++ b/internal/text/querier_setup.go
@@ -229,6 +229,7 @@ func NewQuerier[C models.StreamCompleter](ctx context.Context, userConf Configur
 	// Ensure profile selection is persisted in globalScope/saved conversations.
 	querier.chat.Profile = userConf.UseProfile
 	querier.Raw = userConf.Raw
+	querier.structuredOutput = userConf.ResponseFormat != nil
 	querier.shouldSaveReply = !userConf.ChatMode && userConf.SaveReplyAsConv
 	querier.replyMode = userConf.ReplyMode
 	querier.dirReplyMode = userConf.DirReplyMode

--- a/internal/text/querier_test.go
+++ b/internal/text/querier_test.go
@@ -256,6 +256,80 @@ func Test_Querier_handleToken(t *testing.T) {
 	})
 }
 
+func TestQuerier_StructuredOutputPrintsOnlyFinalResponse(t *testing.T) {
+	inttools.WithTestRegistry(t, func() {
+		inttools.Registry.Set("test", stubTool{output: "tool output that must stay hidden"})
+
+		for _, raw := range []bool{false, true} {
+			t.Run(fmt.Sprintf("raw=%t", raw), func(t *testing.T) {
+				var callCount int
+				model := &MockQuerier{}
+				model.streamFn = func(context.Context, pub_models.Chat) (chan models.CompletionEvent, error) {
+					callCount++
+					out := make(chan models.CompletionEvent, 3)
+					if callCount == 1 {
+						out <- models.ReasoningEvent{Content: "private reasoning before tool"}
+						out <- pub_models.Call{ID: "call-1", Name: "test", Inputs: &pub_models.Input{}}
+					} else {
+						out <- models.ReasoningEvent{Content: "private final reasoning"}
+						out <- `{"summary":"ok","findings":[],"approved":true}`
+					}
+					close(out)
+					return out, nil
+				}
+
+				var output strings.Builder
+				q := Querier[*MockQuerier]{
+					Raw:              raw,
+					structuredOutput: true,
+					Model:            model,
+					out:              &output,
+					chat: pub_models.Chat{Messages: []pub_models.Message{
+						{Role: "user", Content: "review this"},
+					}},
+				}
+
+				if err := q.Query(context.Background()); err != nil {
+					t.Fatalf("Query: %v", err)
+				}
+				want := "{\"summary\":\"ok\",\"findings\":[],\"approved\":true}\n"
+				if got := output.String(); got != want {
+					t.Fatalf("structured output: got %q want %q", got, want)
+				}
+			})
+		}
+	})
+}
+
+func TestQuerier_StructuredOutputPrintsNothingOnError(t *testing.T) {
+	model := &MockQuerier{}
+	model.streamFn = func(context.Context, pub_models.Chat) (chan models.CompletionEvent, error) {
+		out := make(chan models.CompletionEvent, 2)
+		out <- `{"partial":`
+		out <- errors.New("stream failed")
+		close(out)
+		return out, nil
+	}
+
+	var output strings.Builder
+	q := Querier[*MockQuerier]{
+		Raw:              true,
+		structuredOutput: true,
+		Model:            model,
+		out:              &output,
+		chat: pub_models.Chat{Messages: []pub_models.Message{
+			{Role: "user", Content: "return json"},
+		}},
+	}
+
+	if err := q.Query(context.Background()); err == nil {
+		t.Fatal("expected query error")
+	}
+	if got := output.String(); got != "" {
+		t.Fatalf("structured output on error: got %q want empty", got)
+	}
+}
+
 func Test_Context(t *testing.T) {
 	q := Querier[*MockQuerier]{
 		Model: &MockQuerier{

--- a/internal/text/querier_test.go
+++ b/internal/text/querier_test.go
@@ -1436,7 +1436,13 @@ func Test_Querier_Query_ToolCallSession_PreservesFinalReplyRoleAndFinalUsage(t *
 		t.Fatal("expected token usage to be saved")
 	}
 	if saved.TokenUsage.TotalTokens != 14 {
-		t.Fatalf("expected final token usage total 14, got %d", saved.TokenUsage.TotalTokens)
+		t.Fatalf("expected accumulated session token usage total 14, got %d", saved.TokenUsage.TotalTokens)
+	}
+	if saved.RecentTokenUsage == nil {
+		t.Fatal("expected most recent model call usage to be saved")
+	}
+	if saved.RecentTokenUsage.TotalTokens != 8 {
+		t.Fatalf("expected most recent model call usage total 8, got %d", saved.RecentTokenUsage.TotalTokens)
 	}
 	if enrichCalls != 1 {
 		t.Fatalf("expected 1 enrich call, got: %d", enrichCalls)

--- a/internal/text/session.go
+++ b/internal/text/session.go
@@ -21,6 +21,7 @@ type QuerySession struct {
 	ShouldSaveReply     bool
 	Raw                 bool
 	Finalized           bool
+	Failed              bool
 	SawAnyText          bool
 	SawStopEvent        bool
 	LikelyGeminiPreview bool

--- a/internal/text/session_runner.go
+++ b/internal/text/session_runner.go
@@ -35,7 +35,7 @@ type sessionFinalizerer interface {
 	Finalize(*QuerySession)
 }
 
-func (r *sessionRunner[C]) Run(ctx context.Context, session *QuerySession) error {
+func (r *sessionRunner[C]) Run(ctx context.Context, session *QuerySession) (runErr error) {
 	if session == nil {
 		return errors.New("run session: session is nil")
 	}
@@ -45,6 +45,7 @@ func (r *sessionRunner[C]) Run(ctx context.Context, session *QuerySession) error
 	session.StartedAt = time.Now()
 	defer func() {
 		session.FinishedAt = time.Now()
+		session.Failed = runErr != nil
 		r.finalizer.Finalize(session)
 	}()
 
@@ -196,18 +197,24 @@ func (r *sessionRunner[C]) executeModelStep(ctx context.Context, session *QueryS
 				return ModelStepResult{}, fmt.Errorf("completion stream error: %w", cast)
 			case models.NoopEvent:
 			case models.ReasoningEvent:
-				if !q.debug {
+				if !q.reasoningActive {
+					if !q.debug && !q.structuredOutput {
+						w := q.out
+						if w == nil {
+							w = os.Stdout
+						}
+						fmt.Fprint(w, table.Colorize(utils.RoleColor("reasoning"), "[thinking]"))
+					}
+					q.reasoningActive = true
+				}
+				if !q.debug && !q.structuredOutput {
 					w := q.out
 					if w == nil {
 						w = os.Stdout
 					}
-					if !q.reasoningActive {
-						fmt.Fprint(w, table.Colorize(utils.RoleColor("reasoning"), "[thinking]"))
-						q.reasoningActive = true
-					}
 					fmt.Fprint(w, table.Colorize(utils.RoleColor("reasoning"), cast.Content))
-					q.reasoningBuf.WriteString(cast.Content)
 				}
+				q.reasoningBuf.WriteString(cast.Content)
 			case models.StopEvent:
 				q.closeReasoningIfOpen(session)
 				result.AssistantText = session.PendingTextString()

--- a/internal/text/tool_executor.go
+++ b/internal/text/tool_executor.go
@@ -134,7 +134,7 @@ func (e toolExecutor[C]) emitAssistantToolCalls(session *QuerySession, calls []p
 			// assistant turn. Empty for other vendors.
 			modelSafe.ReasoningItems = call.ReasoningItems
 		}
-		if !q.debug {
+		if !q.debug && !q.structuredOutput {
 			display := pub_models.Message{Role: "assistant", Content: call.PrettyPrint(), ToolCalls: []pub_models.Call{call}, ReasoningContent: call.ReasoningContent}
 			if err := utils.AttemptPrettyPrint(q.out, display, q.username, q.Raw); err != nil {
 				return fmt.Errorf("pretty print assistant tool call: %w", err)
@@ -159,13 +159,15 @@ func (e toolExecutor[C]) emitToolResult(session *QuerySession, call pub_models.C
 		ToolCallID: call.ID,
 	}
 	session.Chat.Messages = append(session.Chat.Messages, outMsg)
-	if q.Raw {
-		if err := utils.AttemptPrettyPrint(q.out, outMsg, "tool", q.Raw); err != nil {
-			return fmt.Errorf("pretty print raw tool output: %w", err)
-		}
-	} else if !q.debug {
-		if err := utils.AttemptPrettyPrint(q.out, utils.PrepareDisplayMessage(outMsg), "tool", q.Raw); err != nil {
-			return fmt.Errorf("pretty print tool output: %w", err)
+	if !q.structuredOutput {
+		if q.Raw {
+			if err := utils.AttemptPrettyPrint(q.out, outMsg, "tool", q.Raw); err != nil {
+				return fmt.Errorf("pretty print raw tool output: %w", err)
+			}
+		} else if !q.debug {
+			if err := utils.AttemptPrettyPrint(q.out, utils.PrepareDisplayMessage(outMsg), "tool", q.Raw); err != nil {
+				return fmt.Errorf("pretty print tool output: %w", err)
+			}
 		}
 	}
 	session.ResetPendingText()
@@ -257,7 +259,7 @@ func (e toolExecutor[C]) executeLoadSkill(ctx context.Context, session *QuerySes
 	// display shortening): the loaded skill IS the instruction set.
 	outMsg := pub_models.Message{Role: "tool", Content: content, ToolCallID: call.ID}
 	session.Chat.Messages = append(session.Chat.Messages, outMsg)
-	if !q.debug {
+	if !q.debug && !q.structuredOutput {
 		printMsg := outMsg
 		printMsg.Content = userVisibleContent
 		if err := utils.AttemptPrettyPrint(q.out, printMsg, "tool", q.Raw); err != nil {
@@ -303,7 +305,7 @@ func (e toolExecutor[C]) finalizeAssistantTextBeforeToolCall(session *QuerySessi
 		return nil
 	}
 	q := e.querier
-	if !q.Raw && q.termWidth > 0 {
+	if !q.Raw && !q.structuredOutput && q.termWidth > 0 {
 		utils.UpdateMessageTerminalMetadata(pending, &session.Line, &session.LineCount, q.termWidth)
 		if err := table.ClearTermTo(q.out, session.LineCount-1); err != nil {
 			return fmt.Errorf("clear streamed assistant text before tool call: %w", err)
@@ -325,7 +327,7 @@ func (e toolExecutor[C]) finalizeAssistantTextBeforeToolCall(session *QuerySessi
 		Role:    "assistant",
 		Content: pending,
 	})
-	if !q.Raw {
+	if !q.Raw && !q.structuredOutput {
 		if q.termWidth > 0 {
 			utils.UpdateMessageTerminalMetadata(displayMsg.Content, &q.line, &q.lineCount, q.termWidth)
 		} else {

--- a/internal/vendors/jsonl.go
+++ b/internal/vendors/jsonl.go
@@ -211,7 +211,8 @@ func MapAssistantBlocks(content any, toolKeys ToolCallBlockKeys) []pub_models.Me
 				}
 			}
 			call := pub_models.Call{
-				ID: id,
+				ID:   id,
+				Name: name,
 				Function: pub_models.Specification{
 					Name:      name,
 					Arguments: args,

--- a/internal/vendors/openai/responses_stream.go
+++ b/internal/vendors/openai/responses_stream.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -18,6 +19,16 @@ import (
 )
 
 var responsesDataPrefix = []byte("data: ")
+
+const responsesMaxCallIDLength = 64
+
+func normalizeResponsesCallID(id string) string {
+	if len(id) <= responsesMaxCallIDLength {
+		return id
+	}
+	digest := fmt.Sprintf("%x", sha256.Sum256([]byte(id)))
+	return "call_" + digest[:responsesMaxCallIDLength-len("call_")]
+}
 
 type responsesStreamer struct {
 	apiKey      string
@@ -562,7 +573,7 @@ func mapMessageToResponsesInputItems(msg pub_models.Message, includeReasoning bo
 		}
 		return []responsesInputItem{{
 			Type:   "function_call_output",
-			CallID: msg.ToolCallID,
+			CallID: normalizeResponsesCallID(msg.ToolCallID),
 			// Responses expects `output` to be a string.
 			Output: msg.Content,
 		}}, nil
@@ -601,12 +612,17 @@ func mapMessageToResponsesInputItems(msg pub_models.Message, includeReasoning bo
 			}
 			name := tc.Name
 			if name == "" {
+				// Older foreign-chat imports populated only Function.Name.
+				// Accept both representations so persisted conversations remain usable.
+				name = tc.Function.Name
+			}
+			if name == "" {
 				return nil, fmt.Errorf("map assistant tool call %q: missing name", callID)
 			}
 
 			out = append(out, responsesInputItem{
 				Type:      "function_call",
-				CallID:    callID,
+				CallID:    normalizeResponsesCallID(callID),
 				Name:      name,
 				Arguments: tc.Function.Arguments,
 			})

--- a/internal/vendors/openai/responses_toolcall_mapping_test.go
+++ b/internal/vendors/openai/responses_toolcall_mapping_test.go
@@ -1,10 +1,64 @@
 package openai
 
 import (
+	"strings"
 	"testing"
 
 	pub_models "github.com/baalimago/clai/pkg/text/models"
 )
+
+func TestMapChatToResponsesInput_UsesFunctionNameForImportedToolCall(t *testing.T) {
+	t.Parallel()
+
+	chat := pub_models.Chat{Messages: []pub_models.Message{
+		{Role: "assistant", ToolCalls: []pub_models.Call{{
+			ID:       "call_1",
+			Function: pub_models.Specification{Name: "read", Arguments: `{"path":"main.go"}`},
+		}}},
+	}}
+
+	items, err := mapChatToResponsesInput(chat, false)
+	if err != nil {
+		t.Fatalf("mapChatToResponsesInput: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].Name != "read" {
+		t.Fatalf("expected function name %q, got %q", "read", items[0].Name)
+	}
+}
+
+func TestMapChatToResponsesInput_ShortensLongToolCallIDsConsistently(t *testing.T) {
+	t.Parallel()
+
+	longID := "call_" + strings.Repeat("x", 78)
+	chat := pub_models.Chat{Messages: []pub_models.Message{
+		{Role: "assistant", ToolCalls: []pub_models.Call{{
+			ID:       longID,
+			Name:     "read",
+			Function: pub_models.Specification{Arguments: `{}`},
+		}}},
+		{Role: "tool", ToolCallID: longID, Content: "result"},
+	}}
+
+	items, err := mapChatToResponsesInput(chat, false)
+	if err != nil {
+		t.Fatalf("mapChatToResponsesInput: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if len(items[0].CallID) > 64 {
+		t.Fatalf("function call id has length %d, want at most 64", len(items[0].CallID))
+	}
+	if items[0].CallID == longID {
+		t.Fatalf("function call id was not shortened: %q", items[0].CallID)
+	}
+	if items[1].CallID != items[0].CallID {
+		t.Fatalf("tool output call id %q does not match function call id %q", items[1].CallID, items[0].CallID)
+	}
+}
 
 func TestMapChatToResponsesInput_IncludesAssistantToolCallsBeforeToolOutputs(t *testing.T) {
 	t.Parallel()

--- a/internal/vendors/pi/source_reader_test.go
+++ b/internal/vendors/pi/source_reader_test.go
@@ -500,7 +500,14 @@ func TestMapPiAssistantMessage_ToolCallArgumentsMarshal(t *testing.T) {
 	if len(msgs[0].ToolCalls) != 1 {
 		t.Fatalf("expected 1 tool call, got %d", len(msgs[0].ToolCalls))
 	}
-	if msgs[0].ToolCalls[0].Function.Arguments != `{"path":"/etc/hosts"}` {
-		t.Fatalf("expected marshalled args, got %q", msgs[0].ToolCalls[0].Function.Arguments)
+	call := msgs[0].ToolCalls[0]
+	if call.Name != "read" {
+		t.Fatalf("expected top-level tool name %q, got %q", "read", call.Name)
+	}
+	if call.Function.Name != "read" {
+		t.Fatalf("expected function tool name %q, got %q", "read", call.Function.Name)
+	}
+	if call.Function.Arguments != `{"path":"/etc/hosts"}` {
+		t.Fatalf("expected marshalled args, got %q", call.Function.Arguments)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -59,6 +59,8 @@ Commands:
   c|chat   c|continue  <chatID>   Continue an existing chat with the given chat ID or index.
   c|chat   d|delete    <chatID>   Delete the chat with the given chat ID or index.
   c|chat   l|list                 List all existing chats.
+  c|chat   dir                    Show directory chat info with the stable v1 output.
+  c|chat   dirv2                  Show directory chat info with total and recent token usage.
   c|chat   h|help                 Display detailed help for chat subcommands.
 
 Examples:
@@ -70,6 +72,7 @@ Examples:
   - clai -pm dall-e-2 photo A cat in space
   - docker logs example | clai -I LOG q "Find errors in these logs: LOG"
   - clai c list
+  - clai -r c dirv2
   - clai c help
 `
 

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ Flags:
   -p, -profile string              Set the profile which should be used. For details, see 'clai help profile'. (default '%v')
   -prp, profile-path string        Set the path to a profile file to use instead of -p/-profile.
   -asc, -append-shell-context str  Append a named shell context from <config-dir>/shellContexts/<name>.json to the final query prompt.
-  -rf, -response-format string     Path to a response_format JSON file for structured output (json_object, json_schema).
+  -rf, -response-format string     Block streaming and print only the final structured response (json_object, json_schema).
   -n, -non-interactive             Disable interactive stdin fallback after macro inputs; auto-exit instead.
 
 Config dir: %v
@@ -76,7 +76,14 @@ Examples:
   - clai c help
 `
 
-func triggerCompletionNotification() {
+type completionNotificationSuppressor interface {
+	SuppressCompletionNotification() bool
+}
+
+func triggerCompletionNotification(completed any) {
+	if suppressor, ok := completed.(completionNotificationSuppressor); ok && suppressor.SuppressCompletionNotification() {
+		return
+	}
 	if !utils.NotificationBellEnabled() {
 		return
 	}
@@ -127,7 +134,7 @@ func run(args []string) int {
 		}
 	}
 	cancel()
-	triggerCompletionNotification()
+	triggerCompletionNotification(querier)
 	if misc.Truthy(os.Getenv("DEBUG")) {
 		ancli.PrintOK("things seems to have worked out. Bye bye! 🚀\n")
 	}

--- a/main_chat_e2e_test.go
+++ b/main_chat_e2e_test.go
@@ -82,6 +82,9 @@ func Test_chat_dir_does_not_print_skills_logs_without_text_query(t *testing.T) {
 		if strings.Contains(stdout, "skills") {
 			t.Fatalf("expected no skills logs in chat %s output, got %q", subcommand, stdout)
 		}
+		if strings.ContainsRune(stdout, '\a') {
+			t.Fatalf("raw chat %s output contains a notification bell: %q", subcommand, stdout)
+		}
 	}
 }
 

--- a/main_chat_e2e_test.go
+++ b/main_chat_e2e_test.go
@@ -55,6 +55,12 @@ func splitArgsForTest(args string) []string {
 	return out
 }
 
+func TestMainHelpDocumentsChatDirV2(t *testing.T) {
+	if !strings.Contains(usage, "chat   dirv2") {
+		t.Fatalf("main help does not document chat dirv2")
+	}
+}
+
 func Test_chat_dir_does_not_print_skills_logs_without_text_query(t *testing.T) {
 	confDir := setupMainTestConfigDir(t)
 	oldWd, _ := os.Getwd()
@@ -68,12 +74,14 @@ func Test_chat_dir_does_not_print_skills_logs_without_text_query(t *testing.T) {
 		"enabled": true,
 	})
 
-	stdout, status := runOne(t, workDir, "-r -cm test chat dir")
-	if status != 0 {
-		t.Fatalf("expected zero status, got %d stdout=%q", status, stdout)
-	}
-	if strings.Contains(stdout, "skills") {
-		t.Fatalf("expected no skills logs in chat dir output, got %q", stdout)
+	for _, subcommand := range []string{"dir", "dirv2"} {
+		stdout, status := runOne(t, workDir, "-r -cm test chat "+subcommand)
+		if status != 0 {
+			t.Fatalf("expected zero status for chat %s, got %d stdout=%q", subcommand, status, stdout)
+		}
+		if strings.Contains(stdout, "skills") {
+			t.Fatalf("expected no skills logs in chat %s output, got %q", subcommand, stdout)
+		}
 	}
 }
 

--- a/main_completion_e2e_test.go
+++ b/main_completion_e2e_test.go
@@ -58,5 +58,5 @@ func TestHiddenCompletionOutputsExpectedFormat(t *testing.T) {
 	})
 
 	testboil.FailTestIfDiff(t, gotStatus, 0)
-	testboil.FailTestIfDiff(t, stdout, "continue\tplain\ndelete\tplain\nhelp\tplain\nlist\tplain\n")
+	testboil.FailTestIfDiff(t, stdout, "continue\tplain\ndelete\tplain\ndir\tplain\ndirv2\tplain\nhelp\tplain\nlist\tplain\n")
 }

--- a/main_notification_test.go
+++ b/main_notification_test.go
@@ -31,6 +31,30 @@ func writeNotificationTestPriceFiles(t *testing.T, confDir string) {
 	}
 }
 
+func Test_run_structured_output_prints_only_response(t *testing.T) {
+	for _, rawFlag := range []string{"", "-r"} {
+		t.Run("raw="+rawFlag, func(t *testing.T) {
+			confDir := setupMainTestConfigDir(t)
+			writeNotificationTestPriceFiles(t, confDir)
+			writeSkillFile(t, filepath.Join(confDir, "skills", "review", "SKILL.md"), "---\ndescription: review\n---\nBody")
+			writeSkillsConfigJSON(t, confDir, map[string]any{"enabled": true})
+			responseFormatPath := filepath.Join("examples", "response-format-review.json")
+
+			args := []string{"-cm", "test", "-lb", "-rf", responseFormatPath, "q", "hello"}
+			if rawFlag != "" {
+				args = append([]string{rawFlag}, args...)
+			}
+			var gotStatusCode int
+			gotStdout := testboil.CaptureStdout(t, func(t *testing.T) {
+				gotStatusCode = run(args)
+			})
+
+			testboil.FailTestIfDiff(t, gotStatusCode, 0)
+			testboil.FailTestIfDiff(t, gotStdout, "hello\n")
+		})
+	}
+}
+
 func Test_run_emits_terminal_bell_on_completed_query_when_theme_enables_it(t *testing.T) {
 	confDir := t.TempDir()
 	required := []string{

--- a/pkg/text/models/chat.go
+++ b/pkg/text/models/chat.go
@@ -28,10 +28,14 @@ type Chat struct {
 	// text content. Empty when no user message exists, the first message is
 	// image-only, or the chat predates this feature. Stamped once on first
 	// persist; never rewritten.
-	GroupKey   string      `json:"group_key,omitempty"`
-	Messages   []Message   `json:"messages"`
-	TokenUsage *Usage      `json:"usage,omitempty"`
-	Queries    []QueryCost `json:"queries,omitempty"`
+	GroupKey string    `json:"group_key,omitempty"`
+	Messages []Message `json:"messages"`
+	// TokenUsage is the billable usage accumulated across all model calls in
+	// the latest session. RecentTokenUsage is only the final model call, which
+	// is the closest persisted gauge of the next request's context size.
+	TokenUsage       *Usage      `json:"usage,omitempty"`
+	RecentTokenUsage *Usage      `json:"recent_usage,omitempty"`
+	Queries          []QueryCost `json:"queries,omitempty"`
 }
 
 type QueryCost struct {


### PR DESCRIPTION
We used to have this as default, but it undercounts. So now it's readded in it's true form where it only displays most recent token usage. This is a better gauge on how bloated the context window is, as it shows at least how much tokens will be used on the subsequent call, instead of showing full usage which is a bit harder to reason about

Additional features:
* `-response-format` flag now ONLY prints the response in the response format, allows for better scripting
* Better output for token counting
* `clai chat dirv2` - An upgrade to `clai chat dir`, in both response format and output. Left v1 as I despise regression