### PR TITLE
feat: Output upgrades, rolling window + better colourization

### DIFF
--- a/architecture/colours.md
+++ b/architecture/colours.md
@@ -38,6 +38,7 @@ All colour fields are raw ANSI escape sequences represented as JSON strings.
 | `roleReasoning` | Colour for `reasoning` role labels (thinking/chain-of-thought). |
 | `roleOther` | Fallback colour for any other/unknown role. |
 | `notificationBell` | Whether clai should emit terminal BEL (`\a`) after successful task completion. |
+| `toolOutputRows` | Maximum terminal rows for each non-raw tool result. Default: `6`. |
 
 Defaults are chosen to match the existing `AttemptPrettyPrint` role palette (system=blue, user=cyan, tool=magenta, reasoning=warm-gray).
 
@@ -53,9 +54,13 @@ Example:
   "roleTool": "\u001b[35m",
   "roleReasoning": "\u001b[38;2;180;170;150m",
   "roleOther": "\u001b[34m",
-  "notificationBell": true
+  "notificationBell": true,
+  "toolOutputRows": 6
 }
 ```
+
+Existing theme files get `toolOutputRows: 6` when clai loads them. Set a
+positive value to change the display limit.
 
 `notificationBell` is intended for terminal/tmux attention behavior. Depending on terminal and tmux configuration, BEL may produce an audible bell, visual flash, or other attention marker.
 
@@ -118,6 +123,16 @@ Implementation:
 Raw `chat dir` and `chat dirv2` output does not include BEL. Model output with `-rf` or `-response-format` also excludes BEL.
 
 Structured output blocks all intermediate display output. These rules keep the JSON valid for tools such as `jq`.
+
+### 5) Tool activity
+
+Non-raw tool results do not use glow. clai wraps output for the terminal width
+and shows no more than `toolOutputRows` terminal rows. At the default limit,
+clai shows the first three rows, an omitted-row marker, and the last two rows.
+The full bounded tool result stays in the chat history and model context.
+
+Non-raw assistant tool-call status also does not use glow. It is shortened to
+one terminal row. Raw mode keeps complete tool calls and results.
 
 ## Customization
 

--- a/architecture/colours.md
+++ b/architecture/colours.md
@@ -39,6 +39,9 @@ All colour fields are raw ANSI escape sequences represented as JSON strings.
 | `roleOther` | Fallback colour for any other/unknown role. |
 | `notificationBell` | Whether clai should emit terminal BEL (`\a`) after successful task completion. |
 | `toolOutputRows` | Maximum terminal rows for each non-raw tool result. Default: `6`. |
+| `rollingOutput` | Nested configuration for the shared rolling activity viewport. |
+| `rollingOutput.enabled` | Use the shared rolling activity viewport. Default: `true`. |
+| `rollingOutput.windowCellHeight` | Maximum terminal cells (rows) for the shared non-raw reasoning and tool activity viewport. Default: `30`. |
 
 Defaults are chosen to match the existing `AttemptPrettyPrint` role palette (system=blue, user=cyan, tool=magenta, reasoning=warm-gray).
 
@@ -55,12 +58,26 @@ Example:
   "roleReasoning": "\u001b[38;2;180;170;150m",
   "roleOther": "\u001b[34m",
   "notificationBell": true,
-  "toolOutputRows": 6
+  "toolOutputRows": 6,
+  "rollingOutput": {
+    "enabled": true,
+    "windowCellHeight": 30
+  }
 }
 ```
 
 Existing theme files get `toolOutputRows: 6` when clai loads them. Set a
 positive value to change the display limit.
+
+Existing theme files get the `rollingOutput` block with defaults when clai
+loads them. If `rollingOutput.enabled` is `false`, reasoning uses the plain
+non-rolling thinking format. Tool activity keeps the new header and result
+format, but clai appends each block without cursor redraws. Set
+`rollingOutput.windowCellHeight` to a positive value to change the rolling
+viewport size. The obsolete `reasoningOutputRows`, `activityOutputRows`, and
+flat `rollingOutput` keys are ignored. The earlier kebab-case keys
+`rolling-output` and `window-cell-height` are migrated to the camelCase
+spelling on load, keeping their values.
 
 `notificationBell` is intended for terminal/tmux attention behavior. Depending on terminal and tmux configuration, BEL may produce an audible bell, visual flash, or other attention marker.
 
@@ -91,9 +108,11 @@ Behaviour:
 
 ### 2) Obfuscated chat printing
 
-Function: `internal/chat.printChatObfuscated(w, chat, raw)`
+Function: `internal/chat.printChatObfuscated(w, chat, raw, width)`
 
 For older messages (all but the last 6 messages), it prints one-line summaries.
+The `width` argument is the session's resolved terminal width; every truncation
+in this render uses it, so one operation renders with one dimension set.
 
 - The bracket prefix such as:
 
@@ -120,19 +139,67 @@ Implementation:
 - `main.go:triggerCompletionNotification()`
 - `internal/utils.NotificationBellEnabled()`
 
-Raw `chat dir` and `chat dirv2` output does not include BEL. Model output with `-rf` or `-response-format` also excludes BEL.
+Raw `chat dir` and `chat dirv2` output does not include BEL. Redirected model
+output and model output with `-rf` or `-response-format` also exclude BEL.
 
 Structured output blocks all intermediate display output. These rules keep the JSON valid for tools such as `jq`.
 
 ### 5) Tool activity
 
-Non-raw tool results do not use glow. clai wraps output for the terminal width
-and shows no more than `toolOutputRows` terminal rows. At the default limit,
-clai shows the first three rows, an omitted-row marker, and the last two rows.
-The full bounded tool result stays in the chat history and model context.
+Non-raw tool activity does not use glow. Each execution is one visually
+separate block. The block starts with a primary-colour header such as
+`▸ filesystem.list_directory  path=/work`, then has an indented result preview,
+then one blank line. Built-in names stay unchanged. MCP names drop `mcp_` and
+display as `server.tool`. Input keys are sorted, so headers are deterministic.
 
-Non-raw assistant tool-call status also does not use glow. It is shortened to
-one terminal row. Raw mode keeps complete tool calls and results.
+clai wraps the result preview for the terminal width and shows no more than
+`toolOutputRows` terminal rows. At the default limit, clai shows the first
+three rows, an omitted-row marker, and the last two rows. Error results have a
+magenta `✗` marker. The full bounded result stays in the chat history and model
+context. Assistant and tool role labels are not printed for these blocks.
+
+Async lifecycle results are display summaries only. Start, status, await, and
+cancel results show concise status, ID, and exit data. Log results show status
+and decoded stdout/stderr preview text instead of a JSON envelope. Raw,
+structured, and debug output keep their existing behaviour.
+
+### 6) Streamed reasoning and assistant prose
+
+Normal streaming shows reasoning, assistant prose, and tool activity in one
+rolling viewport. Reasoning starts with the warm-hue `∴ thinking` header.
+Assistant prose that streams while the window is open (for example a short
+preamble before a tool call) is added as its own block with an `assistant`
+header; it is never re-printed outside the window. Its indented body is
+neutral, like a reasoning or tool result body. The viewport uses no more
+than `rollingOutput.windowCellHeight` terminal cells in total. Each tool
+preview remains limited by `toolOutputRows`. Long text wraps by terminal
+display-cell width, including wide Unicode characters. When the viewport is
+full, each new row removes the oldest visible row and redraws the same
+region.
+
+The viewport stores logical activity blocks, not wrapped rows. Each block
+keeps its complete sanitized content; colours and indentation are derived
+again at each rewrap. When the terminal dimensions change, clai rewraps
+every retained block at the new width and redraws the window in one frame.
+The effective window height is `min(windowCellHeight, terminal height)`.
+A terminal-height grow can bring retained content back into view, bounded
+by retention, not by the row cap.
+
+A terminal resize (`SIGWINCH`, for example a tmux pane resize) re-queries
+the terminal size through the shared dimensions viewer, rewraps every
+retained block at the new width, and redraws the window in one frame. The
+resize is consumed in the serialized session loop, never in the signal
+callback, so a redraw can never race a streamed token or tool write. Resize
+bursts coalesce; a failed re-query keeps the last valid size. A resize that
+arrives before the first reasoning or tool event updates the session
+snapshot, so the first render already uses the new dimensions. Raw,
+structured, debug, and redirected output never start the resize watcher.
+
+The complete reasoning stays in the session, model context, and saved chat.
+clai removes terminal control sequences only from the display copy. Raw,
+structured, debug, and redirected stdout do not use this viewport. Redirected
+stdout is identical to raw output. When activity ends, the final viewport
+stays visible and the final answer starts below it.
 
 ## Customization
 

--- a/architecture/query.md
+++ b/architecture/query.md
@@ -94,6 +94,9 @@ loop (`internal/text/session_runner.go`). Each model step:
    - `error` → propagated
    - `models.StopEvent` → cancels context
    - `models.NoopEvent` → ignored
+   - `dimensions.Dimensions` (resize, rolling terminal sessions only) →
+     refreshes the session snapshot, resizes the rolling viewport, and
+     redraws it in one frame before further output
 3. **Tool batch** (when the step produced tool calls): the stoploss controller
    preflights the whole batch against both run budgets before any tool runs
    (`internal/text/tool_executor.go`). Refused calls never reach their

--- a/architecture/tools-command.md
+++ b/architecture/tools-command.md
@@ -42,7 +42,9 @@ main.go:run()
    - one entry per canonical tool; a tool's aliases are annotated on its
      canonical row (`- async_cmd (alias: async_cmd_run): ...`) instead of
      being listed as duplicate entries
-   - attempts to fit descriptions to terminal width via `utils.WidthAppropriateStringTrunc`.
+   - attempts to fit descriptions to the width of the session's output writer
+     via `utils.SessionDimensions(os.Stdout)` and the explicit-width helper
+     `table.WidthAppropriateStringTruncWithWidth`.
 
 5. Prints an instruction footer:
 

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/baalimago/clai
 go 1.26
 
 require (
-	github.com/baalimago/go_away_boilerplate v1.33.8
+	github.com/baalimago/go_away_boilerplate v1.33.9
 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
 	golang.org/x/net v0.43.0
 )
 
-require golang.org/x/text v0.28.0 // indirect
+require golang.org/x/text v0.28.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/baalimago/go_away_boilerplate v1.33.8 h1:hQdKjupQ3xvZCkqwYeFC1BWvtyCLY3V5zjMnPK/n8Lk=
-github.com/baalimago/go_away_boilerplate v1.33.8/go.mod h1:F+JZUsPD+dzq5EqCEHQ61Xa1NwyucY8rmhz1TJm08yY=
+github.com/baalimago/go_away_boilerplate v1.33.9 h1:hMLo8YnYFKM0SPiJYBAJ2Vd/4TNpkpADlZyz24ojRfM=
+github.com/baalimago/go_away_boilerplate v1.33.9/go.mod h1:F+JZUsPD+dzq5EqCEHQ61Xa1NwyucY8rmhz1TJm08yY=
 golang.org/x/exp v0.0.0-20240119083558-1b970713d09a h1:Q8/wZp0KX97QFTc2ywcOE0YRjZPVIx+MXInMzdvQqcA=
 golang.org/x/exp v0.0.0-20240119083558-1b970713d09a/go.mod h1:idGWGoKP1toJGkd5/ig9ZLuPcZBC3ewk7SzmH0uou08=
 golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=

--- a/internal/chat/handler.go
+++ b/internal/chat/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/baalimago/clai/internal/utils"
 	pub_models "github.com/baalimago/clai/pkg/text/models"
 	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
+	"github.com/baalimago/go_away_boilerplate/pkg/dimensions"
 	"github.com/baalimago/go_away_boilerplate/pkg/misc"
 )
 
@@ -74,6 +75,11 @@ type ChatHandler struct {
 
 	out   io.Writer
 	input io.Reader
+	// dims is the one terminal-dimensions snapshot of this chat command
+	// invocation, bound to the handler's output writer. It is resolved once in
+	// New and used by every width-aware render path of the handler. Tests
+	// inject a snapshot to stay ambient-independent.
+	dims dimensions.Dimensions
 }
 
 func (q *ChatHandler) Query(ctx context.Context) error {
@@ -163,7 +169,7 @@ func (cq *ChatHandler) findChatByID(potentialChatIdx string) (pub_models.Chat, e
 func (cq *ChatHandler) printChat(chat pub_models.Chat) error {
 	// New default behavior: fast, heavily obfuscated preview.
 	// This avoids expensive glow rendering and avoids printing message bodies.
-	if err := printChatObfuscated(cq.out, chat, cq.raw); err != nil {
+	if err := printChatObfuscated(cq.out, chat, cq.raw, cq.dims.Width); err != nil {
 		return fmt.Errorf("print obfuscated chat: %w", err)
 	}
 	return nil
@@ -312,6 +318,7 @@ func New(q models.ChatQuerier,
 		config:   conf,
 		raw:      raw,
 		out:      out,
+		dims:     utils.SessionDimensions(out),
 	}
 
 	// Macro mode: extra positional args after "chat list" become table inputs.

--- a/internal/chat/handler_dir.go
+++ b/internal/chat/handler_dir.go
@@ -95,12 +95,8 @@ func aggregateQueryPriceInfo(queries []pub_models.QueryCost) (chatDirPriceInfo, 
 	return price, totalCost
 }
 
-func (cdi chatDirInfo) initialPrompt() string {
-	truncPrompt, err := table.WidthAppropriateStringTrunc(cdi.initialMessage, "", 30)
-	if err != nil {
-		return "failed to get initial prompt"
-	}
-	return truncPrompt
+func (cdi chatDirInfo) initialPrompt(width int) string {
+	return table.WidthAppropriateStringTruncWithWidth(cdi.initialMessage, "", 30, width)
 }
 
 const prettyDirInfoFormat = `scope: %v
@@ -156,7 +152,7 @@ func (cq *ChatHandler) dirInfo() error {
 		cq.out, prettyDirInfoFormat,
 		info.Scope,
 		info.ChatID,
-		info.initialPrompt(),
+		info.initialPrompt(cq.dims.Width),
 		profileOutput(info.Profile),
 		repliesOutput(info.RepliesByRole),
 		info.costString(),
@@ -191,7 +187,7 @@ func (cq *ChatHandler) dirInfoV2() error {
 		cq.out, prettyDirInfoV2Format,
 		info.Scope,
 		info.ChatID,
-		legacy.initialPrompt(),
+		legacy.initialPrompt(cq.dims.Width),
 		profileOutput(info.Profile),
 		repliesOutput(info.RepliesByRole),
 		legacy.costString(),

--- a/internal/chat/handler_list_chat.go
+++ b/internal/chat/handler_list_chat.go
@@ -633,9 +633,8 @@ func (cq *ChatHandler) listChats(ctx context.Context, paginator *ChatIndexPagina
 
 		tblFmt := fmt.Sprintf("%%-%ds| %%-15s | %%-20s| %%-18s | %%-8s | %%v", maxIdxLen)
 		headArgs := []any{"Index", "Source", "Created", "Model", "Cost", "Prompt"}
-		isWide := false
-		if tw, err := table.TermWidth(); err == nil && tw > 120 {
-			isWide = true
+		isWide := cq.dims.Width > 120
+		if isWide {
 			tblFmt = fmt.Sprintf("%%-%ds| %%-15s | %%-20s| %%-8v | %%-15s | %%-18s | %%-8s | %%-6s | %%v", maxIdxLen)
 			headArgs = []any{"Index", "Source", "Created", "Messages", "Profile", "Model", "Cost", "Tokens", "Prompt"}
 		}
@@ -680,10 +679,7 @@ func (cq *ChatHandler) listChats(ctx context.Context, paginator *ChatIndexPagina
 						tokenStr,
 						"",
 					)
-					withSummary, err := table.WidthAppropriateStringTrunc(item.FirstUserMessage, prefix, 15)
-					if err != nil {
-						return "", fmt.Errorf("failed to get widthAppropriateChatSummary: %w", err)
-					}
+					withSummary := table.WidthAppropriateStringTruncWithWidth(item.FirstUserMessage, prefix, 15, cq.dims.Width)
 					return withSummary, nil
 				}
 
@@ -696,10 +692,7 @@ func (cq *ChatHandler) listChats(ctx context.Context, paginator *ChatIndexPagina
 					costStr,
 					"",
 				)
-				withSummary, err := table.WidthAppropriateStringTrunc(item.FirstUserMessage, prefix, 15)
-				if err != nil {
-					return "", fmt.Errorf("failed to get widthAppropriateChatSummary: %w", err)
-				}
+				withSummary := table.WidthAppropriateStringTruncWithWidth(item.FirstUserMessage, prefix, 15, cq.dims.Width)
 				return withSummary, nil
 			},
 		).
@@ -842,10 +835,7 @@ func (cq *ChatHandler) printChatInfoCommon(w io.Writer, chat pub_models.Chat, gr
 	if uMsg, err := chat.FirstUserMessage(); err == nil {
 		firstMessages = uMsg.Content
 	}
-	summary, err := table.WidthAppropriateStringTrunc(firstMessages, "summary: \"", 10)
-	if err != nil {
-		return fmt.Errorf("failed to create widthAppropriateChatSummary: %w", err)
-	}
+	summary := table.WidthAppropriateStringTruncWithWidth(firstMessages, "summary: \"", 10, cq.dims.Width)
 
 	header := table.Colorize(utils.TableTheme().Primary, "=== Chat info ===")
 	fileKey := table.Colorize(utils.TableTheme().Primary, "file path:")
@@ -992,10 +982,10 @@ func editorEditString(toEdit string) (string, error) {
 // reuses messageDisplayText so assistant tool-call turns (persisted with empty
 // Content, model-safe) are shown as reconstructed "Call: ..." lines instead of
 // blank rows, matching the conversation view.
-func messagePickerRow(i int, t pub_models.Message) (string, error) {
+func messagePickerRow(i int, t pub_models.Message, width int) (string, error) {
 	disp := messageDisplayText(t)
 	prefix := fmt.Sprintf(editMessageTblFormat, i, t.Role, utf8.RuneCountInString(disp), "")
-	return table.WidthAppropriateStringTrunc(disp, prefix, 25)
+	return table.WidthAppropriateStringTruncWithWidth(disp, prefix, 25, width), nil
 }
 
 // messageEditorText returns only persisted text. Display-only reconstructions
@@ -1011,7 +1001,7 @@ func (cq *ChatHandler) selectMessagesAt(chat pub_models.Chat, onlyOneSelect bool
 	tb := table.New(
 		table.SlicePaginator(chat.Messages),
 		func(i int, t pub_models.Message) (string, error) {
-			return messagePickerRow(i, t)
+			return messagePickerRow(i, t, cq.dims.Width)
 		},
 	).
 		WithHeader(head).

--- a/internal/chat/handler_list_chat_test.go
+++ b/internal/chat/handler_list_chat_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/baalimago/clai/internal/utils"
 	"github.com/baalimago/clai/internal/vendors"
 	pub_models "github.com/baalimago/clai/pkg/text/models"
+	"github.com/baalimago/go_away_boilerplate/pkg/dimensions"
 )
 
 // chdirToTemp switches the working directory to a fresh temp dir for the duration
@@ -304,7 +305,7 @@ func TestMessagePickerRow_ShowsAssistantContent(t *testing.T) {
 			{Name: "cat", Inputs: &pub_models.Input{"file": "main.go"}},
 		},
 	}
-	row, err := messagePickerRow(2, toolTurn)
+	row, err := messagePickerRow(2, toolTurn, 80)
 	if err != nil {
 		t.Fatalf("messagePickerRow: %v", err)
 	}
@@ -313,7 +314,7 @@ func TestMessagePickerRow_ShowsAssistantContent(t *testing.T) {
 	}
 
 	textTurn := pub_models.Message{Role: "assistant", Content: "the answer is 42"}
-	row, err = messagePickerRow(3, textTurn)
+	row, err = messagePickerRow(3, textTurn, 80)
 	if err != nil {
 		t.Fatalf("messagePickerRow: %v", err)
 	}
@@ -610,15 +611,6 @@ func TestListChats_NarrowWidthShowsCostAndPrompt(t *testing.T) {
 			t.Fatalf("restore TTY: %v", err)
 		}
 	})
-	oldColumns := os.Getenv("COLUMNS")
-	if err := os.Setenv("COLUMNS", "100"); err != nil {
-		t.Fatalf("set COLUMNS: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Setenv("COLUMNS", oldColumns); err != nil {
-			t.Fatalf("restore COLUMNS: %v", err)
-		}
-	})
 
 	paginator, err := NewChatIndexPaginator(convDir)
 	if err != nil {
@@ -626,7 +618,9 @@ func TestListChats_NarrowWidthShowsCostAndPrompt(t *testing.T) {
 	}
 
 	var out strings.Builder
-	cq := &ChatHandler{confDir: confDir, convDir: convDir, out: &out}
+	// The narrow table is selected by the session snapshot width, not by the
+	// ambient COLUMNS variable (the ioctl is authoritative; R2-02).
+	cq := &ChatHandler{confDir: confDir, convDir: convDir, out: &out, dims: dimensions.Dimensions{Width: 100}}
 	err = cq.listChats(context.Background(), paginator, "")
 	if err == nil {
 		t.Fatal("listChats() error = nil, want error from empty selection input")

--- a/internal/chat/obfuscated_print.go
+++ b/internal/chat/obfuscated_print.go
@@ -63,7 +63,10 @@ const (
 	// Need at least: 1 (first user) + headTruncated + bridgeSample + tailTruncated + 1 (last) = 11
 )
 
-func printChatObfuscated(w io.Writer, ch pub_models.Chat, raw bool) error {
+// printChatObfuscated writes a heavily obfuscated preview of a chat to w.
+// width is the session's resolved terminal width: every truncation in this
+// render uses it, so one operation renders with one dimension set.
+func printChatObfuscated(w io.Writer, ch pub_models.Chat, raw bool, width int) error {
 	msgs := ch.Messages
 	msgCount := len(msgs)
 	if msgCount == 0 {
@@ -123,12 +126,9 @@ func printChatObfuscated(w io.Writer, ch pub_models.Chat, raw bool) error {
 			prefix := table.Colorize(utils.TableTheme().Primary, fmt.Sprintf("[#%-3d r: ", i)) +
 				table.Colorize(utils.RoleColor(m.Role), fmt.Sprintf("%-9s", m.Role)) +
 				table.Colorize(utils.TableTheme().Primary, fmt.Sprintf(" l: %5d]: ", lenRunes))
-			trunc, err := table.WidthAppropriateStringTruncColored(
-				messageDisplayText(m), prefix, "", utils.TableTheme().Breadtext, 5,
+			trunc := table.WidthAppropriateStringTruncColoredWithWidth(
+				messageDisplayText(m), prefix, "", utils.TableTheme().Breadtext, 5, width,
 			)
-			if err != nil {
-				return fmt.Errorf("truncate bridge preview: %w", err)
-			}
 			if _, err := fmt.Fprintln(w, trunc); err != nil {
 				return fmt.Errorf("write bridge line: %w", err)
 			}

--- a/internal/chat/obfuscated_print_test.go
+++ b/internal/chat/obfuscated_print_test.go
@@ -34,7 +34,7 @@ func TestPrintChatObfuscated_NO_COLOR_disablesAllColor(t *testing.T) {
 	}}
 
 	var b strings.Builder
-	if err := printChatObfuscated(&b, ch, false); err != nil {
+	if err := printChatObfuscated(&b, ch, false, 80); err != nil {
 		t.Fatalf("printChatObfuscated: %v", err)
 	}
 	got := b.String()
@@ -64,7 +64,7 @@ func TestPrintChatObfuscated_coloriziesPrefix(t *testing.T) {
 	ch := pub_models.Chat{Messages: msgs}
 
 	var b strings.Builder
-	if err := printChatObfuscated(&b, ch, false); err != nil {
+	if err := printChatObfuscated(&b, ch, false, 80); err != nil {
 		t.Fatalf("printChatObfuscated: %v", err)
 	}
 	got := b.String()
@@ -228,7 +228,7 @@ func TestPrintChatObfuscated_RendersToolCallTurns(t *testing.T) {
 	}
 
 	var b strings.Builder
-	if err := printChatObfuscated(&b, chat, true); err != nil {
+	if err := printChatObfuscated(&b, chat, true, 80); err != nil {
 		t.Fatalf("printChatObfuscated: %v", err)
 	}
 	if !strings.Contains(b.String(), "Call: 'ls'") {
@@ -259,7 +259,7 @@ func TestPrintChatObfuscated_RendersReasoningContentInOldMessages(t *testing.T) 
 	}
 
 	var b strings.Builder
-	if err := printChatObfuscated(&b, pub_models.Chat{ID: "c3", Messages: msgs}, true); err != nil {
+	if err := printChatObfuscated(&b, pub_models.Chat{ID: "c3", Messages: msgs}, true, 80); err != nil {
 		t.Fatalf("printChatObfuscated: %v", err)
 	}
 	got := b.String()
@@ -295,7 +295,7 @@ func TestPrintChatObfuscated_NewFormat_LongChat(t *testing.T) {
 	msgs[19] = pub_models.Message{Role: "assistant", Content: "LAST_MSG_FULL"}
 
 	var b strings.Builder
-	if err := printChatObfuscated(&b, pub_models.Chat{ID: "c-long", Messages: msgs}, true); err != nil {
+	if err := printChatObfuscated(&b, pub_models.Chat{ID: "c-long", Messages: msgs}, true, 80); err != nil {
 		t.Fatalf("printChatObfuscated: %v", err)
 	}
 	got := b.String()
@@ -347,7 +347,7 @@ func TestPrintChatObfuscated_NewFormat_ShortChat(t *testing.T) {
 	}
 
 	var b strings.Builder
-	if err := printChatObfuscated(&b, pub_models.Chat{ID: "c-short", Messages: msgs}, true); err != nil {
+	if err := printChatObfuscated(&b, pub_models.Chat{ID: "c-short", Messages: msgs}, true, 80); err != nil {
 		t.Fatalf("printChatObfuscated: %v", err)
 	}
 	got := b.String()

--- a/internal/photo/funimation_0.go
+++ b/internal/photo/funimation_0.go
@@ -2,22 +2,21 @@ package photo
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
-	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
-	"github.com/baalimago/go_away_boilerplate/pkg/table"
+	"github.com/baalimago/clai/internal/utils"
 )
 
 func StartAnimation() func() {
 	t0 := time.Now()
 	ticker := time.NewTicker(time.Second / 60)
 	stop := make(chan struct{})
-	termWidth, err := table.TermWidth()
-	if err != nil {
-		ancli.PrintWarn(fmt.Sprintf("failed to get terminal size: %v\n", err))
-		termWidth = 100
-	}
+	// The animation clears the current row with spaces, so it needs the width
+	// of the file it actually writes to: stdout. A non-terminal stdout yields
+	// the deterministic fallback width.
+	termWidth := utils.SessionDimensions(os.Stdout).Width
 	go func() {
 		for {
 			select {

--- a/internal/text/querier.go
+++ b/internal/text/querier.go
@@ -13,6 +13,7 @@ import (
 	pub_models "github.com/baalimago/clai/pkg/text/models"
 	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
 	"github.com/baalimago/go_away_boilerplate/pkg/debug"
+	"github.com/baalimago/go_away_boilerplate/pkg/dimensions"
 	"github.com/baalimago/go_away_boilerplate/pkg/table"
 )
 
@@ -22,12 +23,18 @@ const (
 )
 
 type Querier[C models.StreamCompleter] struct {
-	Raw                     bool
-	structuredOutput        bool
-	chat                    pub_models.Chat
-	callStackLevel          int
-	username                string
-	termWidth               int
+	Raw              bool
+	structuredOutput bool
+	outputModeKnown  bool
+	outputIsTerminal bool
+	chat             pub_models.Chat
+	callStackLevel   int
+	username         string
+	// dims is the one terminal-dimensions snapshot of this interactive output
+	// session. It is resolved once in NewQuerier from the session writer's fd;
+	// every width-aware render path of the querier reads this value. The
+	// snapshot is always usable: a failed read yields dimensions.Fallback.
+	dims                    dimensions.Dimensions
 	lineCount               int
 	line                    string
 	fullMsg                 string
@@ -56,11 +63,16 @@ type Querier[C models.StreamCompleter] struct {
 	// TextQuery call that does not already carry a system message.
 	systemPrompt string
 
-	// reasoningBuf accumulates thinking/chain-of-thought tokens streamed
-	// before the final answer.  It is wrapped in [thinking]…[/thinking]
-	// when displayed.
-	reasoningBuf    strings.Builder
-	reasoningActive bool
+	// reasoningBuf preserves source reasoning for the session and model. The
+	// activity viewport is a separate, bounded terminal-only copy.
+	reasoningBuf     strings.Builder
+	reasoningActive  bool
+	activityViewport *utils.ActivityViewport
+	// finalAnswerPopPending marks that the trailing assistant-prose block was
+	// removed from the viewport state at stream end. The window redraws (and
+	// the answer prints below it) only when the finalizer prints the answer,
+	// so the terminal paints the pop and the reprint as one transition.
+	finalAnswerPopPending bool
 
 	// Output of the querier. This is used mostly when Querier is invoked as an agent
 	out io.Writer
@@ -89,7 +101,7 @@ type Querier[C models.StreamCompleter] struct {
 }
 
 func (q *Querier[C]) SuppressCompletionNotification() bool {
-	return q.structuredOutput
+	return q.structuredOutput || (q.outputModeKnown && !q.outputIsTerminal)
 }
 
 type SkillLoader interface {
@@ -111,12 +123,32 @@ type LoadedSkillRuntime struct {
 
 func (q *Querier[C]) postProcessOutput(newSysMsg pub_models.Message) {
 	// The token should already have been printed while streamed
-	if q.Raw {
+	if q.rawDisplay() {
+		if q.debug {
+			w := q.out
+			if w == nil {
+				w = os.Stdout
+			}
+			fmt.Fprintln(w, newSysMsg.Content)
+		}
 		return
 	}
-
-	if q.termWidth > 0 {
-		utils.UpdateMessageTerminalMetadata(newSysMsg.Content, &q.line, &q.lineCount, q.termWidth)
+	if q.activityViewport != nil {
+		// Rolling window: the final answer was removed from the window at stream
+		// end. Redraw the window (without the answer) and print the answer below
+		// it back-to-back, so the terminal shows one transition. When no pop is
+		// pending, the assistant text already lives inside the window
+		// (intermediate prose before tool calls) and must never be re-printed.
+		if q.finalAnswerPopPending {
+			if err := q.activityViewport.Render(q.out); err != nil {
+				ancli.Warnf("failed to redraw activity viewport before final answer: %v", err)
+			}
+			utils.AttemptPrettyPrint(q.out, newSysMsg, q.username, q.Raw)
+		}
+		return
+	}
+	if q.dims.Width > 0 {
+		utils.UpdateMessageTerminalMetadata(newSysMsg.Content, &q.line, &q.lineCount, q.dims.Width)
 		// Write the details of q to the file determined by the environment variable DEBUG_OUTPUT_FILE
 		if debugOutputFile := os.Getenv("DEBUG_OUTPUT_FILE"); debugOutputFile != "" {
 			file, err := os.Create(debugOutputFile)
@@ -133,7 +165,7 @@ func (q *Querier[C]) postProcessOutput(newSysMsg pub_models.Message) {
 					FullMessage: q.fullMsg,
 					Line:        q.line,
 					LineCount:   q.lineCount,
-					TermWidth:   q.termWidth,
+					TermWidth:   q.dims.Width,
 				}))
 				if err != nil {
 					ancli.PrintErr(fmt.Sprintf("failed to write to debug output file: %v\n", err))
@@ -151,7 +183,7 @@ func (q *Querier[C]) postProcess() {
 	session := &QuerySession{
 		Chat:               q.chat,
 		ShouldSaveReply:    q.shouldSaveReply,
-		Raw:                q.Raw,
+		Raw:                q.rawDisplay(),
 		FinalAssistantText: q.fullMsg,
 		FinalUsage:         q.chat.TokenUsage,
 		Finalized:          q.hasPrinted,
@@ -173,6 +205,8 @@ func (q *Querier[C]) resetTransientState() {
 	q.hasPrinted = false
 	q.reasoningBuf.Reset()
 	q.reasoningActive = false
+	q.activityViewport = nil
+	q.finalAnswerPopPending = false
 }
 
 func (q *Querier[C]) handleToken(token string) {
@@ -186,7 +220,7 @@ func (q *Querier[C]) handleToken(token string) {
 	}
 }
 
-func (q *Querier[C]) handleTokenForSession(session *QuerySession, token string) {
+func (q *Querier[C]) handleTokenForSession(session *QuerySession, token string) error {
 	w := q.out
 	if w == nil {
 		w = os.Stdout
@@ -194,26 +228,94 @@ func (q *Querier[C]) handleTokenForSession(session *QuerySession, token string) 
 	session.AppendPendingText(token)
 	q.fullMsg = session.PendingTextString()
 	if !q.debug && !q.structuredOutput {
+		if q.usesActivityViewport() && q.activityViewport != nil {
+			q.activityViewport.AppendText(token)
+			if err := q.activityViewport.Render(w); err != nil {
+				return fmt.Errorf("render activity viewport: %w", err)
+			}
+			return nil
+		}
 		fmt.Fprint(w, token)
 	}
+	return nil
 }
 
-// closeReasoningIfOpen prints the closing [/thinking] tag and prepends the
-// wrapped reasoning block to session.PendingText so it survives terminal
-// line-clearing and gets re-printed by the pretty-printer.
+func (q *Querier[C]) usesActivityViewport() bool {
+	return utils.RollingOutputEnabled() && !q.rawDisplay() && !q.debug && !q.structuredOutput
+}
+
+// ensureActivityViewport lazily creates the rolling activity window at the
+// session's current dimensions snapshot. A resize can arrive before the first
+// reasoning or tool event; the snapshot already carries the fresh size then
+// (applyResize updates q.dims first), so the first render uses the new
+// dimensions immediately. The initial effective height is bound to
+// min(configured cap, terminal height) at creation, so the first frame never
+// exceeds the terminal even without a resize (R5-01).
+func (q *Querier[C]) ensureActivityViewport() *utils.ActivityViewport {
+	if q.activityViewport == nil {
+		q.activityViewport = utils.NewActivityViewport(q.dims.Width, utils.RollingOutputWindowCellHeight(), q.dims.Height)
+	}
+	return q.activityViewport
+}
+
+// startResizeWatcher starts one dimensions watcher for terminal
+// rolling-output sessions. It binds to the session writer's fd, the file clai
+// actually writes to, so the observed size matches the output target. The
+// watcher starts exactly when usesActivityViewport holds and the writer is an
+// *os.File; non-rolling, non-terminal, and non-file sessions get a nil
+// channel and a no-op stop and keep today's one-shot q.dims read. The stop
+// function is idempotent and must be called once per started watcher; it
+// releases the process-wide SIGWINCH registration.
+func (q *Querier[C]) startResizeWatcher(ctx context.Context) (<-chan dimensions.Dimensions, func()) {
+	if !q.usesActivityViewport() {
+		return nil, func() {}
+	}
+	f, ok := q.out.(*os.File)
+	if !ok {
+		return nil, func() {}
+	}
+	viewer := dimensions.New(ctx, f.Fd())
+	return viewer.Events(), viewer.Stop
+}
+
+// rawDisplay makes output to pipes, files, and other non-terminal writers
+// identical to explicit raw mode.
+func (q *Querier[C]) rawDisplay() bool {
+	return q.Raw || (q.outputModeKnown && !q.outputIsTerminal)
+}
+
+// closeReasoningIfOpen finishes the display viewport and persists the complete
+// source reasoning separately from assistant text.
 func (q *Querier[C]) closeReasoningIfOpen(session *QuerySession) {
 	if !q.reasoningActive {
 		return
 	}
 	q.reasoningActive = false
+	if q.usesActivityViewport() {
+		session.PendingReasoning.WriteString(q.reasoningBuf.String())
+		q.fullMsg = session.PendingTextString()
+		q.reasoningBuf.Reset()
+		q.activityViewport.FinishReasoning()
+		return
+	}
 	if !q.debug && !q.structuredOutput {
 		w := q.out
 		if w == nil {
 			w = os.Stdout
 		}
-		fmt.Fprint(w, table.Colorize(utils.RoleColor("reasoning"), "\n[/thinking]\n"))
+		if q.rawDisplay() {
+			fmt.Fprint(w, "\n[/thinking]\n")
+		} else {
+			fmt.Fprint(w, table.Colorize(utils.RoleColor("reasoning"), "\n[/thinking]\n"))
+		}
 	}
 	if q.structuredOutput {
+		session.PendingReasoning.WriteString(q.reasoningBuf.String())
+		q.fullMsg = session.PendingTextString()
+		q.reasoningBuf.Reset()
+		return
+	}
+	if !utils.RollingOutputEnabled() && !q.rawDisplay() && !q.debug {
 		session.PendingReasoning.WriteString(q.reasoningBuf.String())
 		q.fullMsg = session.PendingTextString()
 		q.reasoningBuf.Reset()
@@ -248,6 +350,19 @@ func (q *Querier[C]) currentTokenUsage() *pub_models.Usage {
 	return tokenCounter.TokenUsage()
 }
 
+// prepareFinalAnswerPop removes the trailing assistant-prose block from the
+// rolling window state at stream end without redrawing. The window still shows
+// the answer until postProcessOutput redraws it immediately before the answer
+// prints below, so the terminal paints the transition in one frame.
+func (q *Querier[C]) prepareFinalAnswerPop() {
+	if q.activityViewport == nil || !q.usesActivityViewport() {
+		return
+	}
+	if q.activityViewport.RemoveTextBlock() > 0 {
+		q.finalAnswerPopPending = true
+	}
+}
+
 // Query using the underlying model to stream completions and then print the output
 // from the model to stdout. Blocking operation.
 func (q *Querier[C]) Query(ctx context.Context) error {
@@ -255,10 +370,16 @@ func (q *Querier[C]) Query(ctx context.Context) error {
 	if q.out == nil {
 		q.out = os.Stdout
 	}
+	// One dimensions watcher for terminal rolling-output sessions. It observes
+	// the same file the session writes to; the runner consumes fresh snapshots
+	// in the serialized streaming loop. Non-rolling and non-terminal sessions
+	// keep the one-shot q.dims read and never start a signal registration.
+	resizeEvents, stopResizeWatcher := q.startResizeWatcher(ctx)
+	defer stopResizeWatcher()
 	session := &QuerySession{
 		Chat:            q.chat,
 		ShouldSaveReply: q.shouldSaveReply,
-		Raw:             q.Raw,
+		Raw:             q.rawDisplay(),
 		Line:            q.line,
 		LineCount:       q.lineCount,
 	}
@@ -268,6 +389,7 @@ func (q *Querier[C]) Query(ctx context.Context) error {
 		toolExecutor: toolExecutor[C]{querier: q},
 		finalizer:    sessionFinalizer[C]{querier: q},
 		stoploss:     q.newStoploss(),
+		resizeEvents: resizeEvents,
 	}
 	err := runner.Run(ctx, session)
 	q.chat = session.Chat
@@ -277,6 +399,9 @@ func (q *Querier[C]) Query(ctx context.Context) error {
 	q.hasPrinted = session.Finalized
 	q.amToolCalls = session.ToolCallsUsed
 	q.isLikelyGemini3Preview = session.LikelyGeminiPreview
+	// The final answer pop is consumed by the finalizer's postProcessOutput
+	// inside Run; it must not leak into the next query.
+	q.finalAnswerPopPending = false
 	return err
 }
 

--- a/internal/text/querier_setup.go
+++ b/internal/text/querier_setup.go
@@ -20,7 +20,6 @@ import (
 	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
 	"github.com/baalimago/go_away_boilerplate/pkg/debug"
 	"github.com/baalimago/go_away_boilerplate/pkg/misc"
-	"github.com/baalimago/go_away_boilerplate/pkg/table"
 )
 
 // CanonicalModelString is the inverse of vendorType. Given a (vendor, family, modelVersion)
@@ -204,14 +203,6 @@ func NewQuerier[C models.StreamCompleter](ctx context.Context, userConf Configur
 	}
 
 	traceChatf("post setup")
-	termWidth, err := table.TermWidth()
-	if err == nil {
-		querier.termWidth = termWidth
-	} else {
-		if querier.debug {
-			ancli.PrintWarn(fmt.Sprintf("failed to get terminal size: %v\n", err))
-		}
-	}
 	currentUser, err := user.Current()
 	if err == nil {
 		querier.username = currentUser.Username
@@ -229,6 +220,12 @@ func NewQuerier[C models.StreamCompleter](ctx context.Context, userConf Configur
 	// Ensure profile selection is persisted in globalScope/saved conversations.
 	querier.chat.Profile = userConf.UseProfile
 	querier.Raw = userConf.Raw
+	output := userConf.Out
+	if output == nil {
+		output = os.Stdout
+	}
+	querier.outputModeKnown = true
+	querier.outputIsTerminal = utils.IsTerminalWriter(output)
 	querier.structuredOutput = userConf.ResponseFormat != nil
 	querier.shouldSaveReply = !userConf.ChatMode && userConf.SaveReplyAsConv
 	querier.replyMode = userConf.ReplyMode
@@ -238,7 +235,13 @@ func NewQuerier[C models.StreamCompleter](ctx context.Context, userConf Configur
 	querier.toolOutputRuneLimit = userConf.ToolOutputRuneLimit
 	querier.maxToolCalls = userConf.MaxToolCalls
 	querier.stoploss = userConf.Stoploss
-	querier.out = userConf.Out
+	querier.out = output
+	// One dimensions snapshot per interactive output session, bound to the
+	// writer's fd: the observed size matches the file clai actually writes to
+	// (R2-02). A non-terminal writer or a failed read yields the deterministic
+	// dimensions.Fallback, so no width-aware path ever queries the terminal
+	// again.
+	querier.dims = utils.SessionDimensions(output)
 	querier.skillLoader = userConf.SkillLoader
 	querier.baseTools = userConf.BaseTools
 	querier.registeredTools = userConf.RegisteredTools

--- a/internal/text/querier_setup_test.go
+++ b/internal/text/querier_setup_test.go
@@ -1,6 +1,15 @@
 package text
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/baalimago/go_away_boilerplate/pkg/dimensions"
+)
 
 func TestVendorType_OpenRouter(t *testing.T) {
 	vendor, model, modelVersion, err := vendorType("or:openai/gpt-5.2")
@@ -119,5 +128,44 @@ func TestCanonicalModelString_FromConfigFilename(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("CanonicalModelString(%q, %q, %q) = %q, want %q", tt.vendor, tt.family, tt.modelVersion, got, tt.want)
 		}
+	}
+}
+
+// Test_Querier_NewQuerier_dimsBoundToOutputWriter proves the phase-3 snapshot
+// wiring: NewQuerier resolves one dimensions snapshot from the session output
+// writer's fd (R2-02). A non-terminal writer must not fail the querier setup;
+// it deterministically yields dimensions.Fallback, so every width-aware render
+// path of the querier reads one usable value.
+func Test_Querier_NewQuerier_dimsBoundToOutputWriter(t *testing.T) {
+	// Avoid races with the cost manager error logger goroutine in NewQuerier.
+	t.Setenv("CLAI_DISABLE_COST_ERR_LOG_GOROUTINE", "1")
+
+	model := "mock"
+	tmpDir := t.TempDir()
+	if err := os.Mkdir(path.Join(tmpDir, ".clai"), os.FileMode(0o755)); err != nil {
+		t.Fatalf("mkdir .clai: %v", err)
+	}
+	saved, err := json.Marshal(MockQuerier{Somefield: "somevalue"})
+	if err != nil {
+		t.Fatalf("marshal mock: %v", err)
+	}
+	if err := os.WriteFile(path.Join(tmpDir, ".clai", "mock_mock_mock.json"), saved, os.FileMode(0o755)); err != nil {
+		t.Fatalf("write mock config: %v", err)
+	}
+
+	conf := Configurations{
+		Model:     model,
+		ConfigDir: path.Join(tmpDir, ".clai"),
+		Out:       &strings.Builder{},
+	}
+	q, err := NewQuerier(context.Background(), conf, &MockQuerier{})
+	if err != nil {
+		t.Fatalf("NewQuerier with non-terminal output: %v", err)
+	}
+	if q.dims != dimensions.Fallback {
+		t.Fatalf("dims = %+v, want fallback %+v for a non-terminal session writer", q.dims, dimensions.Fallback)
+	}
+	if q.out == nil {
+		t.Fatal("querier output writer must be set")
 	}
 }

--- a/internal/text/querier_test.go
+++ b/internal/text/querier_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/baalimago/clai/internal/models"
 	inttools "github.com/baalimago/clai/internal/tools"
 	pub_models "github.com/baalimago/clai/pkg/text/models"
+	"github.com/baalimago/go_away_boilerplate/pkg/dimensions"
 	"github.com/baalimago/go_away_boilerplate/pkg/testboil"
 )
 
@@ -126,6 +127,70 @@ func Test_Querier_TextQuery_SystemPrompt(t *testing.T) {
 			t.Fatalf("expected user message, got %q", capturedChat.Messages[0].Role)
 		}
 	})
+}
+
+func Test_Querier_Query_DebugRedirectedOutputPrintsFinalAssistantAnswer(t *testing.T) {
+	var printed strings.Builder
+	q := &Querier[*MockQuerier]{
+		debug:            true,
+		out:              &printed,
+		outputModeKnown:  true,
+		outputIsTerminal: false,
+		Model: &MockQuerier{
+			streamFn: func(context.Context, pub_models.Chat) (chan models.CompletionEvent, error) {
+				out := make(chan models.CompletionEvent, 1)
+				out <- "final answer"
+				close(out)
+				return out, nil
+			},
+		},
+	}
+
+	if err := q.Query(context.Background()); err != nil {
+		t.Fatalf("Query() error = %v", err)
+	}
+	if got, want := printed.String(), "\nfinal answer\n"; got != want {
+		t.Fatalf("redirected debug output = %q, want %q", got, want)
+	}
+}
+
+func Test_Querier_SuppressCompletionNotification(t *testing.T) {
+	tests := []struct {
+		name string
+		q    Querier[*MockQuerier]
+		want bool
+	}{
+		{
+			name: "terminal output",
+			q: Querier[*MockQuerier]{
+				outputModeKnown:  true,
+				outputIsTerminal: true,
+			},
+		},
+		{
+			name: "redirected output",
+			q: Querier[*MockQuerier]{
+				outputModeKnown:  true,
+				outputIsTerminal: false,
+			},
+			want: true,
+		},
+		{
+			name: "structured output",
+			q: Querier[*MockQuerier]{
+				structuredOutput: true,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.q.SuppressCompletionNotification(); got != tt.want {
+				t.Fatalf("SuppressCompletionNotification() = %t, want %t", got, tt.want)
+			}
+		})
+	}
 }
 
 func (s stubTool) Call(pub_models.Input) (string, error) {
@@ -385,7 +450,7 @@ func Test_Querier_eventHandling(t *testing.T) {
 			},
 			{
 				desc: "it should call test function when asked to",
-				q:    Querier[*MockQuerier]{out: &strings.Builder{}},
+				q:    Querier[*MockQuerier]{out: &strings.Builder{}, dims: dimensions.Dimensions{Width: 80, Height: 24}},
 				run: func(t *testing.T, q *Querier[*MockQuerier]) string {
 					t.Helper()
 					call := pub_models.Call{
@@ -397,7 +462,7 @@ func Test_Querier_eventHandling(t *testing.T) {
 					if err := q.doToolCallLogic(context.Background(), call); err != nil {
 						t.Fatalf("doToolCallLogic returned err: %v", err)
 					}
-					return "Call: 'test', inputs: [ 'testKey': 'testVal' ]"
+					return "▸ test  testKey=testVal"
 				},
 			},
 		}

--- a/internal/text/querier_tool.go
+++ b/internal/text/querier_tool.go
@@ -60,7 +60,7 @@ func (q *Querier[C]) doToolCallLogic(ctx context.Context, call pub_models.Call) 
 	session := &QuerySession{
 		Chat:            q.chat,
 		ShouldSaveReply: q.shouldSaveReply,
-		Raw:             q.Raw,
+		Raw:             q.rawDisplay(),
 		ToolCallsUsed:   q.amToolCalls,
 	}
 	err := toolExecutor[C]{querier: q}.Execute(ctx, session, call)

--- a/internal/text/querier_tool_test.go
+++ b/internal/text/querier_tool_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/baalimago/clai/internal/models"
 	internaltools "github.com/baalimago/clai/internal/tools"
 	pub_models "github.com/baalimago/clai/pkg/text/models"
+	"github.com/baalimago/go_away_boilerplate/pkg/dimensions"
 	"github.com/baalimago/go_away_boilerplate/pkg/testboil"
 )
 
@@ -180,7 +181,7 @@ func Test_toolExecutor_Execute_EmptyNonAsyncToolOutputBecomesDescriptiveMessage(
 func Test_toolExecutor_Execute_LargeToolOutputStoresTranscriptButCompactsDisplay(t *testing.T) {
 	internaltools.Init()
 	var printed bytes.Buffer
-	q := Querier[*MockQuerier]{out: &printed, toolOutputRuneLimit: 10000}
+	q := Querier[*MockQuerier]{out: &printed, toolOutputRuneLimit: 10000, dims: dimensions.Dimensions{Width: 80, Height: 24}}
 	session := &QuerySession{}
 	dir := t.TempDir()
 	for i := range 20 {
@@ -207,7 +208,7 @@ func Test_toolExecutor_Execute_LargeToolOutputStoresTranscriptButCompactsDisplay
 func Test_toolExecutor_EmitToolResult_CompactsMCPOutputAndRetainsTranscript(t *testing.T) {
 	t.Setenv("NO_COLOR", "true")
 	var printed bytes.Buffer
-	q := Querier[*MockQuerier]{out: &printed, termWidth: 80}
+	q := Querier[*MockQuerier]{out: &printed, dims: dimensions.Dimensions{Width: 80, Height: 24}}
 	session := &QuerySession{}
 	out := "mcp_result\n" + strings.Repeat("a long result row\n", 20)
 	call := pub_models.Call{ID: "call-1", Name: "mcp_server_tool"}
@@ -220,6 +221,21 @@ func Test_toolExecutor_EmitToolResult_CompactsMCPOutputAndRetainsTranscript(t *t
 	}
 	if got := session.Chat.Messages[0].Content; got != out {
 		t.Fatalf("expected full bounded MCP result in transcript, got %q", got)
+	}
+}
+
+func Test_toolExecutor_EmitToolResult_RawDisplayKeepsCompleteResult(t *testing.T) {
+	var printed bytes.Buffer
+	q := Querier[*MockQuerier]{Raw: true, out: &printed, toolOutputRuneLimit: 4}
+	session := &QuerySession{}
+	result := "complete tool result"
+	call := pub_models.Call{ID: "call-1", Name: "test"}
+
+	if err := (toolExecutor[*MockQuerier]{querier: &q}).emitToolResult(session, call, result); err != nil {
+		t.Fatalf("emitToolResult() error = %v", err)
+	}
+	if got := printed.String(); !strings.Contains(got, result) {
+		t.Fatalf("raw display must keep complete result, got %q", got)
 	}
 }
 
@@ -244,7 +260,7 @@ func Test_toolExecutor_ExecuteLoadSkill_PrintsSummary(t *testing.T) {
 func Test_toolExecutor_ExecuteLoadSkill_TruncatesUserVisibleOutputUnlessRaw(t *testing.T) {
 	t.Run("non_raw", func(t *testing.T) {
 		var out bytes.Buffer
-		q := Querier[*MockQuerier]{out: &out, skillLoader: fakeSkillLoader{
+		q := Querier[*MockQuerier]{out: &out, dims: dimensions.Dimensions{Width: 80, Height: 24}, skillLoader: fakeSkillLoader{
 			loaded: LoadedSkillRuntime{
 				Name:         "review",
 				SourceClass:  "default",

--- a/internal/text/querier_tool_test.go
+++ b/internal/text/querier_tool_test.go
@@ -177,7 +177,7 @@ func Test_toolExecutor_Execute_EmptyNonAsyncToolOutputBecomesDescriptiveMessage(
 	}
 }
 
-func Test_toolExecutor_Execute_LargeToolOutputStoresTruncatedTranscriptButShortensPrettyPrint(t *testing.T) {
+func Test_toolExecutor_Execute_LargeToolOutputStoresTranscriptButCompactsDisplay(t *testing.T) {
 	internaltools.Init()
 	var printed bytes.Buffer
 	q := Querier[*MockQuerier]{out: &printed, toolOutputRuneLimit: 10000}
@@ -196,8 +196,30 @@ func Test_toolExecutor_Execute_LargeToolOutputStoresTruncatedTranscriptButShorte
 		t.Fatalf("Execute() error = %v", err)
 	}
 	printedStr := printed.String()
-	if !strings.Contains(printedStr, "...[and ") {
-		t.Fatalf("expected pretty print to shorten tool output, got %q", printedStr)
+	if !strings.Contains(printedStr, "terminal rows omitted") {
+		t.Fatalf("expected compact tool output marker, got %q", printedStr)
+	}
+	if got := session.Chat.Messages[len(session.Chat.Messages)-1].Content; !strings.Contains(got, "file-19-with-long-name.txt") {
+		t.Fatalf("expected complete bounded output in transcript, got %q", got)
+	}
+}
+
+func Test_toolExecutor_EmitToolResult_CompactsMCPOutputAndRetainsTranscript(t *testing.T) {
+	t.Setenv("NO_COLOR", "true")
+	var printed bytes.Buffer
+	q := Querier[*MockQuerier]{out: &printed, termWidth: 80}
+	session := &QuerySession{}
+	out := "mcp_result\n" + strings.Repeat("a long result row\n", 20)
+	call := pub_models.Call{ID: "call-1", Name: "mcp_server_tool"}
+
+	if err := (toolExecutor[*MockQuerier]{querier: &q}).emitToolResult(session, call, out); err != nil {
+		t.Fatalf("emitToolResult() error = %v", err)
+	}
+	if got := printed.String(); !strings.Contains(got, "terminal rows omitted") {
+		t.Fatalf("expected MCP output to be compacted, got %q", got)
+	}
+	if got := session.Chat.Messages[0].Content; got != out {
+		t.Fatalf("expected full bounded MCP result in transcript, got %q", got)
 	}
 }
 

--- a/internal/text/resize_runner_test.go
+++ b/internal/text/resize_runner_test.go
@@ -1,0 +1,733 @@
+package text
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/baalimago/clai/internal/models"
+	"github.com/baalimago/clai/internal/utils"
+	pub_models "github.com/baalimago/clai/pkg/text/models"
+	"github.com/baalimago/go_away_boilerplate/pkg/dimensions"
+)
+
+// withRollingTheme loads the default theme (rolling output enabled) and
+// restores the previous theme after the test. Tests in this package mutate
+// the process-global theme, so every phase-5 test pins its own theme.
+func withRollingTheme(t *testing.T) {
+	t.Helper()
+	confDir := withEmptyClaiConfigDir(t)
+	if err := utils.LoadTheme(confDir); err != nil {
+		t.Fatalf("LoadTheme(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := utils.LoadTheme(t.TempDir()); err != nil {
+			t.Errorf("reset theme: %v", err)
+		}
+	})
+}
+
+// waitFor polls cond until it holds or the timeout expires. The polling
+// interval keeps -race runs deterministic without busy-spinning.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("condition not met within %v", timeout)
+}
+
+// syncBuffer is a mutex-guarded strings.Builder. The session loop renders into
+// it from its own goroutine while the test observes the streaming output.
+type syncBuffer struct {
+	mu sync.Mutex
+	b  strings.Builder
+}
+
+func (w *syncBuffer) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.b.Write(p)
+}
+
+func (w *syncBuffer) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.b.String()
+}
+
+// wideContent is a 100-column line that wraps to one row at width 80 and to
+// three rows at width 40, so tests can tell the wrap width apart.
+const wideContent = "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+
+// wrappedRow is the exact first body row of a wrapped wideContent block at the
+// given viewport width, terminated by the row's newline. The terminating
+// newline makes the marker unambiguous: at width 50 the row is 48 columns
+// long, so a 38-column marker without the newline would match its prefix.
+func wrappedRow(width int) string {
+	return "  " + wideContent[:width-2] + "\n"
+}
+
+// Test_sessionRunner_Run_ResizeDuringStreamingRewrapsRollingOutput proves the
+// acceptance criterion "a simulated SIGWINCH changes rolling output dimensions
+// during streaming": the reasoning first renders at width 80, a resize event
+// rewraps the retained block and redraws the window at width 40, and the
+// trailing token renders at the new width.
+func Test_sessionRunner_Run_ResizeDuringStreamingRewrapsRollingOutput(t *testing.T) {
+	withRollingTheme(t)
+	proceed := make(chan struct{})
+	model := &MockQuerier{}
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		out := make(chan models.CompletionEvent, 4)
+		go func() {
+			out <- models.ReasoningEvent{Content: wideContent}
+			<-proceed
+			out <- "done"
+			close(out)
+		}()
+		return out, nil
+	}
+
+	var printed syncBuffer
+	resizeEvents := make(chan dimensions.Dimensions, 4)
+	q := &Querier[*MockQuerier]{
+		out:   &printed,
+		dims:  dimensions.Dimensions{Width: 80, Height: 10},
+		Model: model,
+	}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    &countingFinalizer{},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+		resizeEvents: resizeEvents,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(context.Background(), session) }()
+
+	row80 := wrappedRow(80)
+	row40 := wrappedRow(40)
+	waitFor(t, 2*time.Second, func() bool { return strings.Contains(printed.String(), row80) })
+
+	resizeEvents <- dimensions.Dimensions{Width: 40, Height: 10}
+	waitFor(t, 2*time.Second, func() bool {
+		return strings.Contains(stripANSIEscapes(printed.String()), row40)
+	})
+
+	close(proceed)
+	if err := <-done; err != nil {
+		t.Fatalf("Run returned err: %v", err)
+	}
+	if q.dims != (dimensions.Dimensions{Width: 40, Height: 10}) {
+		t.Fatalf("q.dims = %+v, want {40 10}", q.dims)
+	}
+	output := stripANSIEscapes(printed.String())
+	if !strings.Contains(output, "done") {
+		t.Fatalf("expected trailing token rendered after the resize, got:\n%s", output)
+	}
+}
+
+// Test_sessionRunner_Run_ResizeBurstConvergesOnLatestDimensions proves resize
+// bursts are safe and converge on the latest dimensions: three events arrive
+// back to back, each redraw is serialized on the session loop, and the last
+// event wins.
+func Test_sessionRunner_Run_ResizeBurstConvergesOnLatestDimensions(t *testing.T) {
+	withRollingTheme(t)
+	proceed := make(chan struct{})
+	model := &MockQuerier{}
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		out := make(chan models.CompletionEvent, 4)
+		go func() {
+			out <- models.ReasoningEvent{Content: wideContent}
+			<-proceed
+			out <- "done"
+			close(out)
+		}()
+		return out, nil
+	}
+
+	var printed syncBuffer
+	resizeEvents := make(chan dimensions.Dimensions, 4)
+	q := &Querier[*MockQuerier]{
+		out:   &printed,
+		dims:  dimensions.Dimensions{Width: 80, Height: 10},
+		Model: model,
+	}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    &countingFinalizer{},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+		resizeEvents: resizeEvents,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(context.Background(), session) }()
+
+	waitFor(t, 2*time.Second, func() bool { return strings.Contains(printed.String(), wrappedRow(80)) })
+
+	resizeEvents <- dimensions.Dimensions{Width: 60, Height: 10}
+	resizeEvents <- dimensions.Dimensions{Width: 50, Height: 10}
+	resizeEvents <- dimensions.Dimensions{Width: 40, Height: 10}
+	waitFor(t, 2*time.Second, func() bool {
+		return strings.Contains(stripANSIEscapes(printed.String()), wrappedRow(40))
+	})
+
+	close(proceed)
+	if err := <-done; err != nil {
+		t.Fatalf("Run returned err: %v", err)
+	}
+	if q.dims != (dimensions.Dimensions{Width: 40, Height: 10}) {
+		t.Fatalf("q.dims = %+v, want last event {40 10}", q.dims)
+	}
+}
+
+// Test_sessionRunner_Run_ResizeBeforeViewportCreationUsesNewDimensions proves
+// the R2-03 ordering: a resize arriving before the first reasoning event
+// updates the session snapshot, and the lazily created viewport renders at the
+// new width immediately — the 80-column row never appears.
+func Test_sessionRunner_Run_ResizeBeforeViewportCreationUsesNewDimensions(t *testing.T) {
+	withRollingTheme(t)
+	start := make(chan struct{})
+	proceed := make(chan struct{})
+	model := &MockQuerier{}
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		out := make(chan models.CompletionEvent, 4)
+		go func() {
+			<-start
+			out <- models.ReasoningEvent{Content: wideContent}
+			<-proceed
+			out <- "done"
+			close(out)
+		}()
+		return out, nil
+	}
+
+	var printed syncBuffer
+	resizeEvents := make(chan dimensions.Dimensions, 4)
+	q := &Querier[*MockQuerier]{
+		out:   &printed,
+		dims:  dimensions.Dimensions{Width: 80, Height: 10},
+		Model: model,
+	}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    &countingFinalizer{},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+		resizeEvents: resizeEvents,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(context.Background(), session) }()
+
+	// The stream emits nothing until the resize is consumed: the select's only
+	// ready case is the resize event, so the ordering is deterministic.
+	resizeEvents <- dimensions.Dimensions{Width: 40, Height: 10}
+	close(start)
+	waitFor(t, 2*time.Second, func() bool {
+		return strings.Contains(stripANSIEscapes(printed.String()), wrappedRow(40))
+	})
+
+	close(proceed)
+	if err := <-done; err != nil {
+		t.Fatalf("Run returned err: %v", err)
+	}
+	if q.dims != (dimensions.Dimensions{Width: 40, Height: 10}) {
+		t.Fatalf("q.dims = %+v, want {40 10}", q.dims)
+	}
+	output := stripANSIEscapes(printed.String())
+	if strings.Contains(output, wrappedRow(80)) {
+		t.Fatalf("first render must use the new width, got an 80-column row:\n%s", output)
+	}
+	if !strings.Contains(output, "done") {
+		t.Fatalf("expected final answer after the resize, got:\n%s", output)
+	}
+}
+
+// Test_sessionRunner_Run_ResizeKeepsToolTransitionAndFinalAnswerValid proves
+// the final answer and tool transitions remain valid after a resize: the
+// thinking/prose/tool order survives, the tool block renders, and the final
+// answer streams at the new width.
+func Test_sessionRunner_Run_ResizeKeepsToolTransitionAndFinalAnswerValid(t *testing.T) {
+	withRollingTheme(t)
+	step2Started := make(chan struct{})
+	releaseStep2 := make(chan struct{})
+	callCount := 0
+	model := &MockQuerier{}
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		callCount++
+		out := make(chan models.CompletionEvent, 8)
+		if callCount == 1 {
+			out <- models.ReasoningEvent{Content: wideContent}
+			out <- "I will run a tool."
+			out <- pub_models.Call{ID: "call-1", Name: "missing_tool"}
+			close(out)
+			return out, nil
+		}
+		close(step2Started)
+		go func() {
+			<-releaseStep2
+			out <- "done"
+			close(out)
+		}()
+		return out, nil
+	}
+
+	var printed syncBuffer
+	resizeEvents := make(chan dimensions.Dimensions, 4)
+	q := &Querier[*MockQuerier]{
+		out:   &printed,
+		dims:  dimensions.Dimensions{Width: 80, Height: 10},
+		Model: model,
+	}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    &countingFinalizer{},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+		resizeEvents: resizeEvents,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(context.Background(), session) }()
+
+	waitFor(t, 2*time.Second, func() bool {
+		select {
+		case <-step2Started:
+			return true
+		default:
+			return false
+		}
+	})
+	resizeEvents <- dimensions.Dimensions{Width: 40, Height: 10}
+	waitFor(t, 2*time.Second, func() bool {
+		return strings.Contains(stripANSIEscapes(printed.String()), wrappedRow(40))
+	})
+	close(releaseStep2)
+
+	if err := <-done; err != nil {
+		t.Fatalf("Run returned err: %v", err)
+	}
+	if q.dims != (dimensions.Dimensions{Width: 40, Height: 10}) {
+		t.Fatalf("q.dims = %+v, want {40 10}", q.dims)
+	}
+	if session.FinalAssistantText != "done" {
+		t.Fatalf("final answer = %q, want %q", session.FinalAssistantText, "done")
+	}
+	output := stripANSIEscapes(printed.String())
+	thinkingAt := strings.Index(output, "∴ thinking")
+	proseAt := strings.Index(output, "assistant\n  I will run a tool.")
+	toolAt := strings.Index(output, "▸ missing_tool")
+	if thinkingAt == -1 || proseAt == -1 || toolAt == -1 || !(thinkingAt < proseAt && proseAt < toolAt) {
+		t.Fatalf("expected thinking < assistant prose < tool after the resize, got:\n%s", output)
+	}
+	if !strings.Contains(output, "done") {
+		t.Fatalf("expected final answer rendered, got:\n%s", output)
+	}
+}
+
+// Test_sessionRunner_Run_InitialHeightBindsTerminalHeight proves R5-01 at the
+// session boundary: the lazily created viewport's first render is bounded by
+// min(cap, terminal height) even before any SIGWINCH. A 5-row terminal with
+// the default 30-row cap renders a 5-row window, not a 30-row window, so the
+// phase-4 acceptance criterion "effective height never exceeds terminal height
+// or configured cap" holds from the very first frame. The dropped middle rows
+// ("  line four" and earlier body rows) prove the window was compacted to the
+// terminal height, exactly the scenario that failed before the fix.
+func Test_sessionRunner_Run_InitialHeightBindsTerminalHeight(t *testing.T) {
+	withRollingTheme(t)
+	model := &MockQuerier{}
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		out := make(chan models.CompletionEvent, 4)
+		out <- models.ReasoningEvent{Content: "line one\nline two\nline three\nline four\nline five\nline six\nline seven\nline eight"}
+		out <- "done"
+		close(out)
+		return out, nil
+	}
+
+	var printed strings.Builder
+	q := &Querier[*MockQuerier]{
+		out:   &printed,
+		dims:  dimensions.Dimensions{Width: 80, Height: 5},
+		Model: model,
+	}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    &countingFinalizer{},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+	}
+
+	if err := runner.Run(context.Background(), session); err != nil {
+		t.Fatalf("Run returned err: %v", err)
+	}
+	output := stripANSIEscapes(printed.String())
+	if !strings.Contains(output, "∴ thinking") {
+		t.Fatalf("expected the reasoning window, got:\n%s", output)
+	}
+	if !strings.Contains(output, "  line eight") {
+		t.Fatalf("expected the trailing reasoning rows in the window, got:\n%s", output)
+	}
+	if strings.Contains(output, "  line four") {
+		t.Fatalf("first render must be bounded by the terminal height 5, got a taller window:\n%s", output)
+	}
+}
+
+// Test_sessionRunner_Run_NoWatcherFallsBackToOneShotRead proves the watcher
+// startup rejection path: a nil resizeEvents channel (non-rolling,
+// non-terminal, or non-file session) keeps today's one-shot q.dims read and
+// renders exactly as before, without starting partial cleanup.
+func Test_sessionRunner_Run_NoWatcherFallsBackToOneShotRead(t *testing.T) {
+	withRollingTheme(t)
+	model := &MockQuerier{}
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		out := make(chan models.CompletionEvent, 4)
+		out <- models.ReasoningEvent{Content: wideContent}
+		out <- "done"
+		close(out)
+		return out, nil
+	}
+
+	var printed strings.Builder
+	q := &Querier[*MockQuerier]{
+		out:   &printed,
+		dims:  dimensions.Dimensions{Width: 80, Height: 10},
+		Model: model,
+	}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    &countingFinalizer{},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+		// resizeEvents intentionally nil: the session must fall back to the
+		// one-shot snapshot.
+	}
+
+	if err := runner.Run(context.Background(), session); err != nil {
+		t.Fatalf("Run returned err: %v", err)
+	}
+	if q.dims != (dimensions.Dimensions{Width: 80, Height: 10}) {
+		t.Fatalf("q.dims = %+v, want unchanged {80 10}", q.dims)
+	}
+	output := stripANSIEscapes(printed.String())
+	if !strings.Contains(output, wrappedRow(80)) {
+		t.Fatalf("expected one-shot width-80 render, got:\n%s", output)
+	}
+	if !strings.Contains(output, "done") {
+		t.Fatalf("expected final answer, got:\n%s", output)
+	}
+}
+
+// Test_sessionRunner_Run_ResizeChannelClosedMidStreamKeepsStreaming proves the
+// termination path where the watcher stops while the stream still runs: the
+// closed channel nils out the resize case and the session finishes normally.
+func Test_sessionRunner_Run_ResizeChannelClosedMidStreamKeepsStreaming(t *testing.T) {
+	withRollingTheme(t)
+	proceed := make(chan struct{})
+	model := &MockQuerier{}
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		out := make(chan models.CompletionEvent, 4)
+		go func() {
+			out <- models.ReasoningEvent{Content: "inspect"}
+			<-proceed
+			out <- "done"
+			close(out)
+		}()
+		return out, nil
+	}
+
+	var printed syncBuffer
+	resizeEvents := make(chan dimensions.Dimensions, 1)
+	q := &Querier[*MockQuerier]{
+		out:   &printed,
+		dims:  dimensions.Dimensions{Width: 80, Height: 10},
+		Model: model,
+	}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    &countingFinalizer{},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+		resizeEvents: resizeEvents,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(context.Background(), session) }()
+
+	waitFor(t, 2*time.Second, func() bool { return strings.Contains(printed.String(), "∴ thinking") })
+	close(resizeEvents)
+	close(proceed)
+
+	if err := <-done; err != nil {
+		t.Fatalf("Run returned err: %v", err)
+	}
+	if q.dims != (dimensions.Dimensions{Width: 80, Height: 10}) {
+		t.Fatalf("q.dims = %+v, want unchanged {80 10}", q.dims)
+	}
+	if !strings.Contains(stripANSIEscapes(printed.String()), "done") {
+		t.Fatalf("expected the stream to finish after the watcher closed, got:\n%s", printed.String())
+	}
+}
+
+// Test_sessionRunner_Run_StreamEndsWhileResizePendingNoLateRedraw proves the
+// termination race: a notification that arrives after the stream ended is
+// never applied and never redraws. The output after teardown stays unchanged.
+func Test_sessionRunner_Run_StreamEndsWhileResizePendingNoLateRedraw(t *testing.T) {
+	withRollingTheme(t)
+	model := &MockQuerier{}
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		out := make(chan models.CompletionEvent, 4)
+		out <- models.ReasoningEvent{Content: wideContent}
+		out <- "done"
+		close(out)
+		return out, nil
+	}
+
+	var printed strings.Builder
+	resizeEvents := make(chan dimensions.Dimensions, 4)
+	q := &Querier[*MockQuerier]{
+		out:   &printed,
+		dims:  dimensions.Dimensions{Width: 80, Height: 10},
+		Model: model,
+	}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    &countingFinalizer{},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+		resizeEvents: resizeEvents,
+	}
+
+	if err := runner.Run(context.Background(), session); err != nil {
+		t.Fatalf("Run returned err: %v", err)
+	}
+	outputBefore := printed.String()
+
+	// The resize arrives after teardown: nobody consumes it, and the viewport
+	// must not redraw.
+	resizeEvents <- dimensions.Dimensions{Width: 40, Height: 10}
+	time.Sleep(50 * time.Millisecond)
+	if got := printed.String(); got != outputBefore {
+		t.Fatalf("late notification caused output after teardown:\nbefore:\n%s\nafter:\n%s", outputBefore, got)
+	}
+	if q.dims != (dimensions.Dimensions{Width: 80, Height: 10}) {
+		t.Fatalf("q.dims = %+v, want unchanged {80 10}", q.dims)
+	}
+}
+
+// Test_sessionRunner_Run_ContextCancellationStopsCleanly proves the
+// cancellation path: the session loop returns promptly when the context is
+// done, with the watcher channel open but idle.
+func Test_sessionRunner_Run_ContextCancellationStopsCleanly(t *testing.T) {
+	withRollingTheme(t)
+	model := &MockQuerier{}
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		// A stream that never delivers: only context cancellation can end it.
+		return make(chan models.CompletionEvent), nil
+	}
+
+	var printed syncBuffer
+	resizeEvents := make(chan dimensions.Dimensions, 1)
+	q := &Querier[*MockQuerier]{
+		out:   &printed,
+		dims:  dimensions.Dimensions{Width: 80, Height: 10},
+		Model: model,
+	}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    &countingFinalizer{},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+		resizeEvents: resizeEvents,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx, session) }()
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned err after cancellation: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after context cancellation")
+	}
+}
+
+// failAfterWriter fails every write at or after the configured call number,
+// so a test can force a mid-frame write error deterministically.
+type failAfterWriter struct {
+	mu     sync.Mutex
+	writes int
+	failOn int
+	b      strings.Builder
+}
+
+func (w *failAfterWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.writes++
+	if w.writes >= w.failOn {
+		return 0, errors.New("boom")
+	}
+	return w.b.Write(p)
+}
+
+func (w *failAfterWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.b.String()
+}
+
+// Test_sessionRunner_Run_ResizeRenderWriterFailureReturnsError proves the
+// writer-failure path: a failed redraw after a resize returns the render error
+// and the run stops without a goroutine leak.
+func Test_sessionRunner_Run_ResizeRenderWriterFailureReturnsError(t *testing.T) {
+	withRollingTheme(t)
+	proceed := make(chan struct{})
+	model := &MockQuerier{}
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		out := make(chan models.CompletionEvent, 4)
+		go func() {
+			out <- models.ReasoningEvent{Content: "inspect"}
+			<-proceed
+			out <- "done"
+			close(out)
+		}()
+		return out, nil
+	}
+
+	// Write 1 is the reasoning render; write 2 is the resize redraw and fails.
+	writer := &failAfterWriter{failOn: 2}
+	resizeEvents := make(chan dimensions.Dimensions, 4)
+	q := &Querier[*MockQuerier]{
+		out:   writer,
+		dims:  dimensions.Dimensions{Width: 80, Height: 10},
+		Model: model,
+	}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    &countingFinalizer{},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+		resizeEvents: resizeEvents,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(context.Background(), session) }()
+
+	waitFor(t, 2*time.Second, func() bool { return strings.Contains(writer.String(), "∴ thinking") })
+	resizeEvents <- dimensions.Dimensions{Width: 40, Height: 10}
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "render activity viewport after resize") {
+			t.Fatalf("Run error = %v, want render-after-resize error", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after the writer failure")
+	}
+}
+
+// Test_Querier_startResizeWatcher covers the watcher gate and lifecycle at the
+// query boundary: the watcher starts exactly when usesActivityViewport holds
+// and the writer is an *os.File, and its stop function releases the
+// registration and closes the event channel.
+func Test_Querier_startResizeWatcher(t *testing.T) {
+	withRollingTheme(t)
+
+	t.Run("rejected for raw sessions", func(t *testing.T) {
+		q := &Querier[*MockQuerier]{Raw: true, out: &strings.Builder{}}
+		ch, stop := q.startResizeWatcher(context.Background())
+		if ch != nil {
+			t.Fatal("raw session must not start a watcher")
+		}
+		stop() // no-op stop must be callable
+	})
+
+	t.Run("rejected for structured output", func(t *testing.T) {
+		q := &Querier[*MockQuerier]{structuredOutput: true, out: &strings.Builder{}}
+		ch, stop := q.startResizeWatcher(context.Background())
+		if ch != nil {
+			t.Fatal("structured session must not start a watcher")
+		}
+		stop()
+	})
+
+	t.Run("rejected for non-file writers", func(t *testing.T) {
+		q := &Querier[*MockQuerier]{out: &strings.Builder{}}
+		ch, stop := q.startResizeWatcher(context.Background())
+		if ch != nil {
+			t.Fatal("non-file writer must not start a watcher")
+		}
+		stop()
+	})
+
+	t.Run("starts for a file writer and stops cleanly", func(t *testing.T) {
+		file, err := os.CreateTemp(t.TempDir(), "session-out")
+		if err != nil {
+			t.Fatalf("CreateTemp: %v", err)
+		}
+		defer file.Close()
+		q := &Querier[*MockQuerier]{out: file}
+		ch, stop := q.startResizeWatcher(context.Background())
+		if ch == nil {
+			t.Fatal("terminal rolling session must start a watcher")
+		}
+		stop()
+		select {
+		case d, ok := <-ch:
+			if ok {
+				t.Fatalf("event channel still open after stop, got %v", d)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("event channel was not closed after stop")
+		}
+	})
+
+	t.Run("stops cleanly after context cancellation", func(t *testing.T) {
+		file, err := os.CreateTemp(t.TempDir(), "session-out")
+		if err != nil {
+			t.Fatalf("CreateTemp: %v", err)
+		}
+		defer file.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		q := &Querier[*MockQuerier]{out: file}
+		ch, stop := q.startResizeWatcher(ctx)
+		if ch == nil {
+			t.Fatal("terminal rolling session must start a watcher")
+		}
+		cancel()
+		stop() // must return promptly and release the registration
+		select {
+		case d, ok := <-ch:
+			if ok {
+				t.Fatalf("event channel still open after cancellation, got %v", d)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("event channel was not closed after cancellation")
+		}
+	})
+}

--- a/internal/text/session_runner.go
+++ b/internal/text/session_runner.go
@@ -12,6 +12,7 @@ import (
 	"github.com/baalimago/clai/internal/utils"
 	pub_models "github.com/baalimago/clai/pkg/text/models"
 	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
+	"github.com/baalimago/go_away_boilerplate/pkg/dimensions"
 	"github.com/baalimago/go_away_boilerplate/pkg/table"
 )
 
@@ -30,6 +31,12 @@ type sessionRunner[C models.StreamCompleter] struct {
 	finalizer      sessionFinalizerer
 	stoploss       *stoploss
 	currentRetries int
+	// resizeEvents delivers fresh terminal dimensions after SIGWINCH. It is
+	// the dimensions.Viewer's Events channel in production and is nil for
+	// non-rolling, non-terminal, and non-file sessions, which keep the
+	// one-shot q.dims read. The runner consumes it in the serialized session
+	// loop, so a resize and its redraw can never race a token or tool write.
+	resizeEvents <-chan dimensions.Dimensions
 }
 
 type sessionFinalizerer interface {
@@ -179,6 +186,9 @@ func (r *sessionRunner[C]) executeModelStep(ctx context.Context, session *QueryS
 		case completion, ok := <-completionsChan:
 			if !ok {
 				q.closeReasoningIfOpen(session)
+				if len(result.ToolCalls) == 0 {
+					q.prepareFinalAnswerPop()
+				}
 				result.EndedNormally = len(result.ToolCalls) == 0
 				result.AssistantText = session.PendingTextString()
 				result.Usage = q.currentTokenUsage()
@@ -186,11 +196,16 @@ func (r *sessionRunner[C]) executeModelStep(ctx context.Context, session *QueryS
 			}
 			switch cast := completion.(type) {
 			case pub_models.Call:
+				if q.reasoningActive && cast.ReasoningContent == "" {
+					cast.ReasoningContent = q.reasoningBuf.String()
+				}
 				q.closeReasoningIfOpen(session)
 				result.ToolCalls = append(result.ToolCalls, cast)
 			case string:
 				q.closeReasoningIfOpen(session)
-				q.handleTokenForSession(session, cast)
+				if err := q.handleTokenForSession(session, cast); err != nil {
+					return ModelStepResult{}, err
+				}
 			case error:
 				if errors.Is(cast, context.Canceled) || errors.Is(cast, io.EOF) {
 					q.closeReasoningIfOpen(session)
@@ -203,21 +218,36 @@ func (r *sessionRunner[C]) executeModelStep(ctx context.Context, session *QueryS
 			case models.NoopEvent:
 			case models.ReasoningEvent:
 				if !q.reasoningActive {
-					if !q.debug && !q.structuredOutput {
+					if q.usesActivityViewport() {
+						q.ensureActivityViewport()
+					} else if !q.debug && !q.structuredOutput {
 						w := q.out
 						if w == nil {
 							w = os.Stdout
 						}
-						fmt.Fprint(w, table.Colorize(utils.RoleColor("reasoning"), "[thinking]"))
+						if q.rawDisplay() {
+							fmt.Fprint(w, "[thinking]")
+						} else {
+							fmt.Fprint(w, table.Colorize(utils.RoleColor("reasoning"), "[thinking]"))
+						}
 					}
 					q.reasoningActive = true
 				}
-				if !q.debug && !q.structuredOutput {
+				if q.usesActivityViewport() {
+					q.activityViewport.AppendReasoning(cast.Content)
+					if err := q.activityViewport.Render(q.out); err != nil {
+						return ModelStepResult{}, fmt.Errorf("render activity viewport: %w", err)
+					}
+				} else if !q.debug && !q.structuredOutput {
 					w := q.out
 					if w == nil {
 						w = os.Stdout
 					}
-					fmt.Fprint(w, table.Colorize(utils.RoleColor("reasoning"), cast.Content))
+					if q.rawDisplay() {
+						fmt.Fprint(w, cast.Content)
+					} else {
+						fmt.Fprint(w, table.Colorize(utils.RoleColor("reasoning"), cast.Content))
+					}
 				}
 				q.reasoningBuf.WriteString(cast.Content)
 			case models.StopEvent:
@@ -227,6 +257,7 @@ func (r *sessionRunner[C]) executeModelStep(ctx context.Context, session *QueryS
 				if len(result.ToolCalls) > 0 {
 					return result, nil
 				}
+				q.prepareFinalAnswerPop()
 				contextCancel := ctx.Value(utils.ContextCancelKey)
 				castContextCancel, ok := contextCancel.(context.CancelFunc)
 				if ok {
@@ -242,14 +273,48 @@ func (r *sessionRunner[C]) executeModelStep(ctx context.Context, session *QueryS
 			default:
 				return ModelStepResult{}, fmt.Errorf("unknown completion type: %v", completion)
 			}
+		case d, ok := <-r.resizeEvents:
+			if !ok {
+				// The watcher stopped (session teardown or source close); no
+				// further resize applies. Nilling the channel keeps the select
+				// from spinning on the closed channel.
+				r.resizeEvents = nil
+				continue
+			}
+			if err := r.applyResize(d); err != nil {
+				return ModelStepResult{}, err
+			}
 		case <-ctx.Done():
 			q.closeReasoningIfOpen(session)
 			result.StopRequested = true
 			result.AssistantText = session.PendingTextString()
 			result.Usage = q.currentTokenUsage()
+			q.prepareFinalAnswerPop()
 			return result, nil
 		}
 	}
+}
+
+// applyResize refreshes the session snapshot and the rolling window after a
+// SIGWINCH. It runs on the serialized session loop, never in a signal
+// callback, so the resize, its redraw, and token/tool writes cannot overlap.
+// The viewer delivers only snapshots from successful reads; a failed refresh
+// never reaches this method, so the last valid snapshot survives. A resize
+// before the first reasoning/tool event updates q.dims only; the lazy
+// viewport creation reads the fresh snapshot and its first render uses the
+// new dimensions immediately. Render errors abort the step like any other
+// viewport write error; a partial frame stays dirty and the next Render
+// retries the full frame.
+func (r *sessionRunner[C]) applyResize(d dimensions.Dimensions) error {
+	q := r.querier
+	q.dims = d
+	if q.activityViewport != nil {
+		q.activityViewport.Resize(d.Width, d.Height)
+		if err := q.activityViewport.Render(q.out); err != nil {
+			return fmt.Errorf("render activity viewport after resize: %w", err)
+		}
+	}
+	return nil
 }
 
 func (r *sessionRunner[C]) modelName() string {

--- a/internal/text/session_runner_test.go
+++ b/internal/text/session_runner_test.go
@@ -3,13 +3,16 @@ package text
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/baalimago/clai/internal/models"
+	"github.com/baalimago/clai/internal/utils"
 	pub_models "github.com/baalimago/clai/pkg/text/models"
+	"github.com/baalimago/go_away_boilerplate/pkg/dimensions"
 )
 
 func stripANSIEscapes(s string) string {
@@ -295,8 +298,8 @@ func Test_sessionRunner_Run_FinalReplyReasoningIsPersistedSeparatelyFromContent(
 	if err != nil {
 		t.Fatalf("Run returned err: %v", err)
 	}
-	if got := session.FinalAssistantText; !strings.Contains(got, "[thinking]Need to inspect.\n[/thinking]\ndone") {
-		t.Fatalf("expected final assistant text to contain wrapped reasoning, got %q", got)
+	if got := session.FinalAssistantText; got != "done" {
+		t.Fatalf("expected final assistant text without display-only reasoning, got %q", got)
 	}
 	if len(session.Chat.Messages) != 2 {
 		t.Fatalf("expected user + finalized assistant-ish message, got %d messages", len(session.Chat.Messages))
@@ -310,6 +313,353 @@ func Test_sessionRunner_Run_FinalReplyReasoningIsPersistedSeparatelyFromContent(
 	}
 	if strings.Contains(finalMsg.Content, "[thinking]") {
 		t.Fatalf("expected persisted assistant content to omit wrapped thinking markup, got %q", finalMsg.Content)
+	}
+}
+
+func Test_sessionRunner_Run_ActivityViewportCombinesReasoningAndToolActivity(t *testing.T) {
+	model := &MockQuerier{}
+	callCount := 0
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		callCount++
+		out := make(chan models.CompletionEvent, 3)
+		if callCount == 1 {
+			out <- models.ReasoningEvent{Content: "inspect \x1b[31mdirectory\x1b[0m"}
+			out <- pub_models.Call{ID: "call-1", Name: "missing_tool"}
+		} else {
+			out <- "done"
+		}
+		close(out)
+		return out, nil
+	}
+
+	var printed strings.Builder
+	q := &Querier[*MockQuerier]{out: &printed, dims: dimensions.Dimensions{Width: 80, Height: 24}, Model: model}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    &countingFinalizer{},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+	}
+
+	if err := runner.Run(context.Background(), session); err != nil {
+		t.Fatalf("Run returned err: %v", err)
+	}
+	output := stripANSIEscapes(printed.String())
+	thinkingAt := strings.Index(output, "∴ thinking\n  inspect directory")
+	toolAt := strings.Index(output, "▸ missing_tool")
+	if thinkingAt == -1 || toolAt == -1 || thinkingAt > toolAt {
+		t.Fatalf("expected viewport before tool activity, got:\n%s", output)
+	}
+	if strings.Contains(output, "assistant: [thinking]") || strings.Contains(output, "[and ") {
+		t.Fatalf("reasoning must not be re-rendered as shortened assistant text, got:\n%s", output)
+	}
+	if session.FinalReasoningText != "" {
+		t.Fatalf("tool-step reasoning must not leak into final reply reasoning, got %q", session.FinalReasoningText)
+	}
+	if got := session.Chat.Messages[1].ReasoningContent; got != "inspect \x1b[31mdirectory\x1b[0m" {
+		t.Fatalf("expected complete reasoning on persisted tool call, got %q", got)
+	}
+}
+
+func Test_sessionRunner_Run_DisabledRollingOutputStreamsPlainThinkingAndPrintsNewToolBlock(t *testing.T) {
+	confDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(confDir, "theme.json"), []byte(`{"notificationBell":true,"rollingOutput":{"enabled":false}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(theme.json): %v", err)
+	}
+	if err := utils.LoadTheme(confDir); err != nil {
+		t.Fatalf("LoadTheme(): %v", err)
+	}
+	resetThemeDir := t.TempDir()
+	t.Cleanup(func() {
+		if err := utils.LoadTheme(resetThemeDir); err != nil {
+			t.Errorf("reset theme: %v", err)
+		}
+	})
+
+	model := &MockQuerier{}
+	callCount := 0
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		callCount++
+		out := make(chan models.CompletionEvent, 3)
+		if callCount == 1 {
+			out <- models.ReasoningEvent{Content: "inspect"}
+			out <- pub_models.Call{ID: "call-1", Name: "missing_tool"}
+		} else {
+			out <- "done"
+		}
+		close(out)
+		return out, nil
+	}
+
+	var printed strings.Builder
+	q := &Querier[*MockQuerier]{out: &printed, dims: dimensions.Dimensions{Width: 80, Height: 24}, Model: model}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    &countingFinalizer{},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+	}
+
+	if err := runner.Run(context.Background(), session); err != nil {
+		t.Fatalf("Run returned err: %v", err)
+	}
+	output := stripANSIEscapes(printed.String())
+	for _, want := range []string{"[thinking]inspect", "[/thinking]", "▸ missing_tool", "done"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected %q in non-rolling output:\n%s", want, output)
+		}
+	}
+	for _, forbidden := range []string{"∴ thinking", "assistant: [thinking]", "\x1b[2A"} {
+		if strings.Contains(output, forbidden) {
+			t.Fatalf("non-rolling output contains %q:\n%s", forbidden, output)
+		}
+	}
+}
+
+func Test_sessionRunner_Run_AssistantProseStaysInsideRollingWindow(t *testing.T) {
+	t.Setenv("NO_COLOR", "true")
+	confDir := withEmptyClaiConfigDir(t)
+	if err := utils.LoadTheme(confDir); err != nil {
+		t.Fatalf("LoadTheme(): %v", err)
+	}
+	model := &MockQuerier{}
+	callCount := 0
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		callCount++
+		out := make(chan models.CompletionEvent, 4)
+		if callCount == 1 {
+			out <- models.ReasoningEvent{Content: "inspect"}
+			out <- "I will run a tool."
+			out <- pub_models.Call{ID: "call-1", Name: "missing_tool"}
+		} else {
+			out <- "done"
+		}
+		close(out)
+		return out, nil
+	}
+
+	var printed strings.Builder
+	q := &Querier[*MockQuerier]{out: &printed, dims: dimensions.Dimensions{Width: 80, Height: 24}, Model: model}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    &countingFinalizer{},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+	}
+
+	if err := runner.Run(context.Background(), session); err != nil {
+		t.Fatalf("Run returned err: %v", err)
+	}
+	output := stripANSIEscapes(printed.String())
+	thinkingAt := strings.Index(output, "∴ thinking\n  inspect")
+	proseAt := strings.Index(output, "assistant\n  I will run a tool.")
+	toolAt := strings.Index(output, "▸ missing_tool")
+	if thinkingAt == -1 || proseAt == -1 || toolAt == -1 {
+		t.Fatalf("expected thinking, assistant prose and tool activity inside one window, got:\n%s", output)
+	}
+	if !(thinkingAt < proseAt && proseAt < toolAt) {
+		t.Fatalf("expected order thinking < assistant prose < tool activity, got:\n%s", output)
+	}
+	if strings.Contains(output, "assistant: I will run a tool.") {
+		t.Fatalf("assistant prose must not be re-printed outside the window, got:\n%s", output)
+	}
+	if session.FinalAssistantText != "done" {
+		t.Fatalf("expected final assistant text, got %q", session.FinalAssistantText)
+	}
+}
+
+func Test_sessionRunner_Run_ProseStreamedBeforeFirstActivityMovesIntoWindow(t *testing.T) {
+	t.Setenv("NO_COLOR", "true")
+	confDir := withEmptyClaiConfigDir(t)
+	if err := utils.LoadTheme(confDir); err != nil {
+		t.Fatalf("LoadTheme(): %v", err)
+	}
+	model := &MockQuerier{}
+	callCount := 0
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		callCount++
+		out := make(chan models.CompletionEvent, 3)
+		if callCount == 1 {
+			out <- "Let me check."
+			out <- pub_models.Call{ID: "call-1", Name: "missing_tool"}
+		} else {
+			out <- "done"
+		}
+		close(out)
+		return out, nil
+	}
+
+	var printed strings.Builder
+	q := &Querier[*MockQuerier]{out: &printed, dims: dimensions.Dimensions{Width: 80, Height: 24}, Model: model}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    &countingFinalizer{},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+	}
+
+	if err := runner.Run(context.Background(), session); err != nil {
+		t.Fatalf("Run returned err: %v", err)
+	}
+	output := stripANSIEscapes(printed.String())
+	proseAt := strings.Index(output, "assistant\n  Let me check.")
+	toolAt := strings.Index(output, "▸ missing_tool")
+	if proseAt == -1 || toolAt == -1 || proseAt > toolAt {
+		t.Fatalf("expected prose inside the window before tool activity, got:\n%s", output)
+	}
+	if strings.Contains(output, "assistant: Let me check.") {
+		t.Fatalf("prose must not be re-printed outside the window, got:\n%s", output)
+	}
+}
+
+func Test_sessionRunner_Run_FinalAnswerPrintsBelowRollingWindow(t *testing.T) {
+	t.Setenv("NO_COLOR", "true")
+	confDir := withEmptyClaiConfigDir(t)
+	if err := utils.LoadTheme(confDir); err != nil {
+		t.Fatalf("LoadTheme(): %v", err)
+	}
+	model := &MockQuerier{}
+	callCount := 0
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		callCount++
+		out := make(chan models.CompletionEvent, 3)
+		if callCount == 1 {
+			out <- models.ReasoningEvent{Content: "inspect"}
+			out <- pub_models.Call{ID: "call-1", Name: "missing_tool"}
+		} else {
+			out <- models.ReasoningEvent{Content: "verify"}
+			out <- "The answer is done."
+		}
+		close(out)
+		return out, nil
+	}
+
+	var printed strings.Builder
+	q := &Querier[*MockQuerier]{out: &printed, dims: dimensions.Dimensions{Width: 80, Height: 24}, Model: model}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    sessionFinalizer[*MockQuerier]{querier: q},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+	}
+
+	if err := runner.Run(context.Background(), session); err != nil {
+		t.Fatalf("Run returned err: %v", err)
+	}
+	raw := printed.String()
+	// The answer block is the trailing two rows of the window. The pop is a
+	// pure shrink: the unchanged window above stays on screen and the pop
+	// clears only the removed rows, immediately followed by the answer print
+	// (one terminal transition, Option A).
+	popSeq := "\x1b[2A\r\x1b[J"
+	popAt := strings.LastIndex(raw, popSeq)
+	if popAt == -1 {
+		t.Fatalf("expected the pop to clear the two answer rows, got:\n%q", raw)
+	}
+	if windowAt := strings.Index(stripANSIEscapes(raw[:popAt]), "∴ thinking"); windowAt == -1 {
+		t.Fatalf("expected the window to stay on screen above the final answer, got:\n%s", stripANSIEscapes(raw[:popAt]))
+	}
+	if got := stripANSIEscapes(raw[popAt+len(popSeq):]); got != "assistant: The answer is done.\n" {
+		t.Fatalf("expected only the final answer right after the pop redraw, got %q", got)
+	}
+	if session.FinalAssistantText != "The answer is done." {
+		t.Fatalf("expected final assistant text, got %q", session.FinalAssistantText)
+	}
+}
+
+func Test_sessionRunner_Run_FinalAnswerStaysInWindowUntilFinalizer(t *testing.T) {
+	// The atomic pop (Option A) removes the answer block from the viewport
+	// state at stream end but defers the redraw to postProcessOutput, which
+	// runs right before the answer prints below. A finalizer that never prints
+	// therefore leaves the answer inside the window in the raw output.
+	t.Setenv("NO_COLOR", "true")
+	confDir := withEmptyClaiConfigDir(t)
+	if err := utils.LoadTheme(confDir); err != nil {
+		t.Fatalf("LoadTheme(): %v", err)
+	}
+	model := &MockQuerier{}
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		out := make(chan models.CompletionEvent, 3)
+		out <- models.ReasoningEvent{Content: "inspect"}
+		out <- "The answer is done."
+		close(out)
+		return out, nil
+	}
+
+	var printed strings.Builder
+	q := &Querier[*MockQuerier]{out: &printed, dims: dimensions.Dimensions{Width: 80, Height: 24}, Model: model}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    &countingFinalizer{},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+	}
+
+	if err := runner.Run(context.Background(), session); err != nil {
+		t.Fatalf("Run returned err: %v", err)
+	}
+	if !q.finalAnswerPopPending {
+		t.Fatal("expected the final-answer pop to stay pending until the finalizer prints")
+	}
+	output := stripANSIEscapes(printed.String())
+	if !strings.Contains(output, "assistant\n  The answer is done.") {
+		t.Fatalf("expected the answer to remain inside the window until the finalizer, got:\n%s", output)
+	}
+	if strings.Contains(output, "assistant: The answer is done.") {
+		t.Fatalf("answer must not be re-printed outside the window, got:\n%s", output)
+	}
+}
+
+func Test_sessionRunner_Run_RedirectedOutputUsesRawRepresentation(t *testing.T) {
+	model := &MockQuerier{}
+	callCount := 0
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		callCount++
+		out := make(chan models.CompletionEvent, 3)
+		if callCount == 1 {
+			out <- models.ReasoningEvent{Content: "inspect"}
+			out <- pub_models.Call{ID: "call-1", Name: "missing_tool"}
+		} else {
+			out <- "done"
+		}
+		close(out)
+		return out, nil
+	}
+
+	var printed strings.Builder
+	q := &Querier[*MockQuerier]{
+		out:              &printed,
+		outputModeKnown:  true,
+		outputIsTerminal: false,
+		Model:            model,
+	}
+	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+	runner := sessionRunner[*MockQuerier]{
+		querier:      q,
+		recorder:     &recordingCallUsageRecorder{},
+		finalizer:    &countingFinalizer{},
+		toolExecutor: toolExecutor[*MockQuerier]{querier: q},
+	}
+
+	if err := runner.Run(context.Background(), session); err != nil {
+		t.Fatalf("Run returned err: %v", err)
+	}
+	output := printed.String()
+	for _, want := range []string{"[thinking]inspect", "[/thinking]", "Call: 'missing_tool'", "ERROR: unknown tool call: missing_tool", "done"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected raw output %q in %q", want, output)
+		}
+	}
+	for _, forbidden := range []string{"\x1b", "▸ missing_tool", "\x1b["} {
+		if strings.Contains(output, forbidden) {
+			t.Fatalf("redirected output contains display-only data %q: %q", forbidden, output)
+		}
 	}
 }
 
@@ -385,8 +735,11 @@ func Test_sessionRunner_Run_PartialStreamFailureFinalizesOnce(t *testing.T) {
 	}
 }
 
-func Test_sessionRunner_Run_DoesNotDuplicateToolCallEchoBeforeStructuredCall(t *testing.T) {
-	withEmptyClaiConfigDir(t)
+func Test_sessionRunner_Run_DoesNotDuplicateToolCallEchoBeforeToolActivity(t *testing.T) {
+	confDir := withEmptyClaiConfigDir(t)
+	if err := utils.LoadTheme(confDir); err != nil {
+		t.Fatalf("LoadTheme(): %v", err)
+	}
 
 	model := &MockQuerier{}
 	callCount := 0
@@ -413,9 +766,9 @@ func Test_sessionRunner_Run_DoesNotDuplicateToolCallEchoBeforeStructuredCall(t *
 
 	var printed strings.Builder
 	q := &Querier[*MockQuerier]{
-		out:       &printed,
-		termWidth: 80,
-		Model:     model,
+		out:   &printed,
+		dims:  dimensions.Dimensions{Width: 80, Height: 24},
+		Model: model,
 	}
 	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
 	runner := sessionRunner[*MockQuerier]{
@@ -430,24 +783,20 @@ func Test_sessionRunner_Run_DoesNotDuplicateToolCallEchoBeforeStructuredCall(t *
 		t.Fatalf("Run returned err: %v", err)
 	}
 
-	printedOutput := printed.String()
-	normalizedOutput := stripANSIEscapes(printedOutput)
-	rawEchoAt := strings.Index(normalizedOutput, echoCall.PrettyPrint())
-	if rawEchoAt == -1 {
-		t.Fatalf("expected raw echoed tool call in output, got:\n%s", normalizedOutput)
+	normalizedOutput := stripANSIEscapes(printed.String())
+	// The echoed tool-call text is streamed once and then cleared; it must
+	// never be re-printed as an assistant message.
+	if got := strings.Count(normalizedOutput, echoCall.PrettyPrint()); got != 1 {
+		t.Fatalf("expected echoed tool call text exactly once, got %d occurrences in output:\n%s", got, normalizedOutput)
 	}
-	clearAt := strings.Index(normalizedOutput[rawEchoAt+len(echoCall.PrettyPrint()):], "\r")
-	if clearAt == -1 {
-		t.Fatalf("expected terminal clear/control output after echoed tool call, got output:\n%s", normalizedOutput)
+	if strings.Contains(normalizedOutput, "assistant: "+echoCall.PrettyPrint()) {
+		t.Fatalf("echoed tool call text must not be re-printed as assistant prose, got:\n%s", normalizedOutput)
 	}
-	clearAt += rawEchoAt + len(echoCall.PrettyPrint())
-	structuredAt := strings.Index(normalizedOutput[clearAt:], "assistant:")
-	if structuredAt == -1 {
-		t.Fatalf("expected structured assistant render after clear, got output:\n%s", normalizedOutput)
+	if !strings.Contains(normalizedOutput, "▸ pwd  path=.") {
+		t.Fatalf("expected paired tool activity in the window, got:\n%s", normalizedOutput)
 	}
-	structuredAt += clearAt
-	if got := strings.Count(normalizedOutput[structuredAt:], echoCall.PrettyPrint()); got != 1 {
-		t.Fatalf("expected exactly one structured tool-call pretty print after assistant render, got %d occurrences in output:\n%s", got, normalizedOutput)
+	if got := strings.Count(normalizedOutput, "assistant: final answer"); got != 1 {
+		t.Fatalf("expected the final answer printed exactly once, got %d occurrences:\n%s", got, normalizedOutput)
 	}
 	if session.FinalAssistantText != "final answer" {
 		t.Fatalf("expected final assistant text from follow-up step, got %q", session.FinalAssistantText)
@@ -455,7 +804,10 @@ func Test_sessionRunner_Run_DoesNotDuplicateToolCallEchoBeforeStructuredCall(t *
 }
 
 func Test_toolExecutor_FinalizeAssistantTextBeforeToolCall_PreservesAssistantProse(t *testing.T) {
-	withEmptyClaiConfigDir(t)
+	confDir := withEmptyClaiConfigDir(t)
+	if err := utils.LoadTheme(confDir); err != nil {
+		t.Fatalf("LoadTheme(): %v", err)
+	}
 
 	call := pub_models.Call{
 		ID:   "call-1",
@@ -463,8 +815,8 @@ func Test_toolExecutor_FinalizeAssistantTextBeforeToolCall_PreservesAssistantPro
 	}
 	var printed strings.Builder
 	q := &Querier[*MockQuerier]{
-		out:       &printed,
-		termWidth: 80,
+		out:  &printed,
+		dims: dimensions.Dimensions{Width: 80, Height: 24},
 	}
 	session := &QuerySession{}
 	session.AppendPendingText("I will check that for you.")
@@ -482,13 +834,21 @@ func Test_toolExecutor_FinalizeAssistantTextBeforeToolCall_PreservesAssistantPro
 	}
 
 	normalizedOutput := stripANSIEscapes(printed.String())
-	if !strings.Contains(normalizedOutput, "I will check that for you.") {
-		t.Fatalf("expected prose to be rendered during finalization, got output:\n%s", normalizedOutput)
+	// The prose is moved into the rolling window; it must not be re-printed as
+	// a standalone assistant message outside the window.
+	if !strings.Contains(normalizedOutput, "assistant\n  I will check that for you.") {
+		t.Fatalf("expected prose rendered inside the rolling window, got output:\n%s", normalizedOutput)
+	}
+	if strings.Contains(normalizedOutput, "assistant: I will check that for you.") {
+		t.Fatalf("prose must not be re-printed outside the window, got output:\n%s", normalizedOutput)
 	}
 }
 
 func Test_toolExecutor_FinalizeAssistantTextBeforeToolCall_DropsWhitespaceEquivalentEcho(t *testing.T) {
-	withEmptyClaiConfigDir(t)
+	confDir := withEmptyClaiConfigDir(t)
+	if err := utils.LoadTheme(confDir); err != nil {
+		t.Fatalf("LoadTheme(): %v", err)
+	}
 
 	call := pub_models.Call{
 		ID:   "call-1",
@@ -497,8 +857,8 @@ func Test_toolExecutor_FinalizeAssistantTextBeforeToolCall_DropsWhitespaceEquiva
 	echoed := "\n" + call.PrettyPrint() + "\n"
 	var printed strings.Builder
 	q := &Querier[*MockQuerier]{
-		out:       &printed,
-		termWidth: 80,
+		out:  &printed,
+		dims: dimensions.Dimensions{Width: 80, Height: 24},
 	}
 	session := &QuerySession{}
 	session.AppendPendingText(echoed)
@@ -638,7 +998,8 @@ func Test_sessionRunner_Run_DrainsAndExecutesParallelToolCallsAsOneTurn(t *testi
 		return out, nil
 	}
 
-	q := &Querier[*MockQuerier]{out: &strings.Builder{}, Model: model}
+	var printed strings.Builder
+	q := &Querier[*MockQuerier]{out: &printed, dims: dimensions.Dimensions{Width: 80, Height: 24}, Model: model}
 	session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
 	runner := sessionRunner[*MockQuerier]{
 		querier:      q,
@@ -655,5 +1016,15 @@ func Test_sessionRunner_Run_DrainsAndExecutesParallelToolCallsAsOneTurn(t *testi
 	}
 	if session.FinalAssistantText != "done" {
 		t.Fatalf("expected final reply, got %q", session.FinalAssistantText)
+	}
+	output := stripANSIEscapes(printed.String())
+	firstCall := strings.Index(output, "▸ missing_one")
+	secondCall := strings.Index(output, "▸ missing_two")
+	if firstCall == -1 || secondCall == -1 {
+		t.Fatalf("expected both tool activity blocks, got:\n%s", output)
+	}
+	firstResult := strings.Index(output[firstCall:], "✗ ERROR:")
+	if firstResult == -1 || firstCall+firstResult > secondCall {
+		t.Fatalf("expected the first result before the second call, got:\n%s", output)
 	}
 }

--- a/internal/text/tool_executor.go
+++ b/internal/text/tool_executor.go
@@ -176,9 +176,13 @@ func (e toolExecutor[C]) emitAssistantToolCalls(session *QuerySession, calls []p
 			modelSafe.ReasoningItems = call.ReasoningItems
 		}
 		if !q.debug && !q.structuredOutput {
-			display := pub_models.Message{Role: "assistant", Content: call.PrettyPrint(), ToolCalls: []pub_models.Call{call}, ReasoningContent: call.ReasoningContent}
-			if err := utils.AttemptPrettyPrint(q.out, display, q.username, q.Raw); err != nil {
-				return fmt.Errorf("pretty print assistant tool call: %w", err)
+			if q.Raw {
+				display := pub_models.Message{Role: "assistant", Content: call.PrettyPrint(), ToolCalls: []pub_models.Call{call}, ReasoningContent: call.ReasoningContent}
+				if err := utils.AttemptPrettyPrint(q.out, display, q.username, q.Raw); err != nil {
+					return fmt.Errorf("pretty print raw assistant tool call: %w", err)
+				}
+			} else if err := utils.PrintCompactToolCall(q.out, "assistant", call.PrettyPrint(), q.toolDisplayWidth()); err != nil {
+				return fmt.Errorf("print assistant tool call: %w", err)
 			}
 		}
 	}
@@ -206,8 +210,8 @@ func (e toolExecutor[C]) emitToolResult(session *QuerySession, call pub_models.C
 				return fmt.Errorf("pretty print raw tool output: %w", err)
 			}
 		} else if !q.debug {
-			if err := utils.AttemptPrettyPrint(q.out, utils.PrepareDisplayMessage(outMsg), "tool", q.Raw); err != nil {
-				return fmt.Errorf("pretty print tool output: %w", err)
+			if err := utils.PrintCompactToolActivity(q.out, "tool", outMsg.Content, q.toolDisplayWidth(), utils.ToolOutputRows()); err != nil {
+				return fmt.Errorf("print tool output: %w", err)
 			}
 		}
 	}
@@ -288,12 +292,40 @@ func (e toolExecutor[C]) executeLoadSkill(ctx context.Context, session *QuerySes
 	if !q.debug && !q.structuredOutput {
 		printMsg := outMsg
 		printMsg.Content = userVisibleContent
-		if err := utils.AttemptPrettyPrint(q.out, printMsg, "tool", q.Raw); err != nil {
-			return fmt.Errorf("pretty print skill output: %w", err)
+		if q.Raw {
+			if err := utils.AttemptPrettyPrint(q.out, printMsg, "tool", q.Raw); err != nil {
+				return fmt.Errorf("pretty print raw skill output: %w", err)
+			}
+			summary := fmt.Sprintf("Loaded skill\n  Name: %s\n  Source: %s\nloaded skill %s [%s]", loaded.Name, loaded.SourceClass, loaded.Name, loaded.SourceClass)
+			if desc := strings.TrimSpace(loaded.Description); desc != "" {
+				summary += fmt.Sprintf("\n  Description: %s", desc)
+			}
+			content := strings.TrimSpace(loaded.RenderedBody)
+			length := utf8.RuneCountInString(content)
+			approxTokens := (length + 3) / 4
+			summary += fmt.Sprintf("\n  Length: %d chars\n  Estimated tokens: ~%d", length, approxTokens)
+			if strings.TrimSpace(loaded.RawArgs) != "" {
+				summary += fmt.Sprintf("\n  Arguments: %q", loaded.RawArgs)
+				summary += fmt.Sprintf("\nloaded skill %s [%s] args=%q", loaded.Name, loaded.SourceClass, loaded.RawArgs)
+			}
+			ancli.Noticef("%s", summary)
+		} else if err := utils.PrintCompactToolActivity(q.out, "tool", printMsg.Content, q.toolDisplayWidth(), utils.ToolOutputRows()); err != nil {
+			return fmt.Errorf("print skill output: %w", err)
 		}
 	}
 	session.ResetPendingText()
 	return nil
+}
+
+func (q *Querier[C]) toolDisplayWidth() int {
+	if q.termWidth > 0 {
+		return q.termWidth
+	}
+	width, err := table.TermWidth()
+	if err == nil && width > 0 {
+		return width
+	}
+	return 80
 }
 
 func formatSkillOutputForDisplay(loaded LoadedSkillRuntime) string {

--- a/internal/text/tool_executor.go
+++ b/internal/text/tool_executor.go
@@ -176,13 +176,11 @@ func (e toolExecutor[C]) emitAssistantToolCalls(session *QuerySession, calls []p
 			modelSafe.ReasoningItems = call.ReasoningItems
 		}
 		if !q.debug && !q.structuredOutput {
-			if q.Raw {
+			if q.rawDisplay() {
 				display := pub_models.Message{Role: "assistant", Content: call.PrettyPrint(), ToolCalls: []pub_models.Call{call}, ReasoningContent: call.ReasoningContent}
-				if err := utils.AttemptPrettyPrint(q.out, display, q.username, q.Raw); err != nil {
+				if err := utils.AttemptPrettyPrint(q.out, display, q.username, q.rawDisplay()); err != nil {
 					return fmt.Errorf("pretty print raw assistant tool call: %w", err)
 				}
-			} else if err := utils.PrintCompactToolCall(q.out, "assistant", call.PrettyPrint(), q.toolDisplayWidth()); err != nil {
-				return fmt.Errorf("print assistant tool call: %w", err)
 			}
 		}
 	}
@@ -194,9 +192,11 @@ func (e toolExecutor[C]) emitAssistantToolCalls(session *QuerySession, calls []p
 // it, and resets pending text — the shared tail of every tool-call exchange.
 func (e toolExecutor[C]) emitToolResult(session *QuerySession, call pub_models.Call, out string) error {
 	q := e.querier
+	displayOut := out
 	out = limitToolOutput(out, q.toolOutputRuneLimit)
 	if out == "" {
 		out = fmt.Sprintf("<NO-OUTPUT> tool %s completed successfully but produced no stdout/stderr.", call.Name)
+		displayOut = out
 	}
 	outMsg := pub_models.Message{
 		Role:       "tool",
@@ -205,12 +205,14 @@ func (e toolExecutor[C]) emitToolResult(session *QuerySession, call pub_models.C
 	}
 	session.Chat.Messages = append(session.Chat.Messages, outMsg)
 	if !q.structuredOutput {
-		if q.Raw {
-			if err := utils.AttemptPrettyPrint(q.out, outMsg, "tool", q.Raw); err != nil {
+		if q.rawDisplay() {
+			printMsg := outMsg
+			printMsg.Content = displayOut
+			if err := utils.AttemptPrettyPrint(q.out, printMsg, "tool", q.rawDisplay()); err != nil {
 				return fmt.Errorf("pretty print raw tool output: %w", err)
 			}
 		} else if !q.debug {
-			if err := utils.PrintCompactToolActivity(q.out, "tool", outMsg.Content, q.toolDisplayWidth(), utils.ToolOutputRows()); err != nil {
+			if err := q.appendToolActivity(call, outMsg.Content); err != nil {
 				return fmt.Errorf("print tool output: %w", err)
 			}
 		}
@@ -272,7 +274,7 @@ func (e toolExecutor[C]) executeLoadSkill(ctx context.Context, session *QuerySes
 	if strings.TrimSpace(userVisibleContent) == "" {
 		userVisibleContent = loaded.RenderedBody
 	}
-	if !q.Raw {
+	if !q.rawDisplay() {
 		userVisibleContent = formatSkillOutputForDisplay(loaded)
 	}
 	if len(loaded.Warnings) > 0 {
@@ -292,24 +294,11 @@ func (e toolExecutor[C]) executeLoadSkill(ctx context.Context, session *QuerySes
 	if !q.debug && !q.structuredOutput {
 		printMsg := outMsg
 		printMsg.Content = userVisibleContent
-		if q.Raw {
-			if err := utils.AttemptPrettyPrint(q.out, printMsg, "tool", q.Raw); err != nil {
+		if q.rawDisplay() {
+			if err := utils.AttemptPrettyPrint(q.out, printMsg, "tool", q.rawDisplay()); err != nil {
 				return fmt.Errorf("pretty print raw skill output: %w", err)
 			}
-			summary := fmt.Sprintf("Loaded skill\n  Name: %s\n  Source: %s\nloaded skill %s [%s]", loaded.Name, loaded.SourceClass, loaded.Name, loaded.SourceClass)
-			if desc := strings.TrimSpace(loaded.Description); desc != "" {
-				summary += fmt.Sprintf("\n  Description: %s", desc)
-			}
-			content := strings.TrimSpace(loaded.RenderedBody)
-			length := utf8.RuneCountInString(content)
-			approxTokens := (length + 3) / 4
-			summary += fmt.Sprintf("\n  Length: %d chars\n  Estimated tokens: ~%d", length, approxTokens)
-			if strings.TrimSpace(loaded.RawArgs) != "" {
-				summary += fmt.Sprintf("\n  Arguments: %q", loaded.RawArgs)
-				summary += fmt.Sprintf("\nloaded skill %s [%s] args=%q", loaded.Name, loaded.SourceClass, loaded.RawArgs)
-			}
-			ancli.Noticef("%s", summary)
-		} else if err := utils.PrintCompactToolActivity(q.out, "tool", printMsg.Content, q.toolDisplayWidth(), utils.ToolOutputRows()); err != nil {
+		} else if err := q.appendToolActivity(call, printMsg.Content); err != nil {
 			return fmt.Errorf("print skill output: %w", err)
 		}
 	}
@@ -317,15 +306,18 @@ func (e toolExecutor[C]) executeLoadSkill(ctx context.Context, session *QuerySes
 	return nil
 }
 
-func (q *Querier[C]) toolDisplayWidth() int {
-	if q.termWidth > 0 {
-		return q.termWidth
+func (q *Querier[C]) appendToolActivity(call pub_models.Call, content string) error {
+	if !utils.RollingOutputEnabled() {
+		if err := utils.PrintToolActivity(q.out, call, content, q.dims.Width, utils.ToolOutputRows()); err != nil {
+			return fmt.Errorf("print tool activity: %w", err)
+		}
+		return nil
 	}
-	width, err := table.TermWidth()
-	if err == nil && width > 0 {
-		return width
+	q.ensureActivityViewport().AppendTool(call, utils.SummarizeAsyncToolResult(call.Name, content), utils.ToolOutputRows())
+	if err := q.activityViewport.Render(q.out); err != nil {
+		return fmt.Errorf("render activity viewport: %w", err)
 	}
-	return 80
+	return nil
 }
 
 func formatSkillOutputForDisplay(loaded LoadedSkillRuntime) string {
@@ -350,9 +342,24 @@ func (e toolExecutor[C]) finalizeAssistantTextBeforeToolCall(session *QuerySessi
 		return nil
 	}
 	q := e.querier
-	if !q.Raw && !q.structuredOutput && q.termWidth > 0 {
-		utils.UpdateMessageTerminalMetadata(pending, &session.Line, &session.LineCount, q.termWidth)
-		if err := table.ClearTermTo(q.out, session.LineCount-1); err != nil {
+	if q.usesActivityViewport() {
+		return e.finalizeAssistantTextRolling(session, pending, call)
+	}
+	return e.finalizeAssistantTextPlain(session, pending, call)
+}
+
+// finalizeAssistantTextPlain finalizes assistant prose for non-rolling
+// display: the streamed text is cleared and re-printed as one proper message
+// above the upcoming tool activity. Echoed tool-call text is dropped.
+func (e toolExecutor[C]) finalizeAssistantTextPlain(session *QuerySession, pending string, call pub_models.Call) error {
+	q := e.querier
+	if !q.rawDisplay() && !q.structuredOutput && q.dims.Width > 0 {
+		utils.UpdateMessageTerminalMetadata(pending, &session.Line, &session.LineCount, q.dims.Width)
+		rowsToClear := session.LineCount - 1
+		if q.activityViewport != nil {
+			rowsToClear += q.activityViewport.DetachRenderedRegion()
+		}
+		if err := table.ClearTermTo(q.out, rowsToClear); err != nil {
 			return fmt.Errorf("clear streamed assistant text before tool call: %w", err)
 		}
 	}
@@ -372,16 +379,65 @@ func (e toolExecutor[C]) finalizeAssistantTextBeforeToolCall(session *QuerySessi
 		Role:    "assistant",
 		Content: pending,
 	})
-	if !q.Raw && !q.structuredOutput {
-		if q.termWidth > 0 {
-			utils.UpdateMessageTerminalMetadata(displayMsg.Content, &q.line, &q.lineCount, q.termWidth)
+	if !q.rawDisplay() && !q.structuredOutput {
+		if q.dims.Width > 0 {
+			utils.UpdateMessageTerminalMetadata(displayMsg.Content, &q.line, &q.lineCount, q.dims.Width)
 		} else {
 			fmt.Fprintln(q.out)
 		}
-		utils.AttemptPrettyPrint(q.out, displayMsg, q.username, q.Raw)
+		utils.AttemptPrettyPrint(q.out, displayMsg, q.username, q.rawDisplay())
 	}
 	session.Line = q.line
 	session.LineCount = q.lineCount
+	return nil
+}
+
+// finalizeAssistantTextRolling finalizes assistant prose while the rolling
+// window is active. The prose already lives inside the window (or is moved
+// into it), so nothing is re-printed outside the window. Echoed tool-call text
+// is dropped from the window and the transcript.
+func (e toolExecutor[C]) finalizeAssistantTextRolling(session *QuerySession, pending string, call pub_models.Call) error {
+	q := e.querier
+	q.ensureActivityViewport()
+	if isEchoedToolCallText(pending, call) {
+		// The model echoed its own tool call as prose. Remove it from the
+		// window when it was streamed there, or clear the direct print when
+		// the window did not exist yet.
+		if q.activityViewport.RemoveTextBlock() > 0 {
+			if err := q.activityViewport.Render(q.out); err != nil {
+				return fmt.Errorf("render activity viewport after dropping echoed tool call: %w", err)
+			}
+		} else if q.dims.Width > 0 {
+			utils.UpdateMessageTerminalMetadata(pending, &session.Line, &session.LineCount, q.dims.Width)
+			if err := table.ClearTermTo(q.out, session.LineCount-1); err != nil {
+				return fmt.Errorf("clear echoed tool call text: %w", err)
+			}
+		}
+		session.ResetPendingText()
+		q.fullMsg = ""
+		q.line = ""
+		q.lineCount = 0
+		return nil
+	}
+	if !q.activityViewport.TextBlockActive() {
+		// The prose was streamed before any activity created the window. Move
+		// it inside the window instead of leaving it outside it.
+		if q.dims.Width > 0 {
+			utils.UpdateMessageTerminalMetadata(pending, &session.Line, &session.LineCount, q.dims.Width)
+			if err := table.ClearTermTo(q.out, session.LineCount-1); err != nil {
+				return fmt.Errorf("clear streamed assistant text before tool call: %w", err)
+			}
+		}
+		q.activityViewport.AppendText(pending)
+		if err := q.activityViewport.Render(q.out); err != nil {
+			return fmt.Errorf("render activity viewport: %w", err)
+		}
+	}
+	session.ResetPendingText()
+	session.FinalAssistantText = pending
+	q.fullMsg = pending
+	q.line = ""
+	q.lineCount = 0
 	return nil
 }
 

--- a/internal/tools/cmd.go
+++ b/internal/tools/cmd.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
+	"github.com/baalimago/clai/internal/utils"
 	"github.com/baalimago/go_away_boilerplate/pkg/table"
 )
 
@@ -52,10 +54,10 @@ func SubCmd(ctx context.Context, args []string) error {
 			aliasSuffix = " (alias: " + strings.Join(aliasesOfTool, ", ") + ")"
 		}
 		prefix := fmt.Sprintf("- %s%s: ", name, aliasSuffix)
-		maybeShortenedDesc, err := table.WidthAppropriateStringTrunc(spec.Description, prefix, 5)
-		if err != nil {
-			return fmt.Errorf("failed to truncate descriptoin: :%v", err)
-		}
+		// The listing writes to stdout, so it resolves one snapshot bound to
+		// stdout's fd (R2-02): a non-terminal stdout yields the deterministic
+		// fallback width.
+		maybeShortenedDesc := table.WidthAppropriateStringTruncWithWidth(spec.Description, prefix, 5, utils.SessionDimensions(os.Stdout).Width)
 		fmt.Println(maybeShortenedDesc)
 	}
 	fmt.Println("\nRun 'clai tools <tool-name>' for more details.")

--- a/internal/tools/mcp/tool.go
+++ b/internal/tools/mcp/tool.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/baalimago/clai/internal/utils"
 	pub_models "github.com/baalimago/clai/pkg/text/models"
 	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
 	"github.com/baalimago/go_away_boilerplate/pkg/debug"
@@ -89,7 +90,10 @@ func (m *mcpTool) call(ctx context.Context, input pub_models.Input) (string, err
 
 			if misc.Truthy(os.Getenv("DEBUG_MCP_TOOL")) {
 				rawS, _ := raw.MarshalJSON()
-				shortened, _ := table.WidthAppropriateStringTrunc(string(rawS), "", 10)
+				// Debug output goes to stdout via ancli, so the snapshot is bound
+				// to stdout's fd; a non-terminal stdout yields the deterministic
+				// fallback width.
+				shortened := table.WidthAppropriateStringTruncWithWidth(string(rawS), "", 10, utils.SessionDimensions(os.Stdout).Width)
 				ancli.Okf("mcp_server client received: '%s'", shortened)
 			}
 			var resp Response

--- a/internal/utils/dimensions.go
+++ b/internal/utils/dimensions.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"io"
+	"os"
+
+	"github.com/baalimago/go_away_boilerplate/pkg/dimensions"
+)
+
+// SessionDimensions resolves the one terminal-size snapshot for w. The
+// snapshot is bound to the writer's file descriptor, so the observed size
+// matches the file the output is actually written to (R2-02): a terminal
+// yields its live size, and a non-terminal writer, a failed read, or a
+// reported zero size deterministically yields dimensions.Fallback (80x24).
+// No error propagates, matching the legacy silent fallback. A nil writer
+// resolves to os.Stdout.
+//
+// This is the single width-discovery point of clai. Every width-aware render
+// path either stores the result of this helper for its session (the querier's
+// snapshot) or calls it once at the start of a standalone render operation.
+func SessionDimensions(w io.Writer) dimensions.Dimensions {
+	if w == nil {
+		w = os.Stdout
+	}
+	if f, ok := w.(*os.File); ok {
+		if d, err := dimensions.DefaultReader(f.Fd())(); err == nil {
+			return d
+		}
+	}
+	return dimensions.Fallback
+}

--- a/internal/utils/dimensions_test.go
+++ b/internal/utils/dimensions_test.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/baalimago/go_away_boilerplate/pkg/dimensions"
+)
+
+// TestSessionDimensions_NonFileWriterFallsBack proves that a writer which is
+// not an *os.File (buffers, builders, io.Discard) has no file descriptor to
+// query, so the deterministic fallback applies. This is the common shape of
+// captured output in tests and pipes in production.
+func TestSessionDimensions_NonFileWriterFallsBack(t *testing.T) {
+	if got := SessionDimensions(&strings.Builder{}); got != dimensions.Fallback {
+		t.Fatalf("SessionDimensions(builder) = %+v, want fallback %+v", got, dimensions.Fallback)
+	}
+	if got := SessionDimensions(nil); got != dimensions.Fallback {
+		t.Fatalf("SessionDimensions(nil) = %+v, want fallback %+v", got, dimensions.Fallback)
+	}
+}
+
+// TestSessionDimensions_RegularFileFallsBack proves that a real file
+// descriptor which is not a terminal (a regular file) yields the
+// deterministic fallback: the ioctl fails, and no environment lookup or
+// fabrication happens at this boundary.
+func TestSessionDimensions_RegularFileFallsBack(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.txt")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create file: %v", err)
+	}
+	defer f.Close()
+
+	got := SessionDimensions(f)
+	if got != dimensions.Fallback {
+		t.Fatalf("SessionDimensions(regular file) = %+v, want fallback %+v", got, dimensions.Fallback)
+	}
+}
+
+// TestSessionDimensions_UsableSize proves that SessionDimensions always
+// returns a usable size: a live terminal yields its real size, and every
+// failure path yields the fallback. Width and height are therefore always
+// positive, so width-aware render paths never divide by zero or emit
+// malformed output.
+func TestSessionDimensions_UsableSize(t *testing.T) {
+	got := SessionDimensions(os.Stdout)
+	if got.Width <= 0 || got.Height <= 0 {
+		t.Fatalf("SessionDimensions(os.Stdout) = %+v, want positive width and height", got)
+	}
+}

--- a/internal/utils/print.go
+++ b/internal/utils/print.go
@@ -210,9 +210,108 @@ func ShortenedOutput(out string, maxShortenedNewlines int) string {
 	return fmt.Sprintf("%v\n...[and %v more %v]", firstTokensStr, amLeft, abbreviationType)
 }
 
+// PrintCompactToolActivity prints non-raw tool output without markdown rendering.
+// It uses at most maxRows terminal rows after the coloured role prefix.
+func PrintCompactToolActivity(w io.Writer, role, content string, termWidth, maxRows int) error {
+	if w == nil {
+		w = os.Stdout
+	}
+	prefix := compactRolePrefix(role, termWidth)
+	contentWidth := max(termWidth-utf8.RuneCountInString(prefix), 1)
+	rows := compactTerminalRows(content, contentWidth, maxRows)
+	for i, row := range rows {
+		if i > 0 {
+			if _, err := fmt.Fprint(w, "\n"); err != nil {
+				return fmt.Errorf("write tool output newline: %w", err)
+			}
+		}
+		if i == 0 {
+			if _, err := fmt.Fprint(w, table.Colorize(RoleColor(role), prefix)); err != nil {
+				return fmt.Errorf("write tool output prefix: %w", err)
+			}
+		}
+		isMarker := isToolOutputMarker(row)
+		row = truncateTerminalRow(row, contentWidth)
+		if isMarker {
+			row = table.Colorize(TableTheme().Secondary, row)
+		}
+		if _, err := fmt.Fprint(w, row); err != nil {
+			return fmt.Errorf("write tool output: %w", err)
+		}
+	}
+	_, err := fmt.Fprintln(w)
+	return err
+}
+
+// PrintCompactToolCall prints one non-raw tool-call status line without glow.
+func PrintCompactToolCall(w io.Writer, role, content string, termWidth int) error {
+	if w == nil {
+		w = os.Stdout
+	}
+	prefix := compactRolePrefix(role, termWidth)
+	content = truncateTerminalRow(content, max(termWidth-utf8.RuneCountInString(prefix), 1))
+	_, err := fmt.Fprintf(w, "%s%s\n", table.Colorize(RoleColor(role), prefix), content)
+	return err
+}
+
+func compactTerminalRows(content string, width, maxRows int) []string {
+	rows := terminalRows(content, width)
+	if maxRows <= 0 || len(rows) <= maxRows {
+		return rows
+	}
+	head := maxRows / 2
+	tail := maxRows - head - 1
+	marker := fmt.Sprintf("... [%d terminal rows omitted] ...", len(rows)-head-tail)
+	compacted := make([]string, 0, maxRows)
+	compacted = append(compacted, rows[:head]...)
+	compacted = append(compacted, marker)
+	compacted = append(compacted, rows[len(rows)-tail:]...)
+	return compacted
+}
+
+func terminalRows(content string, width int) []string {
+	width = max(width, 1)
+	var rows []string
+	for line := range strings.SplitSeq(content, "\n") {
+		runes := []rune(line)
+		if len(runes) == 0 {
+			rows = append(rows, "")
+			continue
+		}
+		for len(runes) > width {
+			rows = append(rows, string(runes[:width]))
+			runes = runes[width:]
+		}
+		rows = append(rows, string(runes))
+	}
+	return rows
+}
+
+func isToolOutputMarker(row string) bool {
+	return strings.HasPrefix(row, "... [") && strings.HasSuffix(row, " terminal rows omitted] ...")
+}
+
+func truncateTerminalRow(content string, width int) string {
+	runes := []rune(content)
+	if len(runes) <= width {
+		return content
+	}
+	if width == 1 {
+		return "…"
+	}
+	return string(runes[:width-1]) + "…"
+}
+
+func compactRolePrefix(role string, width int) string {
+	if width <= 1 {
+		return ""
+	}
+	return truncateTerminalRow(role+": ", width-1)
+}
+
 func PrepareDisplayMessage(msg pub_models.Message) pub_models.Message {
 	display := msg
-	if display.Role == "tool" && !strings.Contains(display.Content, "mcp_") {
+	if display.Role == "tool" {
 		display.Content = ShortenedOutput(display.Content, MaxShortenedNewlines)
 		return display
 	}

--- a/internal/utils/print.go
+++ b/internal/utils/print.go
@@ -2,17 +2,27 @@ package utils
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"unicode"
 	"unicode/utf8"
 
 	pub_models "github.com/baalimago/clai/pkg/text/models"
 	"github.com/baalimago/go_away_boilerplate/pkg/table"
+	"golang.org/x/text/width"
+)
+
+var (
+	ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]`)
+	ansiOSCPattern    = regexp.MustCompile(`\x1b\][^\a\x1b]*(?:\a|\x1b\\)`)
 )
 
 const MaxShortenedNewlines = 5
@@ -135,10 +145,7 @@ func AttemptPrettyPrint(w io.Writer, chatMessage pub_models.Message, username st
 		}
 	}
 
-	termWidth, err := table.TermWidth()
-	if err != nil {
-		return fmt.Errorf("get terminal width for glow: %w", err)
-	}
+	termWidth := SessionDimensions(w).Width
 
 	cmd := exec.Command("glow", glowRenderArgs(termWidth)...)
 	inp := content
@@ -171,6 +178,9 @@ func isTerminalWriter(w io.Writer) bool {
 	}
 	return fi.Mode()&os.ModeCharDevice != 0
 }
+
+// IsTerminalWriter reports whether w resolves to a terminal writer.
+func IsTerminalWriter(w io.Writer) bool { return isTerminalWriter(w) }
 
 // glowAvailable reports whether the glow markdown renderer is installed. The
 // probe spawns a subprocess, so it runs once per process.
@@ -210,32 +220,30 @@ func ShortenedOutput(out string, maxShortenedNewlines int) string {
 	return fmt.Sprintf("%v\n...[and %v more %v]", firstTokensStr, amLeft, abbreviationType)
 }
 
-// PrintCompactToolActivity prints non-raw tool output without markdown rendering.
-// It uses at most maxRows terminal rows after the coloured role prefix.
-func PrintCompactToolActivity(w io.Writer, role, content string, termWidth, maxRows int) error {
+// PrintToolActivity prints one non-raw tool execution as a header and its result.
+// The model transcript remains independent from this display-only representation.
+func PrintToolActivity(w io.Writer, call pub_models.Call, content string, termWidth, maxRows int) error {
 	if w == nil {
 		w = os.Stdout
 	}
-	prefix := compactRolePrefix(role, termWidth)
-	contentWidth := max(termWidth-utf8.RuneCountInString(prefix), 1)
+	header := truncateTerminalRow(toolActivityHeader(call), max(termWidth, 1))
+	if _, err := fmt.Fprintln(w, table.Colorize(TableTheme().Primary, header)); err != nil {
+		return fmt.Errorf("write tool activity header: %w", err)
+	}
+	content = SummarizeAsyncToolResult(call.Name, content)
+	content = sanitizeTerminalText(content)
+	contentWidth := max(termWidth-2, 1)
 	rows := compactTerminalRows(content, contentWidth, maxRows)
 	for i, row := range rows {
-		if i > 0 {
-			if _, err := fmt.Fprint(w, "\n"); err != nil {
-				return fmt.Errorf("write tool output newline: %w", err)
-			}
-		}
-		if i == 0 {
-			if _, err := fmt.Fprint(w, table.Colorize(RoleColor(role), prefix)); err != nil {
-				return fmt.Errorf("write tool output prefix: %w", err)
-			}
-		}
 		isMarker := isToolOutputMarker(row)
 		row = truncateTerminalRow(row, contentWidth)
 		if isMarker {
 			row = table.Colorize(TableTheme().Secondary, row)
 		}
-		if _, err := fmt.Fprint(w, row); err != nil {
+		if i == 0 && isToolError(content) {
+			row = table.Colorize(RoleColor("tool"), truncateTerminalRow("✗ "+row, contentWidth))
+		}
+		if _, err := fmt.Fprintf(w, "  %s\n", row); err != nil {
 			return fmt.Errorf("write tool output: %w", err)
 		}
 	}
@@ -243,15 +251,590 @@ func PrintCompactToolActivity(w io.Writer, role, content string, termWidth, maxR
 	return err
 }
 
-// PrintCompactToolCall prints one non-raw tool-call status line without glow.
-func PrintCompactToolCall(w io.Writer, role, content string, termWidth int) error {
+func toolActivityHeader(call pub_models.Call) string {
+	var header strings.Builder
+	header.WriteString("▸ ")
+	header.WriteString(sanitizeTerminalRow(displayToolName(call.Name)))
+	for _, key := range sortedInputKeys(call.Inputs) {
+		fmt.Fprintf(&header, "  %s=%s", sanitizeTerminalRow(key), sanitizeTerminalRow(displayInputValue((*call.Inputs)[key])))
+	}
+	return strings.TrimSpace(header.String())
+}
+
+func displayToolName(name string) string {
+	if !strings.HasPrefix(name, "mcp_") {
+		return name
+	}
+	name = strings.TrimPrefix(name, "mcp_")
+	server, tool, found := strings.Cut(name, "_")
+	if found {
+		return server + "." + tool
+	}
+	return name
+}
+
+func sortedInputKeys(inputs *pub_models.Input) []string {
+	if inputs == nil {
+		return nil
+	}
+	keys := make([]string, 0, len(*inputs))
+	for key := range *inputs {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func displayInputValue(value any) string {
+	if text, ok := value.(string); ok {
+		return strings.Join(strings.Fields(sanitizeTerminalText(text)), " ")
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprint(value)
+	}
+	return string(encoded)
+}
+
+func sanitizeTerminalText(text string) string {
+	text = ansiEscapePattern.ReplaceAllString(text, "")
+	text = ansiOSCPattern.ReplaceAllString(text, "")
+	text = strings.Map(func(r rune) rune {
+		switch r {
+		case '\n':
+			return r
+		case '\t':
+			return ' '
+		case '\r':
+			return -1
+		}
+		if r < ' ' || r == 0x7f {
+			return -1
+		}
+		return r
+	}, text)
+	return text
+}
+
+// sanitizeTerminalRow makes untrusted text safe for a single terminal row.
+func sanitizeTerminalRow(text string) string {
+	return strings.TrimSpace(strings.Map(func(r rune) rune {
+		switch r {
+		case '\n', '\r', '\t':
+			return ' '
+		}
+		return r
+	}, sanitizeTerminalText(text)))
+}
+
+// ActivityViewport keeps a bounded, display-only view of streamed reasoning,
+// assistant prose, and tool activity. It never changes model or tool source data.
+//
+// Storage is logical, not visual: each block keeps the full sanitized content
+// (the source of truth) plus its display policy (kind, header and role colours,
+// 2-space body indentation, and tool output-marker and ERROR: handling).
+// Colours and indentation are re-derived at rewrap time, so a width change
+// rewraps every retained block instead of reconstructing content from already
+// wrapped rows. The active reasoning and text blocks coalesce streamed tokens
+// into one open block; finished blocks keep their logical content until the
+// retention policy evicts them (maxActivityBlocks blocks, each bounded by
+// maxActivityBlockRunes). A terminal-height grow can therefore bring retained
+// content back into view, bounded by retention, not by the last visible row
+// count.
+type ActivityViewport struct {
+	width   int
+	maxRows int
+	// height is the effective height: min(configured cap, terminal height).
+	height int
+	blocks []*activityBlock
+	// activeReasoning and activeText are the open coalescing blocks. They are
+	// always the last blocks in the history and are never evicted.
+	activeReasoning *activityBlock
+	activeText      *activityBlock
+	rows            []activityRow
+	drawnRows       int
+	lastRendered    []string
+	// dirty marks that the on-screen region no longer matches the viewport
+	// state (after Resize or a partial write); the next Render emits a complete
+	// atomic frame instead of a diff.
+	dirty bool
+}
+
+// maxActivityBlocks bounds the number of logical blocks retained in the
+// activity history. Finished blocks keep their logical content until this
+// retention policy evicts them; the open coalescing blocks always survive.
+const maxActivityBlocks = 16
+
+// maxActivityBlockRunes bounds the sanitized content retained per logical
+// block. The bound exists to keep memory bounded; realistic activity blocks
+// never reach it. Content beyond the budget is reduced to its head and tail
+// (mirroring the display policy), so a later rewrap still has the content the
+// policy would show.
+const maxActivityBlockRunes = 64 * 1024
+
+// contentTruncationMarker separates the retained head and tail of an
+// over-budget block.
+const contentTruncationMarker = "\n...[content truncated]...\n"
+
+// blockKind identifies the display policy of a logical activity block.
+type blockKind uint8
+
+const (
+	blockReasoning blockKind = iota
+	blockText
+	blockTool
+)
+
+// activityBlock is one logical activity unit. Content is the sanitized source
+// of truth; rows is a display cache re-derived at rewrap time (Resize and
+// streaming updates).
+type activityBlock struct {
+	kind    blockKind
+	content string
+	// call is the tool-call metadata used to render the tool header.
+	call pub_models.Call
+	// toolBodyRows is the body compaction budget of tool blocks.
+	toolBodyRows int
+	rows         []activityRow
+}
+
+type activityRow struct {
+	content string
+	color   string
+}
+
+// NewActivityViewport creates a viewport for all transient model activity.
+// maxRows is the configured rolling-window cap; terminalHeight is the raw
+// terminal height at creation. The effective height is
+// min(maxRows, max(terminalHeight, 1)) from the start, so the viewport never
+// renders taller than the terminal it writes to (R5-01). Resize takes raw
+// terminal dimensions and keeps the same min(cap, terminal height) bound on
+// later dimension changes.
+func NewActivityViewport(width, maxRows, terminalHeight int) *ActivityViewport {
+	capRows := max(maxRows, 1)
+	return &ActivityViewport{
+		width:   max(width, 1),
+		maxRows: capRows,
+		height:  min(capRows, max(terminalHeight, 1)),
+	}
+}
+
+// AppendReasoning adds a reasoning block. The warm colour applies only to its
+// header; its indented body has the same neutral presentation as tool output.
+// An open assistant-prose block is closed first so the reasoning starts a new
+// block.
+func (v *ActivityViewport) AppendReasoning(content string) {
+	if v == nil {
+		return
+	}
+	v.FinishText()
+	v.appendCoalescing(&v.activeReasoning, blockReasoning, content)
+}
+
+// AppendText adds an assistant-prose block to the same viewport. Streamed
+// tokens coalesce into one block until FinishText or RemoveTextBlock closes it.
+func (v *ActivityViewport) AppendText(content string) {
+	if v == nil {
+		return
+	}
+	v.FinishReasoning()
+	v.appendCoalescing(&v.activeText, blockText, content)
+}
+
+// appendCoalescing appends streamed content to the open block of the given
+// kind, creating it (and evicting the oldest finished block) when needed. The
+// open block is always the last retained block.
+func (v *ActivityViewport) appendCoalescing(active **activityBlock, kind blockKind, content string) {
+	if *active == nil {
+		*active = &activityBlock{kind: kind}
+		v.blocks = append(v.blocks, *active)
+		v.evict()
+	}
+	(*active).content = boundContent((*active).content + sanitizeTerminalText(content))
+	(*active).rows = v.wrapBlock(*active)
+	v.rewrap()
+}
+
+// FinishReasoning closes the current reasoning block. Its visible rows stay in
+// the activity history, while the next reasoning event starts a new block.
+func (v *ActivityViewport) FinishReasoning() {
+	if v == nil {
+		return
+	}
+	v.activeReasoning = nil
+}
+
+// FinishText closes the active assistant-prose block. Its visible rows stay in
+// the activity history, while the next prose stream starts a new block.
+func (v *ActivityViewport) FinishText() {
+	if v == nil {
+		return
+	}
+	v.activeText = nil
+}
+
+// RemoveTextBlock removes the active assistant-prose block from the activity
+// history and returns the number of rows removed. The final answer is removed
+// this way so it prints below the window instead of remaining inside it. The
+// active text block is the last retained block, so its rows are the cache tail.
+func (v *ActivityViewport) RemoveTextBlock() int {
+	if v == nil || v.activeText == nil {
+		return 0
+	}
+	removed := min(len(v.rows), len(v.activeText.rows))
+	for i, block := range v.blocks {
+		if block == v.activeText {
+			v.blocks = append(v.blocks[:i], v.blocks[i+1:]...)
+			break
+		}
+	}
+	v.activeText = nil
+	v.rewrap()
+	return removed
+}
+
+// TextBlockActive reports whether an assistant-prose block is currently open.
+func (v *ActivityViewport) TextBlockActive() bool {
+	return v != nil && v.activeText != nil
+}
+
+// AppendTool adds a compacted tool block to the same viewport. An open
+// assistant-prose or reasoning block is closed first so the tool starts a new
+// block.
+func (v *ActivityViewport) AppendTool(call pub_models.Call, content string, maxRows int) {
+	if v == nil {
+		return
+	}
+	v.FinishText()
+	v.FinishReasoning()
+	block := &activityBlock{
+		kind:         blockTool,
+		content:      boundContent(sanitizeTerminalText(content)),
+		call:         call,
+		toolBodyRows: maxRows,
+	}
+	v.blocks = append(v.blocks, block)
+	block.rows = v.wrapBlock(block)
+	v.evict()
+	v.rewrap()
+}
+
+// evict drops the oldest finished blocks once the retained history exceeds
+// maxActivityBlocks. The open coalescing blocks always survive; finished
+// blocks keep their logical content until this policy evicts them.
+func (v *ActivityViewport) evict() {
+	if len(v.blocks) <= maxActivityBlocks {
+		return
+	}
+	excess := len(v.blocks) - maxActivityBlocks
+	kept := make([]*activityBlock, 0, len(v.blocks)-excess)
+	dropped := 0
+	for _, block := range v.blocks {
+		if dropped < excess && block != v.activeReasoning && block != v.activeText {
+			dropped++
+			continue
+		}
+		kept = append(kept, block)
+	}
+	v.blocks = kept
+}
+
+// wrapBlock derives the display rows of one block at the current width,
+// re-applying the block's display policy. The "keep header and trailing rows,
+// drop middle" policy is width-stable: the same policy runs at every width,
+// even though the visible rows change because wrapping changes.
+func (v *ActivityViewport) wrapBlock(block *activityBlock) []activityRow {
+	switch block.kind {
+	case blockReasoning:
+		rows := []activityRow{{content: "∴ thinking", color: RoleColor("reasoning")}}
+		for _, row := range terminalRows(block.content, max(v.width-2, 1)) {
+			rows = append(rows, activityRow{content: "  " + row})
+		}
+		return compactActivityBlock(rows, v.height)
+	case blockText:
+		rows := []activityRow{{content: "assistant", color: RoleColor("assistant")}}
+		for _, row := range terminalRows(block.content, max(v.width-2, 1)) {
+			rows = append(rows, activityRow{content: "  " + row})
+		}
+		return compactActivityBlock(rows, v.height)
+	case blockTool:
+		rows := []activityRow{{content: truncateTerminalRow(toolActivityHeader(block.call), v.width), color: TableTheme().Primary}}
+		for _, row := range compactTerminalRows(block.content, max(v.width-2, 1), block.toolBodyRows) {
+			color := ""
+			if isToolOutputMarker(row) {
+				color = TableTheme().Secondary
+			}
+			if strings.HasPrefix(row, "ERROR:") {
+				row = truncateTerminalRow("✗ "+row, max(v.width-2, 1))
+				color = RoleColor("tool")
+			}
+			rows = append(rows, activityRow{content: "  " + row, color: color})
+		}
+		return append(rows, activityRow{})
+	}
+	return nil
+}
+
+// compactActivityBlock keeps a wrapped block's header and trailing rows and
+// drops its middle once it exceeds the row budget.
+func compactActivityBlock(rows []activityRow, budget int) []activityRow {
+	if budget <= 1 {
+		if len(rows) > 1 {
+			return rows[:1]
+		}
+		return rows
+	}
+	if len(rows) <= budget {
+		return rows
+	}
+	compacted := make([]activityRow, 0, budget)
+	compacted = append(compacted, rows[0])
+	compacted = append(compacted, rows[len(rows)-(budget-1):]...)
+	return compacted
+}
+
+// boundContent caps a block's retained content at maxActivityBlockRunes,
+// keeping the head and tail so a later rewrap still has the content the
+// display policy would show.
+func boundContent(content string) string {
+	if utf8.RuneCountInString(content) <= maxActivityBlockRunes {
+		return content
+	}
+	runes := []rune(content)
+	markerLen := utf8.RuneCountInString(contentTruncationMarker)
+	head := (maxActivityBlockRunes - markerLen) / 2
+	tail := maxActivityBlockRunes - markerLen - head
+	return string(runes[:head]) + contentTruncationMarker + string(runes[len(runes)-tail:])
+}
+
+// rewrap rebuilds the visible row cache from the retained blocks. Only the
+// trailing effective-height rows are kept; earlier history stays in the blocks
+// for a later height-grow reappearance.
+func (v *ActivityViewport) rewrap() {
+	rows := make([]activityRow, 0, v.height)
+	for _, block := range v.blocks {
+		rows = append(rows, block.rows...)
+	}
+	if len(rows) > v.height {
+		rows = rows[len(rows)-v.height:]
+	}
+	v.rows = rows
+}
+
+// Content returns the sanitized content of the open reasoning block, or ""
+// when no reasoning block is open.
+func (v *ActivityViewport) Content() string {
+	if v == nil || v.activeReasoning == nil {
+		return ""
+	}
+	return v.activeReasoning.content
+}
+
+// Rows returns the physical terminal rows currently visible in the viewport.
+func (v *ActivityViewport) Rows() []string {
+	if v == nil {
+		return nil
+	}
+	rows := make([]string, 0, len(v.rows))
+	for _, row := range v.rows {
+		rows = append(rows, row.content)
+	}
+	return rows
+}
+
+// Resize applies new terminal dimensions to the viewport. It mutates state
+// only: it stores the new width, computes the effective height as
+// min(configured cap, terminal height), rewraps all retained blocks at the new
+// width, invalidates the render bookkeeping, and marks the viewport dirty. It
+// never writes to the writer and is a no-op when the supplied dimensions equal
+// the current ones. Resize is invoked only from the serialized session loop,
+// never from a signal callback; mutation and rendering stay on that loop, so
+// no mutex is needed.
+func (v *ActivityViewport) Resize(width, terminalHeight int) {
+	if v == nil {
+		return
+	}
+	width = max(width, 1)
+	height := min(v.maxRows, max(terminalHeight, 1))
+	if width == v.width && height == v.height {
+		return
+	}
+	v.width = width
+	v.height = height
+	for _, block := range v.blocks {
+		block.rows = v.wrapBlock(block)
+	}
+	v.rewrap()
+	v.dirty = true
+}
+
+// Render redraws the viewport in its existing terminal region. A dirty
+// viewport (after Resize or a partial write) emits one complete atomic frame:
+// move up the previously drawn rows, clear down, and rewrite the full window.
+// The diff path is used only for normal streaming appends: pure appends print
+// below the previously drawn region without clearing, and a changed tail
+// clears from the first changed row down. The whole update lands in one write,
+// so the terminal never paints an intermediate blank frame. The cursor is left
+// below the viewport so subsequent tool activity or answer text follows it. A
+// partial or failed write leaves the viewport dirty; the next Render retries
+// the full frame.
+func (v *ActivityViewport) Render(w io.Writer) error {
+	if v == nil {
+		return nil
+	}
 	if w == nil {
 		w = os.Stdout
 	}
-	prefix := compactRolePrefix(role, termWidth)
-	content = truncateTerminalRow(content, max(termWidth-utf8.RuneCountInString(prefix), 1))
-	_, err := fmt.Fprintf(w, "%s%s\n", table.Colorize(RoleColor(role), prefix), content)
-	return err
+	rendered := make([]string, 0, len(v.rows))
+	for _, row := range v.rows {
+		rendered = append(rendered, table.Colorize(row.color, row.content))
+	}
+	var buf bytes.Buffer
+	if v.dirty {
+		if v.drawnRows > 0 {
+			fmt.Fprintf(&buf, "\x1b[%dA\r\x1b[J", v.drawnRows)
+		}
+		for _, row := range rendered {
+			fmt.Fprintln(&buf, row)
+		}
+	} else {
+		start := 0
+		clearUp := 0
+		if v.drawnRows > 0 {
+			common := commonRowPrefix(v.lastRendered, rendered)
+			switch {
+			case common == len(v.lastRendered) && common == len(rendered):
+				return nil // content unchanged, nothing to redraw
+			case common == len(v.lastRendered):
+				start = len(v.lastRendered) // pure append, no clear needed
+			default:
+				start = common
+				clearUp = len(v.lastRendered) - common
+			}
+		}
+		if clearUp > 0 {
+			fmt.Fprintf(&buf, "\x1b[%dA\r\x1b[J", clearUp)
+		}
+		for _, row := range rendered[start:] {
+			fmt.Fprintln(&buf, row)
+		}
+	}
+	if buf.Len() == 0 {
+		if v.dirty {
+			// The empty frame is complete: nothing was drawn before, nothing
+			// needs clearing, and the viewport is clean again.
+			v.drawnRows = len(rendered)
+			v.lastRendered = rendered
+			v.dirty = false
+		}
+		return nil
+	}
+	n, err := w.Write(buf.Bytes())
+	if err != nil {
+		v.dirty = true
+		return fmt.Errorf("write activity viewport: %w", err)
+	}
+	if n != buf.Len() {
+		v.dirty = true
+		return fmt.Errorf("write activity viewport: short write (%d of %d bytes)", n, buf.Len())
+	}
+	v.drawnRows = len(rendered)
+	v.lastRendered = rendered
+	v.dirty = false
+	return nil
+}
+
+// commonRowPrefix returns the number of leading rows shared by two renderings.
+func commonRowPrefix(a, b []string) int {
+	n := min(len(a), len(b))
+	i := 0
+	for i < n && a[i] == b[i] {
+		i++
+	}
+	return i
+}
+
+// DetachRenderedRegion transfers ownership of the rows already drawn to the
+// caller. The retained activity history will render at the current cursor
+// position on the next Render call.
+func (v *ActivityViewport) DetachRenderedRegion() int {
+	if v == nil {
+		return 0
+	}
+	drawnRows := v.drawnRows
+	v.drawnRows = 0
+	v.lastRendered = nil
+	v.dirty = false
+	return drawnRows
+}
+
+func isToolError(content string) bool {
+	return strings.Contains(content, "ERROR:")
+}
+
+// SummarizeAsyncToolResult returns the concise interactive representation of
+// async tool output. Raw and redirected output bypass this helper.
+func SummarizeAsyncToolResult(name, content string) string {
+	if !strings.HasPrefix(name, "async_cmd") {
+		return content
+	}
+	var result map[string]any
+	if json.Unmarshal([]byte(content), &result) != nil {
+		return content
+	}
+	if name == "async_cmd_logs" {
+		return summarizeAsyncLogs(result)
+	}
+	return summarizeAsyncStatus(result)
+}
+
+func summarizeAsyncStatus(result map[string]any) string {
+	var parts []string
+	if value := stringField(result, "result"); value != "" {
+		parts = append(parts, "result="+value)
+	}
+	if value := stringField(result, "status"); value != "" {
+		parts = append(parts, "status="+value)
+	}
+	if value := stringField(result, "async_cmd_id"); value != "" {
+		parts = append(parts, "id="+value)
+	}
+	if value, ok := result["exit_code"]; ok && value != nil {
+		parts = append(parts, "exit="+fmt.Sprint(value))
+	}
+	if value := stringField(result, "error"); value != "" {
+		parts = append(parts, "error="+value)
+	}
+	if commands, ok := result["async_cmds"].([]any); ok {
+		for _, command := range commands {
+			if status, ok := command.(map[string]any); ok {
+				parts = append(parts, summarizeAsyncStatus(status))
+			}
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func summarizeAsyncLogs(result map[string]any) string {
+	var summary strings.Builder
+	summary.WriteString(summarizeAsyncStatus(result))
+	for _, streamName := range []string{"stdout", "stderr"} {
+		stream, ok := result[streamName].(map[string]any)
+		if !ok {
+			continue
+		}
+		preview := stringField(stream, "preview")
+		if preview == "" {
+			continue
+		}
+		summary.WriteString("\n" + streamName + ":\n" + preview)
+	}
+	return summary.String()
+}
+
+func stringField(values map[string]any, key string) string {
+	value, _ := values[key].(string)
+	return value
 }
 
 func compactTerminalRows(content string, width, maxRows int) []string {
@@ -273,16 +856,27 @@ func terminalRows(content string, width int) []string {
 	width = max(width, 1)
 	var rows []string
 	for line := range strings.SplitSeq(content, "\n") {
-		runes := []rune(line)
-		if len(runes) == 0 {
+		if line == "" {
 			rows = append(rows, "")
 			continue
 		}
-		for len(runes) > width {
-			rows = append(rows, string(runes[:width]))
-			runes = runes[width:]
+		var row strings.Builder
+		rowWidth := 0
+		for _, r := range line {
+			cellWidth := terminalRuneWidth(r)
+			if cellWidth > width {
+				r = '…'
+				cellWidth = 1
+			}
+			if rowWidth > 0 && rowWidth+cellWidth > width {
+				rows = append(rows, row.String())
+				row.Reset()
+				rowWidth = 0
+			}
+			row.WriteRune(r)
+			rowWidth += cellWidth
 		}
-		rows = append(rows, string(runes))
+		rows = append(rows, row.String())
 	}
 	return rows
 }
@@ -292,21 +886,47 @@ func isToolOutputMarker(row string) bool {
 }
 
 func truncateTerminalRow(content string, width int) string {
-	runes := []rune(content)
-	if len(runes) <= width {
+	width = max(width, 1)
+	if terminalStringWidth(content) <= width {
 		return content
 	}
 	if width == 1 {
 		return "…"
 	}
-	return string(runes[:width-1]) + "…"
+	var truncated strings.Builder
+	used := 0
+	for _, r := range content {
+		runeWidth := terminalRuneWidth(r)
+		if used+runeWidth > width-1 {
+			break
+		}
+		truncated.WriteRune(r)
+		used += runeWidth
+	}
+	truncated.WriteRune('…')
+	return truncated.String()
 }
 
-func compactRolePrefix(role string, width int) string {
-	if width <= 1 {
-		return ""
+func terminalStringWidth(content string) int {
+	cellWidth := 0
+	for _, r := range content {
+		cellWidth += terminalRuneWidth(r)
 	}
-	return truncateTerminalRow(role+": ", width-1)
+	return cellWidth
+}
+
+func terminalRuneWidth(r rune) int {
+	if unicode.Is(unicode.Mn, r) || unicode.Is(unicode.Me, r) || unicode.Is(unicode.Cf, r) {
+		return 0
+	}
+	switch width.LookupRune(r).Kind() {
+	case width.EastAsianFullwidth, width.EastAsianWide:
+		return 2
+	}
+	if r >= 0x1f000 && r <= 0x1faff {
+		return 2
+	}
+	return 1
 }
 
 func PrepareDisplayMessage(msg pub_models.Message) pub_models.Message {

--- a/internal/utils/print_test.go
+++ b/internal/utils/print_test.go
@@ -1,11 +1,33 @@
 package utils
 
 import (
+	"bytes"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	pub_models "github.com/baalimago/clai/pkg/text/models"
 )
+
+// errorWriter fails every write with a fixed error, pinning the phase-3
+// collaborator-error contract: width-aware render helpers surface writer
+// failures instead of silently dropping output.
+type errorWriter struct{ err error }
+
+func (w errorWriter) Write([]byte) (int, error) { return 0, w.err }
+
+func TestPrintToolActivity_WriterErrorSurfaces(t *testing.T) {
+	want := errors.New("disk full")
+	err := PrintToolActivity(errorWriter{err: want}, pub_models.Call{Name: "ls"}, "output", 80, 3)
+	if err == nil {
+		t.Fatal("expected the writer error to surface")
+	}
+	if !errors.Is(err, want) {
+		t.Fatalf("expected the writer error to be wrapped, got: %v", err)
+	}
+}
 
 func TestUpdateMessageTerminalMetadata(t *testing.T) {
 	testCases := []struct {
@@ -209,25 +231,368 @@ func TestCompactToolActivity(t *testing.T) {
 		}
 	})
 
-	t.Run("non raw display uses no glow and respects no color", func(t *testing.T) {
+	t.Run("pairs a concise call header with its indented result", func(t *testing.T) {
 		t.Setenv("NO_COLOR", "true")
 		var out strings.Builder
-		if err := PrintCompactToolActivity(&out, "tool", "one\ntwo\nthree\nfour", 80, 3); err != nil {
-			t.Fatalf("PrintCompactToolActivity: %v", err)
+		inputs := pub_models.Input{"long": true, "directory": "/tmp/example"}
+		call := pub_models.Call{Name: "ls", Inputs: &inputs}
+		if err := PrintToolActivity(&out, call, "one\ntwo\nthree\nfour", 80, 3); err != nil {
+			t.Fatalf("PrintToolActivity: %v", err)
 		}
-		if got, want := out.String(), "tool: one\n... [2 terminal rows omitted] ...\nfour\n"; got != want {
-			t.Fatalf("PrintCompactToolActivity() = %q, want %q", got, want)
+		if got, want := out.String(), "▸ ls  directory=/tmp/example  long=true\n  one\n  ... [2 terminal rows omitted] ...\n  four\n\n"; got != want {
+			t.Fatalf("PrintToolActivity() = %q, want %q", got, want)
 		}
 	})
 
-	t.Run("tool call status is one terminal row", func(t *testing.T) {
+	t.Run("renders MCP names as server dot tool and marks errors", func(t *testing.T) {
 		t.Setenv("NO_COLOR", "true")
 		var out strings.Builder
-		if err := PrintCompactToolCall(&out, "assistant", "Call: very-long-tool-name", 16); err != nil {
-			t.Fatalf("PrintCompactToolCall: %v", err)
+		call := pub_models.Call{Name: "mcp_filesystem_list_directory"}
+		if err := PrintToolActivity(&out, call, "ERROR: permission denied", 80, 6); err != nil {
+			t.Fatalf("PrintToolActivity: %v", err)
 		}
-		if got, want := out.String(), "assistant: Call…\n"; got != want {
-			t.Fatalf("PrintCompactToolCall() = %q, want %q", got, want)
+		if got, want := out.String(), "▸ filesystem.list_directory\n  ✗ ERROR: permission denied\n\n"; got != want {
+			t.Fatalf("PrintToolActivity() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("keeps multiline and styled inputs on one safe header row", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var out strings.Builder
+		inputs := pub_models.Input{"command": "printf 'one\ntwo'\n\x1b[31mecho red\x1b[0m"}
+		call := pub_models.Call{Name: "cmd", Inputs: &inputs}
+		if err := PrintToolActivity(&out, call, "done", 120, 6); err != nil {
+			t.Fatalf("PrintToolActivity: %v", err)
+		}
+		lines := strings.Split(strings.TrimSuffix(out.String(), "\n\n"), "\n")
+		if len(lines) != 2 {
+			t.Fatalf("expected one header and one result row, got %q", out.String())
+		}
+		if strings.Contains(out.String(), "\x1b[") {
+			t.Fatalf("expected tool-provided ANSI escapes to be removed, got %q", out.String())
+		}
+	})
+
+	t.Run("sanitizes tool names and keys including OSC controls", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var out strings.Builder
+		inputs := pub_models.Input{"key\n\x1b]8;;https://bad.example\a": "value\r\x1b]0;title\a"}
+		call := pub_models.Call{Name: "tool\x1b[2J\nname", Inputs: &inputs}
+		if err := PrintToolActivity(&out, call, "done", 120, 6); err != nil {
+			t.Fatalf("PrintToolActivity: %v", err)
+		}
+		for _, forbidden := range []string{"\x1b", "\r", "\a"} {
+			if strings.Contains(out.String(), forbidden) {
+				t.Fatalf("header contains terminal control %q: %q", forbidden, out.String())
+			}
+		}
+		if got := strings.Count(strings.TrimSuffix(out.String(), "\n\n"), "\n"); got != 1 {
+			t.Fatalf("expected one safe header row and one result row, got %q", out.String())
+		}
+	})
+
+	t.Run("summarizes async logs without JSON escaping", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var out strings.Builder
+		call := pub_models.Call{Name: "async_cmd_logs"}
+		result := `{"async_cmd_id":"async_cmd_1","status":"succeeded","stdout":{"preview":"line one\nline two","truncated":false,"log_path":"/tmp/out"},"stderr":{"preview":"warning","truncated":false,"log_path":"/tmp/err"}}`
+		if err := PrintToolActivity(&out, call, result, 80, 6); err != nil {
+			t.Fatalf("PrintToolActivity: %v", err)
+		}
+		got := out.String()
+		for _, want := range []string{"status=succeeded id=async_cmd_1", "stdout:", "line one", "line two", "stderr:", "warning"} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("expected %q in %q", want, got)
+			}
+		}
+		if strings.Contains(got, `\n`) {
+			t.Fatalf("expected decoded log preview, got %q", got)
+		}
+	})
+
+	t.Run("summarizes async await lifecycle data", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var out strings.Builder
+		call := pub_models.Call{Name: "async_cmd_await"}
+		result := `{"result":"completed","async_cmds":[{"async_cmd_id":"async_cmd_1","status":"succeeded","exit_code":0,"stdout_log_path":"/tmp/out"}]}`
+		if err := PrintToolActivity(&out, call, result, 120, 6); err != nil {
+			t.Fatalf("PrintToolActivity: %v", err)
+		}
+		got := out.String()
+		for _, want := range []string{"result=completed", "status=succeeded", "id=async_cmd_1", "exit=0"} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("expected %q in %q", want, got)
+			}
+		}
+		if strings.Contains(got, "stdout_log_path") {
+			t.Fatalf("expected lifecycle paths to be omitted, got %q", got)
+		}
+	})
+}
+
+func TestActivityViewport(t *testing.T) {
+	t.Run("wraps wide unicode by terminal cells", func(t *testing.T) {
+		viewport := NewActivityViewport(10, 6, 6)
+		viewport.AppendReasoning("界界界界界")
+
+		got := viewport.Rows()
+		want := []string{"∴ thinking", "  界界界界", "  界"}
+		if strings.Join(got, "\n") != strings.Join(want, "\n") {
+			t.Fatalf("Rows() = %q, want display-cell wrapping %q", got, want)
+		}
+	})
+
+	t.Run("coalesces streamed reasoning chunks into one wrapped block", func(t *testing.T) {
+		viewport := NewActivityViewport(20, 6, 6)
+		viewport.AppendReasoning("inspect ")
+		viewport.AppendReasoning("the repository")
+
+		got := viewport.Rows()
+		want := []string{"∴ thinking", "  inspect the reposi", "  tory"}
+		if strings.Join(got, "\n") != strings.Join(want, "\n") {
+			t.Fatalf("Rows() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("starts a new thinking block after reasoning finishes", func(t *testing.T) {
+		viewport := NewActivityViewport(40, 8, 8)
+		viewport.AppendReasoning("first")
+		viewport.FinishReasoning()
+		viewport.AppendTool(pub_models.Call{Name: "pwd"}, "/tmp", 2)
+		viewport.AppendReasoning("second")
+
+		if got := strings.Count(strings.Join(viewport.Rows(), "\n"), "∴ thinking"); got != 2 {
+			t.Fatalf("thinking header count = %d, want 2; rows=%q", got, viewport.Rows())
+		}
+	})
+
+	t.Run("keeps mixed activity within one rolling viewport", func(t *testing.T) {
+		viewport := NewActivityViewport(20, 5, 5)
+		viewport.AppendReasoning("one two")
+		inputs := pub_models.Input{"path": "/tmp"}
+		viewport.AppendTool(pub_models.Call{Name: "ls", Inputs: &inputs}, "first\nsecond", 6)
+
+		got := viewport.Rows()
+		want := []string{"  one two", "▸ ls  path=/tmp", "  first", "  second", ""}
+		if strings.Join(got, "\n") != strings.Join(want, "\n") {
+			t.Fatalf("Rows() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("sanitizes display-only reasoning and handles tiny limits", func(t *testing.T) {
+		viewport := NewActivityViewport(0, 0, 0)
+		viewport.AppendReasoning("safe\x1b[31m text\x1b[0m")
+
+		if got, want := viewport.Rows(), []string{"∴ thinking"}; strings.Join(got, "\n") != strings.Join(want, "\n") {
+			t.Fatalf("Rows() = %q, want %q", got, want)
+		}
+		if got := viewport.Content(); got != "safe text" {
+			t.Fatalf("Content() = %q, want sanitized display content", got)
+		}
+	})
+
+	t.Run("redraws only the changed trailing rows", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var out strings.Builder
+		viewport := NewActivityViewport(80, 3, 3)
+		viewport.AppendReasoning("first")
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("first Render(): %v", err)
+		}
+		viewport.AppendReasoning(" second")
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("second Render(): %v", err)
+		}
+		if got := out.String(); !strings.Contains(got, "\x1b[1A\r\x1b[J") {
+			t.Fatalf("expected a single-row redraw, got %q", got)
+		}
+	})
+
+	t.Run("appends new rows without clearing or cursor moves", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var out strings.Builder
+		viewport := NewActivityViewport(80, 6, 6)
+		viewport.AppendReasoning("first")
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("first Render(): %v", err)
+		}
+		viewport.AppendTool(pub_models.Call{Name: "pwd"}, "/tmp", 2)
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("second Render(): %v", err)
+		}
+		if strings.Contains(out.String(), "\x1b[") {
+			t.Fatalf("pure appends must not emit control sequences, got %q", out.String())
+		}
+		for _, want := range []string{"∴ thinking", "  first", "▸ pwd", "  /tmp"} {
+			if !strings.Contains(out.String(), want) {
+				t.Fatalf("expected %q in %q", want, out.String())
+			}
+		}
+	})
+
+	t.Run("skips render when content is unchanged", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var out strings.Builder
+		viewport := NewActivityViewport(80, 3, 3)
+		viewport.AppendReasoning("first")
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("first Render(): %v", err)
+		}
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("second Render(): %v", err)
+		}
+		if got := strings.Count(out.String(), "  first"); got != 1 {
+			t.Fatalf("unchanged render must not reprint rows, got %q", out.String())
+		}
+	})
+
+	t.Run("full redraw when the window scrolls", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var out strings.Builder
+		viewport := NewActivityViewport(80, 3, 3)
+		viewport.AppendReasoning("inspect")
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("first Render(): %v", err)
+		}
+		viewport.AppendTool(pub_models.Call{Name: "pwd"}, "/tmp", 2)
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("second Render(): %v", err)
+		}
+		if !strings.Contains(out.String(), "\x1b[2A\r\x1b[J") {
+			t.Fatalf("expected a full redraw when the drawn rows shift, got %q", out.String())
+		}
+	})
+
+	t.Run("pop redraws only the removed block", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var out strings.Builder
+		viewport := NewActivityViewport(80, 6, 6)
+		viewport.AppendReasoning("inspect")
+		viewport.AppendText("let me check")
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("first Render(): %v", err)
+		}
+		viewport.RemoveTextBlock()
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("second Render(): %v", err)
+		}
+		if !strings.Contains(out.String(), "\x1b[2A\r\x1b[J") {
+			t.Fatalf("expected the pop to clear only the removed rows, got %q", out.String())
+		}
+	})
+
+	t.Run("detaches a rendered region without discarding its history", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var first strings.Builder
+		viewport := NewActivityViewport(80, 6, 6)
+		viewport.AppendReasoning("inspect")
+		if err := viewport.Render(&first); err != nil {
+			t.Fatalf("first Render(): %v", err)
+		}
+
+		if got, want := viewport.DetachRenderedRegion(), 2; got != want {
+			t.Fatalf("DetachRenderedRegion() = %d, want %d", got, want)
+		}
+		viewport.AppendTool(pub_models.Call{Name: "pwd"}, "/tmp", 2)
+		var second strings.Builder
+		if err := viewport.Render(&second); err != nil {
+			t.Fatalf("second Render(): %v", err)
+		}
+		if strings.Contains(second.String(), "\x1b[") {
+			t.Fatalf("detached viewport must render at the new cursor position, got %q", second.String())
+		}
+		for _, want := range []string{"∴ thinking", "  inspect", "▸ pwd", "  /tmp"} {
+			if !strings.Contains(second.String(), want) {
+				t.Fatalf("detached viewport lost %q from history: %q", want, second.String())
+			}
+		}
+	})
+
+	t.Run("uses the reasoning hue only for the thinking header", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "false")
+		var out strings.Builder
+		viewport := NewActivityViewport(80, 3, 3)
+		viewport.AppendReasoning("inspect")
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("Render(): %v", err)
+		}
+		if !strings.Contains(out.String(), RoleColor("reasoning")+"∴ thinking") {
+			t.Fatalf("expected warm thinking header, got %q", out.String())
+		}
+		if strings.Contains(out.String(), RoleColor("reasoning")+"  inspect") {
+			t.Fatalf("reasoning body must remain neutral, got %q", out.String())
+		}
+	})
+
+	t.Run("coalesces streamed assistant prose into one block", func(t *testing.T) {
+		viewport := NewActivityViewport(20, 6, 6)
+		viewport.AppendText("let me ")
+		viewport.AppendText("check")
+
+		got := viewport.Rows()
+		want := []string{"assistant", "  let me check"}
+		if strings.Join(got, "\n") != strings.Join(want, "\n") {
+			t.Fatalf("Rows() = %q, want %q", got, want)
+		}
+		if !viewport.TextBlockActive() {
+			t.Fatal("TextBlockActive() = false, want true")
+		}
+	})
+
+	t.Run("remove text block pops only the trailing assistant prose", func(t *testing.T) {
+		viewport := NewActivityViewport(40, 8, 8)
+		viewport.AppendReasoning("inspect")
+		viewport.AppendText("let me check")
+
+		if got, want := viewport.RemoveTextBlock(), 2; got != want {
+			t.Fatalf("RemoveTextBlock() = %d, want %d", got, want)
+		}
+		got := viewport.Rows()
+		want := []string{"∴ thinking", "  inspect"}
+		if strings.Join(got, "\n") != strings.Join(want, "\n") {
+			t.Fatalf("Rows() = %q, want %q", got, want)
+		}
+		if viewport.TextBlockActive() {
+			t.Fatal("TextBlockActive() = true after remove, want false")
+		}
+		if got := viewport.RemoveTextBlock(); got != 0 {
+			t.Fatalf("RemoveTextBlock() on empty block = %d, want 0", got)
+		}
+	})
+
+	t.Run("finish text starts a new prose block", func(t *testing.T) {
+		viewport := NewActivityViewport(40, 8, 8)
+		viewport.AppendText("first")
+		viewport.FinishText()
+		viewport.AppendText("second")
+
+		if got := strings.Count(strings.Join(viewport.Rows(), "\n"), "assistant"); got != 2 {
+			t.Fatalf("assistant header count = %d, want 2; rows=%q", got, viewport.Rows())
+		}
+	})
+
+	t.Run("reasoning and tool blocks close the active prose block", func(t *testing.T) {
+		viewport := NewActivityViewport(40, 12, 12)
+		viewport.AppendText("let me check")
+		viewport.AppendTool(pub_models.Call{Name: "pwd"}, "/tmp", 2)
+		viewport.AppendReasoning("verify")
+		viewport.AppendText("second")
+
+		if got := strings.Count(strings.Join(viewport.Rows(), "\n"), "assistant"); got != 2 {
+			t.Fatalf("assistant header count = %d, want 2; rows=%q", got, viewport.Rows())
+		}
+	})
+
+	t.Run("uses the assistant role hue for the prose header", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "false")
+		var out strings.Builder
+		viewport := NewActivityViewport(80, 3, 3)
+		viewport.AppendText("hello")
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("Render(): %v", err)
+		}
+		if !strings.Contains(out.String(), RoleColor("assistant")+"assistant") {
+			t.Fatalf("expected assistant role color on the prose header, got %q", out.String())
 		}
 	})
 }
@@ -293,6 +658,522 @@ func TestAttemptPrettyPrint_ReasoningContent(t *testing.T) {
 		}
 		if !strings.Contains(got, "just an answer") {
 			t.Fatalf("expected content, got: %q", got)
+		}
+	})
+}
+
+// failAfterWriter writes up to remaining bytes, then fails. It pins the
+// phase-4 frame contract: a partial write must leave the viewport dirty so
+// the next Render retries the full frame.
+type failAfterWriter struct {
+	remaining int
+	buf       bytes.Buffer
+}
+
+func (w *failAfterWriter) Write(p []byte) (int, error) {
+	if len(p) <= w.remaining {
+		w.remaining -= len(p)
+		w.buf.Write(p)
+		return len(p), nil
+	}
+	n := w.remaining
+	if n > 0 {
+		w.buf.Write(p[:n])
+	}
+	w.remaining = 0
+	return n, errors.New("injected write failure")
+}
+
+// shortWriter accepts at most three bytes per call and reports no error,
+// pinning the io.Writer short-write contract: Render must treat a short write
+// as a failed frame and retry the full frame on the next call.
+type shortWriter struct{ buf strings.Builder }
+
+func (w *shortWriter) Write(p []byte) (int, error) {
+	if len(p) > 3 {
+		w.buf.Write(p[:3])
+		return 3, nil
+	}
+	w.buf.Write(p)
+	return len(p), nil
+}
+
+func TestActivityViewportResize(t *testing.T) {
+	t.Run("width narrows rewraps retained blocks", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var out strings.Builder
+		viewport := NewActivityViewport(20, 10, 10)
+		viewport.AppendReasoning("inspect directory")
+		inputs := pub_models.Input{"path": "/tmp"}
+		viewport.AppendTool(pub_models.Call{Name: "ls", Inputs: &inputs}, "one two three", 6)
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("Render(): %v", err)
+		}
+
+		viewport.Resize(10, 10)
+
+		got := strings.Join(viewport.Rows(), "\n")
+		for _, want := range []string{"∴ thinking", "  inspect ", "  director", "  y", "  one two ", "  three"} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("Rows() after narrow resize missing %q: %q", want, got)
+			}
+		}
+		if strings.Contains(got, "  inspect directory") {
+			t.Fatalf("stale old-width row survived the rewrap: %q", got)
+		}
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("Render() after resize: %v", err)
+		}
+		if !strings.Contains(out.String(), "\x1b[5A\r\x1b[J") {
+			t.Fatalf("expected a full-frame redraw after resize, got %q", out.String())
+		}
+	})
+
+	t.Run("reasoning text and tool activity survive reflow", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		viewport := NewActivityViewport(40, 20, 20)
+		viewport.AppendReasoning("think step one\nthink step two")
+		viewport.AppendText("checking the plan")
+		viewport.AppendTool(pub_models.Call{Name: "pwd"}, "/tmp/work", 2)
+		viewport.Resize(20, 12)
+		got := strings.Join(viewport.Rows(), "\n")
+		for _, want := range []string{"∴ thinking", "think step", "assistant", "checking the", "▸ pwd", "  /tmp/work"} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("Rows() after reflow missing %q: %q", want, got)
+			}
+		}
+	})
+
+	t.Run("height shrink keeps only the effective-height rows", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var first strings.Builder
+		viewport := NewActivityViewport(40, 10, 10)
+		viewport.AppendReasoning("line one\nline two\nline three")
+		viewport.AppendTool(pub_models.Call{Name: "pwd"}, "a\nb\nc\nd\ne\nf\ng", 6)
+		if err := viewport.Render(&first); err != nil {
+			t.Fatalf("Render(): %v", err)
+		}
+
+		viewport.Resize(40, 5)
+
+		if got := len(viewport.Rows()); got != 5 {
+			t.Fatalf("Rows() after shrink = %d, want effective height 5", got)
+		}
+		var redraw strings.Builder
+		if err := viewport.Render(&redraw); err != nil {
+			t.Fatalf("Render() after shrink: %v", err)
+		}
+		if !strings.Contains(redraw.String(), "\x1b[10A\r\x1b[J") {
+			t.Fatalf("expected full-frame clear of the old window, got %q", redraw.String())
+		}
+		for _, gone := range []string{"∴ thinking", "  line one"} {
+			if strings.Contains(redraw.String(), gone) {
+				t.Fatalf("shrunk window still shows %q: %q", gone, redraw.String())
+			}
+		}
+	})
+
+	t.Run("height grow brings retained content back into view", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		viewport := NewActivityViewport(40, 30, 30) // cap high enough that the terminal height binds
+		viewport.Resize(40, 5)
+		viewport.AppendReasoning("one\ntwo\nthree\nfour\nfive\nsix\nseven\neight")
+		rows := viewport.Rows()
+		if len(rows) != 5 {
+			t.Fatalf("Rows() at height 5 = %d rows, want 5", len(rows))
+		}
+		if strings.Contains(strings.Join(rows, "\n"), "  three") {
+			t.Fatalf("middle rows must be dropped at height 5: %q", rows)
+		}
+		viewport.Resize(40, 10)
+		got := strings.Join(viewport.Rows(), "\n")
+		if !strings.Contains(got, "  three") {
+			t.Fatalf("height grow must reappear retained content, got %q", got)
+		}
+		if len(viewport.Rows()) != 9 {
+			t.Fatalf("Rows() after grow = %d rows, want 9", len(viewport.Rows()))
+		}
+	})
+
+	t.Run("unchanged dimensions leave the viewport clean", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var first strings.Builder
+		viewport := NewActivityViewport(40, 8, 8)
+		viewport.AppendReasoning("first")
+		if err := viewport.Render(&first); err != nil {
+			t.Fatalf("Render(): %v", err)
+		}
+		viewport.Resize(40, 20) // effective height stays min(8, 20) = 8
+		var after strings.Builder
+		if err := viewport.Render(&after); err != nil {
+			t.Fatalf("Render() after a no-op Resize: %v", err)
+		}
+		if after.Len() != 0 {
+			t.Fatalf("no-op resize must not redraw, got %q", after.String())
+		}
+	})
+
+	t.Run("resize never writes to the writer", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var out strings.Builder
+		viewport := NewActivityViewport(40, 8, 8)
+		viewport.AppendReasoning("first")
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("Render(): %v", err)
+		}
+		// Resize takes no writer and must not emit anything; Render is the
+		// only writer in the viewport contract.
+		before := out.String()
+		viewport.Resize(30, 6)
+		if got := out.String(); got != before {
+			t.Fatalf("Resize wrote to the writer: %q", got)
+		}
+		var redraw strings.Builder
+		if err := viewport.Render(&redraw); err != nil {
+			t.Fatalf("Render(): %v", err)
+		}
+		if !strings.Contains(redraw.String(), "\x1b[2A\r\x1b[J") {
+			t.Fatalf("expected the resize redraw to go through Render, got %q", redraw.String())
+		}
+	})
+
+	t.Run("resize before the first append renders at the new dimensions", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var out strings.Builder
+		viewport := NewActivityViewport(80, 30, 30)
+		viewport.Resize(40, 10)
+		viewport.AppendReasoning("one two three four five six seven eight")
+		want := []string{"∴ thinking", "  one two three four five six seven eigh", "  t"}
+		if got := viewport.Rows(); strings.Join(got, "\n") != strings.Join(want, "\n") {
+			t.Fatalf("Rows() = %q, want %q", got, want)
+		}
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("Render(): %v", err)
+		}
+		if !strings.Contains(out.String(), "  t") {
+			t.Fatalf("first render must use the resized width, got %q", out.String())
+		}
+	})
+
+	t.Run("two consecutive resizes converge on the last dimensions", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var first strings.Builder
+		viewport := NewActivityViewport(80, 30, 30)
+		viewport.AppendReasoning("one two three four five six seven eight")
+		if err := viewport.Render(&first); err != nil {
+			t.Fatalf("Render(): %v", err)
+		}
+		viewport.Resize(60, 20)
+		viewport.Resize(40, 10)
+		var redraw strings.Builder
+		if err := viewport.Render(&redraw); err != nil {
+			t.Fatalf("Render() after resizes: %v", err)
+		}
+		if !strings.Contains(redraw.String(), "\x1b[2A\r\x1b[J") {
+			t.Fatalf("expected one full frame over the old region, got %q", redraw.String())
+		}
+		if !strings.Contains(redraw.String(), "  t") {
+			t.Fatalf("expected the last width to win, got %q", redraw.String())
+		}
+		var clean strings.Builder
+		if err := viewport.Render(&clean); err != nil {
+			t.Fatalf("Render() after clean: %v", err)
+		}
+		if clean.Len() != 0 {
+			t.Fatalf("clean viewport must not redraw, got %q", clean.String())
+		}
+	})
+
+	t.Run("resize while a text block is active keeps coalescing", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var out strings.Builder
+		viewport := NewActivityViewport(80, 10, 10)
+		viewport.AppendText("alpha beta")
+		viewport.Resize(10, 10)
+		viewport.AppendText(" gamma delta epsilon")
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("Render(): %v", err)
+		}
+		got := strings.Join(viewport.Rows(), "\n")
+		if strings.Count(got, "assistant") != 1 {
+			t.Fatalf("text must coalesce into one block after resize, got %q", got)
+		}
+		if !strings.Contains(got, "  alpha be") || !strings.Contains(got, "  psilon") {
+			t.Fatalf("streamed tokens must rewrap and continue at the new width, got %q", got)
+		}
+		if !viewport.TextBlockActive() {
+			t.Fatal("TextBlockActive() = false after resize, want true")
+		}
+	})
+
+	t.Run("resize during the final-answer pop keeps the pop correct", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var first strings.Builder
+		viewport := NewActivityViewport(80, 10, 10)
+		viewport.AppendReasoning("inspect")
+		viewport.AppendText("final answer text")
+		if err := viewport.Render(&first); err != nil {
+			t.Fatalf("Render(): %v", err)
+		}
+		if removed := viewport.RemoveTextBlock(); removed == 0 {
+			t.Fatal("RemoveTextBlock() = 0, want the answer block removed")
+		}
+		viewport.Resize(40, 10)
+		var redraw strings.Builder
+		if err := viewport.Render(&redraw); err != nil {
+			t.Fatalf("Render() after pop and resize: %v", err)
+		}
+		if strings.Contains(redraw.String(), "final answer text") {
+			t.Fatalf("popped answer must stay out of the window, got %q", redraw.String())
+		}
+		if !strings.Contains(redraw.String(), "∴ thinking") {
+			t.Fatalf("retained reasoning must survive the pop and resize, got %q", redraw.String())
+		}
+	})
+
+	t.Run("terminal shrink below the drawn window clears and rewrites", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var first strings.Builder
+		viewport := NewActivityViewport(40, 10, 10)
+		viewport.AppendReasoning("one\ntwo\nthree")
+		viewport.AppendTool(pub_models.Call{Name: "pwd"}, "a\nb", 6)
+		if err := viewport.Render(&first); err != nil {
+			t.Fatalf("Render(): %v", err)
+		}
+		viewport.Resize(40, 3)
+		if got := len(viewport.Rows()); got != 3 {
+			t.Fatalf("Rows() after shrink = %d, want effective height 3", got)
+		}
+		var redraw strings.Builder
+		if err := viewport.Render(&redraw); err != nil {
+			t.Fatalf("Render() after shrink: %v", err)
+		}
+		if !strings.Contains(redraw.String(), "\x1b[8A\r\x1b[J") {
+			t.Fatalf("expected full clear of the old window, got %q", redraw.String())
+		}
+		if strings.Contains(redraw.String(), "∴ thinking") {
+			t.Fatalf("shrunk window must not reprint evicted rows, got %q", redraw.String())
+		}
+	})
+
+	t.Run("partial frame write leaves the viewport dirty and retries", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var first strings.Builder
+		viewport := NewActivityViewport(40, 10, 10)
+		viewport.AppendReasoning("inspect")
+		if err := viewport.Render(&first); err != nil {
+			t.Fatalf("Render(): %v", err)
+		}
+		viewport.Resize(30, 10)
+		failing := &failAfterWriter{remaining: 4}
+		if err := viewport.Render(failing); err == nil {
+			t.Fatal("Render() with a failing writer must return an error")
+		}
+		var retry strings.Builder
+		if err := viewport.Render(&retry); err != nil {
+			t.Fatalf("Render() retry: %v", err)
+		}
+		if !strings.Contains(retry.String(), "\x1b[2A\r\x1b[J") {
+			t.Fatalf("retry must emit a full frame over the old region, got %q", retry.String())
+		}
+		if !strings.Contains(retry.String(), "  inspect") {
+			t.Fatalf("retry must rewrite the retained rows, got %q", retry.String())
+		}
+		var clean strings.Builder
+		if err := viewport.Render(&clean); err != nil {
+			t.Fatalf("Render() after clean: %v", err)
+		}
+		if clean.Len() != 0 {
+			t.Fatalf("viewport must be clean after a successful full frame, got %q", clean.String())
+		}
+	})
+
+	t.Run("write failure on the diff path marks the viewport dirty", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var first strings.Builder
+		viewport := NewActivityViewport(40, 10, 10)
+		viewport.AppendReasoning("first")
+		if err := viewport.Render(&first); err != nil {
+			t.Fatalf("Render(): %v", err)
+		}
+		viewport.AppendReasoning(" second")
+		if err := viewport.Render(&failAfterWriter{}); err == nil {
+			t.Fatal("Render() with a failing writer must return an error")
+		}
+		var retry strings.Builder
+		if err := viewport.Render(&retry); err != nil {
+			t.Fatalf("Render() retry: %v", err)
+		}
+		if !strings.Contains(retry.String(), "\x1b[2A\r\x1b[J") {
+			t.Fatalf("retry must emit a full frame, got %q", retry.String())
+		}
+	})
+
+	t.Run("resize with no content renders nothing and stays clean", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var out strings.Builder
+		viewport := NewActivityViewport(40, 8, 8)
+		viewport.Resize(30, 6)
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("Render(): %v", err)
+		}
+		if out.Len() != 0 {
+			t.Fatalf("empty dirty viewport must render nothing, got %q", out.String())
+		}
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("second Render(): %v", err)
+		}
+		if out.Len() != 0 {
+			t.Fatalf("clean viewport must stay silent, got %q", out.String())
+		}
+	})
+
+	t.Run("short write without error leaves the viewport dirty", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var first strings.Builder
+		viewport := NewActivityViewport(40, 10, 10)
+		viewport.AppendReasoning("inspect")
+		if err := viewport.Render(&first); err != nil {
+			t.Fatalf("Render(): %v", err)
+		}
+		viewport.Resize(30, 10)
+		if err := viewport.Render(&shortWriter{}); err == nil {
+			t.Fatal("Render() with a short writer must return an error")
+		}
+		var retry strings.Builder
+		if err := viewport.Render(&retry); err != nil {
+			t.Fatalf("Render() retry: %v", err)
+		}
+		if !strings.Contains(retry.String(), "\x1b[2A\r\x1b[J") {
+			t.Fatalf("retry must emit a full frame over the old region, got %q", retry.String())
+		}
+	})
+
+	t.Run("empty text block renders stable empty rows", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var out strings.Builder
+		viewport := NewActivityViewport(40, 8, 8)
+		viewport.AppendText("")
+		want := []string{"assistant", "  "}
+		if got := viewport.Rows(); strings.Join(got, "\n") != strings.Join(want, "\n") {
+			t.Fatalf("Rows() = %q, want %q", got, want)
+		}
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("Render(): %v", err)
+		}
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("second Render(): %v", err)
+		}
+		if got := strings.Count(out.String(), "assistant"); got != 1 {
+			t.Fatalf("unchanged empty block must render once, got %d copies", got)
+		}
+	})
+
+	t.Run("effective height is the cap capped by terminal height", func(t *testing.T) {
+		viewport := NewActivityViewport(80, 10, 10)
+		viewport.Resize(80, 99)
+		viewport.AppendReasoning("one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\neleven\ntwelve")
+		if got := len(viewport.Rows()); got != 10 {
+			t.Fatalf("Rows() = %d rows, want the cap 10", got)
+		}
+		viewport.Resize(80, 4)
+		if got := len(viewport.Rows()); got != 4 {
+			t.Fatalf("Rows() = %d rows, want terminal height 4", got)
+		}
+		viewport.Resize(80, 0)
+		if got := len(viewport.Rows()); got != 1 {
+			t.Fatalf("Rows() = %d rows, want clamped height 1", got)
+		}
+	})
+
+	t.Run("initial height binds the terminal height at creation", func(t *testing.T) {
+		viewport := NewActivityViewport(40, 30, 5)
+		viewport.AppendReasoning("one\ntwo\nthree\nfour\nfive\nsix\nseven\neight")
+		if got := len(viewport.Rows()); got != 5 {
+			t.Fatalf("Rows() = %d rows, want the terminal height 5 bound at creation", got)
+		}
+		// The min(cap, terminal height) binding stays live: growing the
+		// terminal reveals retained content without any prior Resize.
+		viewport.Resize(40, 8)
+		if got := len(viewport.Rows()); got != 8 {
+			t.Fatalf("Rows() after terminal grow = %d rows, want 8", got)
+		}
+	})
+
+	t.Run("clamps width and height below one", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		viewport := NewActivityViewport(0, 0, 0)
+		viewport.Resize(-10, -10)
+		viewport.AppendReasoning("x")
+		want := []string{"∴ thinking"}
+		if got := viewport.Rows(); strings.Join(got, "\n") != strings.Join(want, "\n") {
+			t.Fatalf("Rows() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("retention evicts the oldest finished blocks", func(t *testing.T) {
+		viewport := NewActivityViewport(80, 30, 30)
+		for i := range maxActivityBlocks + 4 {
+			viewport.AppendReasoning(fmt.Sprintf("block %d", i))
+			viewport.FinishReasoning()
+		}
+		if got := len(viewport.blocks); got != maxActivityBlocks {
+			t.Fatalf("retained blocks = %d, want %d", got, maxActivityBlocks)
+		}
+		if got, want := viewport.blocks[0].content, "block 4"; got != want {
+			t.Fatalf("oldest retained block = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("retention bounds content per block", func(t *testing.T) {
+		viewport := NewActivityViewport(80, 30, 30)
+		big := strings.Repeat("x", maxActivityBlockRunes*2)
+		viewport.AppendReasoning(big)
+		got := viewport.activeReasoning.content
+		if utf8.RuneCountInString(got) > maxActivityBlockRunes {
+			t.Fatalf("retained content = %d runes, want at most %d", utf8.RuneCountInString(got), maxActivityBlockRunes)
+		}
+		before, after, found := strings.Cut(got, contentTruncationMarker)
+		if !found {
+			t.Fatal("expected the truncation marker in over-budget content")
+		}
+		if before != strings.Repeat("x", utf8.RuneCountInString(before)) {
+			t.Fatal("content head must survive unchanged")
+		}
+		if after != strings.Repeat("x", utf8.RuneCountInString(after)) {
+			t.Fatal("content tail must survive unchanged")
+		}
+		if utf8.RuneCountInString(before)+utf8.RuneCountInString(after)+utf8.RuneCountInString(contentTruncationMarker) > maxActivityBlockRunes {
+			t.Fatal("retained content must stay within the rune budget")
+		}
+	})
+
+	t.Run("nil viewport is safe", func(t *testing.T) {
+		var viewport *ActivityViewport
+		viewport.AppendReasoning("x")
+		viewport.AppendText("y")
+		viewport.AppendTool(pub_models.Call{Name: "pwd"}, "z", 2)
+		viewport.FinishReasoning()
+		viewport.FinishText()
+		viewport.Resize(40, 10)
+		if got := viewport.Rows(); got != nil {
+			t.Fatalf("Rows() on nil = %v, want nil", got)
+		}
+		if got := viewport.Content(); got != "" {
+			t.Fatalf("Content() on nil = %q, want empty", got)
+		}
+		if got := viewport.RemoveTextBlock(); got != 0 {
+			t.Fatalf("RemoveTextBlock() on nil = %d, want 0", got)
+		}
+		if got := viewport.DetachRenderedRegion(); got != 0 {
+			t.Fatalf("DetachRenderedRegion() on nil = %d, want 0", got)
+		}
+		if viewport.TextBlockActive() {
+			t.Fatal("TextBlockActive() on nil = true, want false")
+		}
+		var out strings.Builder
+		if err := viewport.Render(&out); err != nil {
+			t.Fatalf("Render() on nil: %v", err)
 		}
 	})
 }

--- a/internal/utils/print_test.go
+++ b/internal/utils/print_test.go
@@ -182,11 +182,52 @@ func TestPrepareDisplayMessage(t *testing.T) {
 		}
 	})
 
-	t.Run("mcp tool messages are preserved", func(t *testing.T) {
+	t.Run("mcp tool messages are shortened", func(t *testing.T) {
 		msg := pub_models.Message{Role: "tool", Content: "mcp_result\n" + strings.Repeat("0123456789\n", 30)}
 		got := PrepareDisplayMessage(msg)
-		if got.Content != msg.Content {
-			t.Fatalf("expected mcp tool output to remain untouched")
+		if !strings.Contains(got.Content, "[and 27 more lines]") {
+			t.Fatalf("expected shortened mcp tool output, got %q", got.Content)
+		}
+	})
+}
+
+func TestCompactToolActivity(t *testing.T) {
+	t.Run("keeps the first three rows, marker, and last two rows", func(t *testing.T) {
+		rows := []string{"one", "two", "three", "four", "five", "six", "seven", "eight"}
+		got := compactTerminalRows(strings.Join(rows, "\n"), 80, 6)
+		want := []string{"one", "two", "three", "... [3 terminal rows omitted] ...", "seven", "eight"}
+		if strings.Join(got, "\n") != strings.Join(want, "\n") {
+			t.Fatalf("compactTerminalRows() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("counts wrapped terminal rows", func(t *testing.T) {
+		got := compactTerminalRows("abcdefghijkl", 3, 3)
+		want := []string{"abc", "... [2 terminal rows omitted] ...", "jkl"}
+		if strings.Join(got, "\n") != strings.Join(want, "\n") {
+			t.Fatalf("compactTerminalRows() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("non raw display uses no glow and respects no color", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var out strings.Builder
+		if err := PrintCompactToolActivity(&out, "tool", "one\ntwo\nthree\nfour", 80, 3); err != nil {
+			t.Fatalf("PrintCompactToolActivity: %v", err)
+		}
+		if got, want := out.String(), "tool: one\n... [2 terminal rows omitted] ...\nfour\n"; got != want {
+			t.Fatalf("PrintCompactToolActivity() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("tool call status is one terminal row", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "true")
+		var out strings.Builder
+		if err := PrintCompactToolCall(&out, "assistant", "Call: very-long-tool-name", 16); err != nil {
+			t.Fatalf("PrintCompactToolCall: %v", err)
+		}
+		if got, want := out.String(), "assistant: Call…\n"; got != want {
+			t.Fatalf("PrintCompactToolCall() = %q, want %q", got, want)
 		}
 	})
 }

--- a/internal/utils/print_theme_test.go
+++ b/internal/utils/print_theme_test.go
@@ -127,11 +127,13 @@ func TestAttemptPrettyPrint_SkipsGlowForCapturedWriters(t *testing.T) {
 }
 
 // TestAttemptPrettyPrint_UsesGlowForTerminalWriters proves the glow renderer
-// still receives the width-aware args when the destination is a terminal
-// (character device), and that the version probe answers the fake glow.
+// receives the width-aware args when the destination is a character device and
+// the version probe answers the fake glow. /dev/null is a character device but
+// not a terminal, so its TIOCGWINSZ read fails and the deterministic fallback
+// width (80) drives the args: the ioctl is authoritative and COLUMNS plays no
+// role (R2-02).
 func TestAttemptPrettyPrint_UsesGlowForTerminalWriters(t *testing.T) {
 	t.Setenv("NO_COLOR", "")
-	t.Setenv("COLUMNS", "100")
 
 	argsPath := filepath.Join(t.TempDir(), "glow-args.txt")
 	glowPath := filepath.Join(t.TempDir(), "glow")
@@ -155,8 +157,44 @@ func TestAttemptPrettyPrint_UsesGlowForTerminalWriters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read fake glow args: %v", err)
 	}
-	if got, want := strings.TrimSpace(string(gotArgsBytes)), "-w 95"; got != want {
+	if got, want := strings.TrimSpace(string(gotArgsBytes)), "-w 75"; got != want {
 		t.Fatalf("unexpected glow args\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+// TestAttemptPrettyPrint_GlowFailureSurfacesError pins the phase-3 error
+// contract for the width-aware glow collaborator: when the glow subprocess
+// fails after answering the version probe, AttemptPrettyPrint returns the
+// error instead of emitting malformed output. The caller (chat print paths)
+// aborts on this error.
+func TestAttemptPrettyPrint_GlowFailureSurfacesError(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+
+	glowPath := filepath.Join(t.TempDir(), "glow")
+	if err := os.WriteFile(glowPath, []byte(`#!/bin/sh
+if [ "$1" = "--version" ]; then
+	echo "glow test"
+	exit 0
+fi
+exit 3
+`), 0o755); err != nil {
+		t.Fatalf("write failing fake glow: %v", err)
+	}
+	t.Setenv("PATH", filepath.Dir(glowPath))
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open %s: %v", os.DevNull, err)
+	}
+	defer devNull.Close()
+
+	msg := pub_models.Message{Role: "assistant", Content: "hello markdown"}
+	err = AttemptPrettyPrint(devNull, msg, "alice", false)
+	if err == nil {
+		t.Fatal("expected glow failure to surface as an error")
+	}
+	if !strings.Contains(err.Error(), "run glow") {
+		t.Fatalf("expected the glow error to be wrapped, got: %v", err)
 	}
 }
 

--- a/internal/utils/theme.go
+++ b/internal/utils/theme.go
@@ -33,6 +33,16 @@ type Theme struct {
 	TableItems int `json:"tableItems"`
 
 	ToolOutputRows int `json:"toolOutputRows"`
+
+	RollingOutput RollingOutputConfig `json:"rollingOutput"`
+}
+
+// RollingOutputConfig configures the shared rolling activity viewport that
+// contains streamed reasoning and tool blocks.
+type RollingOutputConfig struct {
+	Enabled bool `json:"enabled"`
+
+	WindowCellHeight int `json:"windowCellHeight"`
 }
 
 func defaultTheme() *Theme {
@@ -53,6 +63,11 @@ func defaultTheme() *Theme {
 		TableItems: 10,
 
 		ToolOutputRows: 6,
+
+		RollingOutput: RollingOutputConfig{
+			Enabled:          true,
+			WindowCellHeight: 30,
+		},
 	}
 }
 
@@ -81,34 +96,69 @@ func TableTheme() table.Theme {
 
 func migrateThemeConfig(configDirPath string) error {
 	themePath := ThemeConfigPath(configDirPath)
-	hasNotificationBell := hasJSONKey(themePath, "notificationBell")
-	if hasNotificationBell {
-		return nil
-	}
-
-	type themeMigration struct {
-		Primary          string `json:"primary"`
-		Secondary        string `json:"secondary"`
-		Breadtext        string `json:"breadtext"`
-		RoleSystem       string `json:"roleSystem"`
-		RoleUser         string `json:"roleUser"`
-		RoleTool         string `json:"roleTool"`
-		RoleOther        string `json:"roleOther"`
-		NotificationBell bool   `json:"notificationBell"`
-		TableItems       int    `json:"tableItems"`
-	}
-
-	var conf themeMigration
-	err := ReadAndUnmarshal(themePath, &conf)
+	content, err := os.ReadFile(themePath)
 	if err != nil {
 		return fmt.Errorf("read theme config for migration: %w", err)
 	}
+	var conf map[string]json.RawMessage
+	if err := json.Unmarshal(content, &conf); err != nil {
+		return fmt.Errorf("read theme config for migration: %w", err)
+	}
+	changed := false
 
-	conf.NotificationBell = true
+	// Rename the kebab-case rolling-output block to the canonical camelCase
+	// rollingOutput key. The camelCase spelling wins when both are present.
+	if raw, ok := conf["rolling-output"]; ok {
+		if _, exists := conf["rollingOutput"]; !exists {
+			conf["rollingOutput"] = raw
+		}
+		delete(conf, "rolling-output")
+		changed = true
+	}
 
-	err = WriteFile(themePath, &conf)
-	if err != nil {
-		return fmt.Errorf("write theme config migration: %w", err)
+	// The obsolete flat rollingOutput boolean (pre-block config shape) would
+	// collide with the nested block key; drop it so it keeps being ignored.
+	if raw, ok := conf["rollingOutput"]; ok && !isJSONObject(raw) {
+		delete(conf, "rollingOutput")
+		changed = true
+	}
+
+	// Rename window-cell-height to windowCellHeight inside the block.
+	if raw, ok := conf["rollingOutput"]; ok {
+		var sub map[string]json.RawMessage
+		if json.Unmarshal(raw, &sub) == nil {
+			subChanged := false
+			if height, ok := sub["window-cell-height"]; ok {
+				if _, exists := sub["windowCellHeight"]; !exists {
+					sub["windowCellHeight"] = height
+				}
+				delete(sub, "window-cell-height")
+				subChanged = true
+			}
+			if subChanged {
+				updated, err := json.Marshal(sub)
+				if err != nil {
+					return fmt.Errorf("marshal rolling output config migration: %w", err)
+				}
+				conf["rollingOutput"] = updated
+				changed = true
+			}
+		}
+	}
+
+	// Add the field without decoding into a fixed legacy struct. A fixed struct
+	// drops newer and unknown fields when it rewrites the file, including the
+	// obsolete flat rolling keys from earlier config shapes.
+	if _, ok := conf["notificationBell"]; !ok {
+		conf["notificationBell"] = json.RawMessage("true")
+		changed = true
+	}
+
+	if changed {
+		err = WriteFile(themePath, &conf)
+		if err != nil {
+			return fmt.Errorf("write theme config migration: %w", err)
+		}
 	}
 	return nil
 }
@@ -139,16 +189,10 @@ func NotificationBellEnabled() bool { return globalTheme.NotificationBell }
 // ToolOutputRows returns the maximum terminal rows used for non-raw tool output.
 func ToolOutputRows() int { return globalTheme.ToolOutputRows }
 
-func hasJSONKey(path, key string) bool {
-	content, err := os.ReadFile(path)
-	if err != nil {
-		return false
-	}
-	var raw map[string]json.RawMessage
-	err = json.Unmarshal(content, &raw)
-	if err != nil {
-		return false
-	}
-	_, exists := raw[key]
-	return exists
-}
+// RollingOutputEnabled reports whether reasoning and tool activity share a
+// rolling terminal viewport.
+func RollingOutputEnabled() bool { return globalTheme.RollingOutput.Enabled }
+
+// RollingOutputWindowCellHeight returns the maximum terminal cells (rows) for
+// the shared rolling activity viewport.
+func RollingOutputWindowCellHeight() int { return globalTheme.RollingOutput.WindowCellHeight }

--- a/internal/utils/theme.go
+++ b/internal/utils/theme.go
@@ -31,6 +31,8 @@ type Theme struct {
 	NotificationBell bool `json:"notificationBell"`
 
 	TableItems int `json:"tableItems"`
+
+	ToolOutputRows int `json:"toolOutputRows"`
 }
 
 func defaultTheme() *Theme {
@@ -49,6 +51,8 @@ func defaultTheme() *Theme {
 		NotificationBell: true,
 
 		TableItems: 10,
+
+		ToolOutputRows: 6,
 	}
 }
 
@@ -131,6 +135,9 @@ func RoleColor(role string) string {
 }
 
 func NotificationBellEnabled() bool { return globalTheme.NotificationBell }
+
+// ToolOutputRows returns the maximum terminal rows used for non-raw tool output.
+func ToolOutputRows() int { return globalTheme.ToolOutputRows }
 
 func hasJSONKey(path, key string) bool {
 	content, err := os.ReadFile(path)

--- a/internal/utils/theme_notification_test.go
+++ b/internal/utils/theme_notification_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -154,22 +155,190 @@ func TestDefaultTheme_HasTableItemsSetTo10(t *testing.T) {
 	}
 }
 
+func TestDefaultTheme_RollingOutputDefaults(t *testing.T) {
+	conf := defaultTheme().RollingOutput
+	if !conf.Enabled {
+		t.Fatal("defaultTheme().RollingOutput.Enabled = false, want true")
+	}
+	if conf.WindowCellHeight != 30 {
+		t.Fatalf("defaultTheme().RollingOutput.WindowCellHeight = %d, want 30", conf.WindowCellHeight)
+	}
+}
+
 func TestLoadTheme_AppendsToolOutputRowsDefaultForExistingThemeWithoutField(t *testing.T) {
+	assertLoadThemeAppendsRowsDefault(
+		t,
+		`{"notificationBell": true, "tableItems": 10}`,
+		"toolOutputRows",
+		ToolOutputRows,
+		6,
+	)
+}
+
+func TestLoadTheme_AppendsRollingOutputDefaultsForExistingThemeWithoutField(t *testing.T) {
 	confDir := t.TempDir()
 	themePath := filepath.Join(confDir, "theme.json")
-	if err := os.WriteFile(themePath, []byte(`{"notificationBell": true, "tableItems": 10}`), 0o644); err != nil {
+	initial := `{"notificationBell": true, "tableItems": 10, "toolOutputRows": 6}`
+	if err := os.WriteFile(themePath, []byte(initial), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", themePath, err)
 	}
 
 	if err := LoadTheme(confDir); err != nil {
 		t.Fatalf("LoadTheme(%q): %v", confDir, err)
 	}
-	if got := ToolOutputRows(); got != 6 {
-		t.Fatalf("ToolOutputRows() = %d, want 6", got)
+	if !RollingOutputEnabled() {
+		t.Fatal("RollingOutputEnabled() = false, want true")
+	}
+	if RollingOutputWindowCellHeight() != 30 {
+		t.Fatalf("RollingOutputWindowCellHeight() = %d, want 30", RollingOutputWindowCellHeight())
 	}
 	themeBytes, err := os.ReadFile(themePath)
 	if err != nil {
 		t.Fatalf("ReadFile(%q): %v", themePath, err)
 	}
-	testboil.AssertStringContains(t, string(themeBytes), `"toolOutputRows": 6`)
+	for _, want := range []string{`"rollingOutput"`, `"enabled": true`, `"windowCellHeight": 30`} {
+		testboil.AssertStringContains(t, string(themeBytes), want)
+	}
+}
+
+func TestLoadTheme_FillsMissingWindowCellHeightInPartialRollingOutput(t *testing.T) {
+	confDir := t.TempDir()
+	themePath := filepath.Join(confDir, "theme.json")
+	if err := os.WriteFile(themePath, []byte(`{"notificationBell":true,"rollingOutput":{"enabled":false}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", themePath, err)
+	}
+
+	if err := LoadTheme(confDir); err != nil {
+		t.Fatalf("LoadTheme(%q): %v", confDir, err)
+	}
+	if RollingOutputEnabled() {
+		t.Fatal("RollingOutputEnabled() = true, want false")
+	}
+	if RollingOutputWindowCellHeight() != 30 {
+		t.Fatalf("RollingOutputWindowCellHeight() = %d, want 30", RollingOutputWindowCellHeight())
+	}
+	themeBytes, err := os.ReadFile(themePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", themePath, err)
+	}
+	testboil.AssertStringContains(t, string(themeBytes), `"windowCellHeight": 30`)
+}
+
+func TestLoadTheme_MigratesKebabCaseRollingOutputKeys(t *testing.T) {
+	confDir := t.TempDir()
+	themePath := filepath.Join(confDir, "theme.json")
+	if err := os.WriteFile(themePath, []byte(`{"notificationBell":true,"rolling-output":{"enabled":false,"window-cell-height":12}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", themePath, err)
+	}
+
+	if err := LoadTheme(confDir); err != nil {
+		t.Fatalf("LoadTheme(%q): %v", confDir, err)
+	}
+	if RollingOutputEnabled() {
+		t.Fatal("RollingOutputEnabled() = true, want false")
+	}
+	if got := RollingOutputWindowCellHeight(); got != 12 {
+		t.Fatalf("RollingOutputWindowCellHeight() = %d, want 12", got)
+	}
+	themeBytes, err := os.ReadFile(themePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", themePath, err)
+	}
+	content := string(themeBytes)
+	for _, want := range []string{`"rollingOutput"`, `"enabled": false`, `"windowCellHeight": 12`} {
+		testboil.AssertStringContains(t, content, want)
+	}
+	if strings.Contains(content, "rolling-output") || strings.Contains(content, "window-cell-height") {
+		t.Fatalf("kebab-case keys survived migration: %s", content)
+	}
+}
+
+func TestLoadTheme_PreservesDisabledRollingOutput(t *testing.T) {
+	confDir := t.TempDir()
+	themePath := filepath.Join(confDir, "theme.json")
+	if err := os.WriteFile(themePath, []byte(`{"notificationBell":true,"rollingOutput":{"enabled":false}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", themePath, err)
+	}
+
+	if err := LoadTheme(confDir); err != nil {
+		t.Fatalf("LoadTheme(%q): %v", confDir, err)
+	}
+	if RollingOutputEnabled() {
+		t.Fatal("RollingOutputEnabled() = true, want false")
+	}
+}
+
+func TestLoadTheme_NotificationBellMigrationPreservesDisabledRollingOutput(t *testing.T) {
+	confDir := t.TempDir()
+	themePath := filepath.Join(confDir, "theme.json")
+	if err := os.WriteFile(themePath, []byte(`{"rolling-output":{"enabled":false}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", themePath, err)
+	}
+
+	if err := LoadTheme(confDir); err != nil {
+		t.Fatalf("LoadTheme(%q): %v", confDir, err)
+	}
+	if !NotificationBellEnabled() {
+		t.Fatal("notification bell must default to enabled after migration")
+	}
+	if RollingOutputEnabled() {
+		t.Fatal("RollingOutputEnabled() = true, want false")
+	}
+
+	themeBytes, err := os.ReadFile(themePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", themePath, err)
+	}
+	content := string(themeBytes)
+	testboil.AssertStringContains(t, content, `"enabled": false`)
+	testboil.AssertStringContains(t, content, `"rollingOutput"`)
+	if strings.Contains(content, "rolling-output") {
+		t.Fatalf("kebab-case rolling-output key survived migration: %s", content)
+	}
+}
+
+func TestLoadTheme_IgnoresObsoleteFlatRollingKeys(t *testing.T) {
+	confDir := t.TempDir()
+	themePath := filepath.Join(confDir, "theme.json")
+	if err := os.WriteFile(themePath, []byte(`{"notificationBell":true,"rollingOutput":false,"activityOutputRows":12}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", themePath, err)
+	}
+
+	if err := LoadTheme(confDir); err != nil {
+		t.Fatalf("LoadTheme(%q): %v", confDir, err)
+	}
+	if !RollingOutputEnabled() {
+		t.Fatal("obsolete flat rollingOutput must not disable the rolling output")
+	}
+	if RollingOutputWindowCellHeight() != 30 {
+		t.Fatalf("RollingOutputWindowCellHeight() = %d, want 30", RollingOutputWindowCellHeight())
+	}
+	themeBytes, err := os.ReadFile(themePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", themePath, err)
+	}
+	content := string(themeBytes)
+	testboil.AssertStringContains(t, content, `"rollingOutput": {`)
+	testboil.AssertStringContains(t, content, `"windowCellHeight": 30`)
+}
+
+func assertLoadThemeAppendsRowsDefault(t *testing.T, initial, key string, get func() int, want int) {
+	t.Helper()
+	confDir := t.TempDir()
+	themePath := filepath.Join(confDir, "theme.json")
+	if err := os.WriteFile(themePath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", themePath, err)
+	}
+
+	if err := LoadTheme(confDir); err != nil {
+		t.Fatalf("LoadTheme(%q): %v", confDir, err)
+	}
+	if got := get(); got != want {
+		t.Fatalf("%s = %d, want %d", key, got, want)
+	}
+	themeBytes, err := os.ReadFile(themePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", themePath, err)
+	}
+	testboil.AssertStringContains(t, string(themeBytes), fmt.Sprintf("%q: %d", key, want))
 }

--- a/internal/utils/theme_notification_test.go
+++ b/internal/utils/theme_notification_test.go
@@ -153,3 +153,23 @@ func TestDefaultTheme_HasTableItemsSetTo10(t *testing.T) {
 		t.Fatalf("defaultTheme().TableItems = %d, want 10", th.TableItems)
 	}
 }
+
+func TestLoadTheme_AppendsToolOutputRowsDefaultForExistingThemeWithoutField(t *testing.T) {
+	confDir := t.TempDir()
+	themePath := filepath.Join(confDir, "theme.json")
+	if err := os.WriteFile(themePath, []byte(`{"notificationBell": true, "tableItems": 10}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", themePath, err)
+	}
+
+	if err := LoadTheme(confDir); err != nil {
+		t.Fatalf("LoadTheme(%q): %v", confDir, err)
+	}
+	if got := ToolOutputRows(); got != 6 {
+		t.Fatalf("ToolOutputRows() = %d, want 6", got)
+	}
+	themeBytes, err := os.ReadFile(themePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", themePath, err)
+	}
+	testboil.AssertStringContains(t, string(themeBytes), `"toolOutputRows": 6`)
+}

--- a/main_chat_e2e_test.go
+++ b/main_chat_e2e_test.go
@@ -136,7 +136,7 @@ func Test_goldenFile_CHAT_DIRSCOPED(t *testing.T) {
 
 	out, status := runOne(t, bar, "-r -cm test q hello")
 	testboil.FailTestIfDiff(t, status, 0)
-	testboil.FailTestIfDiff(t, out, "hello\n\a")
+	testboil.FailTestIfDiff(t, out, "hello\n")
 
 	out, status = runOne(t, bar, "-r -cm test chat dir")
 	testboil.FailTestIfDiff(t, status, 0)
@@ -168,7 +168,7 @@ func Test_goldenFile_CHAT_DIRSCOPED(t *testing.T) {
 
 	out, status = runOne(t, baz, "-r -cm test q baz")
 	testboil.FailTestIfDiff(t, status, 0)
-	testboil.FailTestIfDiff(t, out, "baz\n\a")
+	testboil.FailTestIfDiff(t, out, "baz\n")
 
 	out, status = runOne(t, baz, "-r -cm test chat dir")
 	testboil.FailTestIfDiff(t, status, 0)
@@ -200,7 +200,7 @@ func Test_goldenFile_CHAT_DIRSCOPED(t *testing.T) {
 
 	out, status = runOne(t, baz, "-r -cm test -re -dre q hello3")
 	testboil.FailTestIfDiff(t, status, 0)
-	testboil.FailTestIfDiff(t, out, "hello3\n\a")
+	testboil.FailTestIfDiff(t, out, "hello3\n")
 
 	convDir := filepath.Join(confDir, "conversations")
 	entries, err := os.ReadDir(convDir)
@@ -474,7 +474,7 @@ func Test_e2e_dre_queries_continue_directory_scoped_conversation(t *testing.T) {
 
 	out, status := runOne(t, workDir, "-r -cm test q I like blue")
 	testboil.FailTestIfDiff(t, status, 0)
-	testboil.FailTestIfDiff(t, out, "I like blue\n\a")
+	testboil.FailTestIfDiff(t, out, "I like blue\n")
 
 	out, status = runOne(t, workDir, "-r -cm test chat dir")
 	testboil.FailTestIfDiff(t, status, 0)
@@ -643,7 +643,7 @@ func Test_e2e_dre_profile_swap_does_not_create_new_conversation(t *testing.T) {
 
 	out, status := runOne(t, workDir, "-r -cm test q seed prompt")
 	testboil.FailTestIfDiff(t, status, 0)
-	testboil.FailTestIfDiff(t, out, "seed prompt\n\a")
+	testboil.FailTestIfDiff(t, out, "seed prompt\n")
 
 	initialChatID, err := chat.LoadDirScopeChatID(confDir)
 	if err != nil {

--- a/main_config_e2e_test.go
+++ b/main_config_e2e_test.go
@@ -38,5 +38,5 @@ func Test_goldenFile_CONFIG_flag_defaults_do_not_override_mode_config(t *testing
 	})
 
 	testboil.FailTestIfDiff(t, gotStatus, 0)
-	testboil.FailTestIfDiff(t, stdout, "hello\n\a")
+	testboil.FailTestIfDiff(t, stdout, "hello\n")
 }

--- a/main_e2e_test.go
+++ b/main_e2e_test.go
@@ -27,7 +27,7 @@ func Test_goldenFile_calibration(t *testing.T) {
 			// echo text querier. It will respond with whatever the input is
 			givenArgs:      "-r -cm test q test",
 			givenEnvs:      make(map[string]string),
-			wantOutExactly: "test\n\a",
+			wantOutExactly: "test\n",
 			wantErr:        "",
 			wantStatusCode: 0,
 		},
@@ -36,7 +36,7 @@ func Test_goldenFile_calibration(t *testing.T) {
 			expect:         "Multiple tests-test",
 			givenArgs:      "-r -cm test q another test",
 			givenEnvs:      make(map[string]string),
-			wantOutExactly: "another test\n\a",
+			wantOutExactly: "another test\n",
 			wantErr:        "",
 			wantStatusCode: 0,
 		},

--- a/main_notification_test.go
+++ b/main_notification_test.go
@@ -55,7 +55,7 @@ func Test_run_structured_output_prints_only_response(t *testing.T) {
 	}
 }
 
-func Test_run_emits_terminal_bell_on_completed_query_when_theme_enables_it(t *testing.T) {
+func Test_run_redirected_completed_query_suppresses_bell(t *testing.T) {
 	confDir := t.TempDir()
 	required := []string{
 		"conversations",
@@ -79,7 +79,12 @@ func Test_run_emits_terminal_bell_on_completed_query_when_theme_enables_it(t *te
   "roleReasoning": "",
   "roleOther": "",
   "notificationBell": true,
-  "tableItems": 10
+  "tableItems": 10,
+  "toolOutputRows": 6,
+  "rollingOutput": {
+    "enabled": true,
+    "windowCellHeight": 30
+  }
 }`), 0o644)
 	if err != nil {
 		t.Fatalf("WriteFile(theme.json): %v", err)
@@ -94,7 +99,26 @@ func Test_run_emits_terminal_bell_on_completed_query_when_theme_enables_it(t *te
 	})
 
 	testboil.FailTestIfDiff(t, gotStatusCode, 0)
-	testboil.FailTestIfDiff(t, gotStdout, "hello\n\a")
+	testboil.FailTestIfDiff(t, gotStdout, "hello\n")
+}
+
+type notificationTestCompletion struct {
+	suppress bool
+}
+
+func (c notificationTestCompletion) SuppressCompletionNotification() bool {
+	return c.suppress
+}
+
+func Test_triggerCompletionNotification_emits_bell_when_completion_does_not_suppress_it(t *testing.T) {
+	confDir := setupMainTestConfigDir(t)
+	writeNotificationTestPriceFiles(t, confDir)
+
+	gotStdout := testboil.CaptureStdout(t, func(t *testing.T) {
+		triggerCompletionNotification(notificationTestCompletion{})
+	})
+
+	testboil.FailTestIfDiff(t, gotStdout, "\a")
 }
 
 // Test_run_false_notification_bell_setting_stays_disabled pins the
@@ -126,7 +150,12 @@ func Test_run_false_notification_bell_setting_stays_disabled(t *testing.T) {
   "roleReasoning": "",
   "roleOther": "",
   "notificationBell": false,
-  "tableItems": 10
+  "tableItems": 10,
+  "toolOutputRows": 6,
+  "rollingOutput": {
+    "enabled": true,
+    "windowCellHeight": 30
+  }
 }`), 0o644)
 	if err != nil {
 		t.Fatalf("WriteFile(theme.json): %v", err)

--- a/main_query_e2e_test.go
+++ b/main_query_e2e_test.go
@@ -28,7 +28,7 @@ func Test_goldenFile_QUERY_stdin_and_token_replacement(t *testing.T) {
 			name:     "stdin_only_becomes_prompt",
 			stdin:    "from-stdin",
 			args:     "-r -cm test q",
-			wantOut:  "from-stdin\n\a",
+			wantOut:  "from-stdin\n",
 			wantCode: 0,
 		},
 		{
@@ -36,7 +36,7 @@ func Test_goldenFile_QUERY_stdin_and_token_replacement(t *testing.T) {
 			stdin: "X",
 			args:  "-r -cm test q hello {} world",
 			// Note: current Prompt() semantics append stdin after args as well.
-			wantOut:  "hello X world X\n\a",
+			wantOut:  "hello X world X\n",
 			wantCode: 0,
 		},
 		{
@@ -44,7 +44,7 @@ func Test_goldenFile_QUERY_stdin_and_token_replacement(t *testing.T) {
 			stdin: "Y",
 			args:  "-r -cm test -I __ q hello __ world",
 			// Note: replacement does not currently occur for custom token, stdin is appended.
-			wantOut:  "hello __ world Y\n\a",
+			wantOut:  "hello __ world Y\n",
 			wantCode: 0,
 		},
 	}
@@ -111,12 +111,12 @@ func Test_goldenFile_QUERY_shell_context_is_in_system_prompt_not_user_message(t 
 		gotStatusCode = run(strings.Split("-r -cm test -add-shell-context minimal q hello", " "))
 	})
 
-	want := "hello\n\a"
+	want := "hello\n"
 	testboil.FailTestIfDiff(t, gotStatusCode, 0)
 	testboil.FailTestIfDiff(t, gotStdout, want)
 }
 
-func Test_goldenFile_QUERY_raw_output_ends_with_newline_before_bell(t *testing.T) {
+func Test_goldenFile_QUERY_redirected_raw_output_ends_with_newline(t *testing.T) {
 	_ = setupMainTestConfigDir(t)
 
 	oldArgs := os.Args
@@ -128,7 +128,7 @@ func Test_goldenFile_QUERY_raw_output_ends_with_newline_before_bell(t *testing.T
 	})
 
 	testboil.FailTestIfDiff(t, gotStatus, 0)
-	testboil.FailTestIfDiff(t, stdout, "hello\n\a")
+	testboil.FailTestIfDiff(t, stdout, "hello\n")
 }
 
 func Test_goldenFile_QUERY_shell_context_flag_keeps_user_message_output_clean(t *testing.T) {
@@ -156,7 +156,7 @@ func Test_goldenFile_QUERY_shell_context_flag_keeps_user_message_output_clean(t 
 		gotStatusCode = run(strings.Split("-r -cm test -add-shell-context minimal q hello", " "))
 	})
 
-	want := "hello\n\a"
+	want := "hello\n"
 	testboil.FailTestIfDiff(t, gotStatusCode, 0)
 	testboil.FailTestIfDiff(t, gotStdout, want)
 }

--- a/main_skills_e2e_test.go
+++ b/main_skills_e2e_test.go
@@ -38,7 +38,7 @@ func Test_e2e_skills_bootstrap_creates_config_and_default_dir(t *testing.T) {
 	if gotStatus != 0 {
 		t.Fatalf("expected success status, got %d, stdout=%q", gotStatus, stdout)
 	}
-	if !strings.HasSuffix(stdout, "bootstrap\n\a") {
+	if !strings.HasSuffix(stdout, "bootstrap\n") {
 		t.Fatalf("unexpected bootstrap output: %q", stdout)
 	}
 	if _, err := os.Stat(filepath.Join(confDir, "skills")); err != nil {
@@ -405,11 +405,12 @@ func Test_e2e_skill_automatically_enables_local_tools(t *testing.T) {
 	if strings.Contains(stdout, "skill requested unavailable tool") {
 		t.Fatalf("local tools reported unavailable: %q", stdout)
 	}
-	if !strings.Contains(stdout, "skill enabled local tools: async_cmd, async_cmd_await, async_cmd_cancel, async_cmd_logs, async_cmd_status") {
+	compactStdout := strings.ReplaceAll(stdout, "\n  ", "")
+	if !strings.Contains(compactStdout, "skill enabled local tools: async_cmd, async_cmd_await, async_cmd_cancel, async_cmd_logs, async_cmd_status") {
 		t.Fatalf("expected automatic tool warning, got %q", stdout)
 	}
-	if count := strings.Count(stdout, "Name: review"); count != 1 {
-		t.Fatalf("expected one skill result, got %d in %q", count, stdout)
+	if count := strings.Count(stdout, "Body"); count != 1 {
+		t.Fatalf("expected one complete raw skill result, got %d in %q", count, stdout)
 	}
 	if strings.Contains(stdout, "Loaded skill") {
 		t.Fatalf("expected no duplicate activation notice, got %q", stdout)

--- a/main_test_helpers_test.go
+++ b/main_test_helpers_test.go
@@ -39,7 +39,12 @@ func setupMainTestConfigDir(t *testing.T) string {
   "roleReasoning": "",
   "roleOther": "",
   "notificationBell": true,
-  "tableItems": 10
+  "tableItems": 10,
+  "toolOutputRows": 6,
+  "rollingOutput": {
+    "enabled": true,
+    "windowCellHeight": 30
+  }
 }`
 	if err := os.WriteFile(filepath.Join(confDir, "theme.json"), []byte(themeContent), 0o644); err != nil {
 		t.Fatalf("WriteFile(theme.json): %v", err)

--- a/worklogs/2026-08-07-terminal-dimensions/README.md
+++ b/worklogs/2026-08-07-terminal-dimensions/README.md
@@ -1,0 +1,278 @@
+# Shared Unix Terminal Dimensions and Dynamic Rolling Viewport
+
+## Status board
+
+| #   | Phase                                                         | Status              | Summary                                                                                                                                                                                                                                                                                                                      |
+| --- | ------------------------------------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | [dimensions package](./phase-1-dimensions-package.md)         | Done                | Add the shared Unix terminal-dimensions viewer in `go_away_boilerplate/pkg/dimensions`.                                                                                                                                                                                                                                      |
+| 2   | [table migration](./phase-2-table-migration.md)               | Done                | Make `pkg/table` consume the dimensions package and remove its private ioctl implementation.                                                                                                                                                                                                                                 |
+| 3   | [clai width unification](./phase-3-clai-width-unification.md) | Done                | Route all clai width-aware output through one dimensions snapshot per session (`utils.SessionDimensions`) and explicit-width table helpers; remove `Querier.termWidth` and all hidden terminal queries.                                                                                                                      |
+| 4   | [viewport reflow](./phase-4-viewport-reflow.md)               | Done                | ActivityViewport stores logical blocks, `Resize` rewraps retained blocks and marks the viewport dirty, and `Render` emits one full atomic frame on dirty state with a diff path for normal appends; retention bounds blocks and per-block content.                                                                           |
+| 5   | [SIGWINCH integration](./phase-5-sigwinch-integration.md)     | Done                | One dimensions watcher per terminal rolling-output session refreshes the snapshot, resizes the viewport, and redraws in the serialized session loop; raw/structured/non-terminal sessions never start a watcher. R5-01 fixed: the viewport constructor binds the initial effective height to min(cap, terminal height), so the first frame never exceeds the terminal even without a resize. |
+| 6   | [quality gates](./phase-6-quality-gates.md)                   | Done                | All repository QA gates pass in both repositories; searches confirm the single terminal-dimension system; released-dependency verification recorded with the release hand-off for the temporary local replace.                                                                                                               |
+
+Phase order is strict. Phase 1 must land before Phase 2. Phase 2 must land before the clai migration in Phase 3. Phases 3 and 4 may proceed in parallel after Phase 2, but Phase 5 depends on both. Phase 6 is always last.
+
+## Motivation
+
+clai's rolling activity viewport currently captures terminal width once and uses several independent width paths afterward. In tmux, resizing a pane changes the foreground pseudo-terminal dimensions and delivers `SIGWINCH`, but clai does not currently re-query and reflow its output.
+
+The shared implementation belongs in `go_away_boilerplate`, because `pkg/table` and clai both need terminal dimensions. clai must not add a second ioctl implementation.
+
+## Strategy
+
+`go_away_boilerplate/pkg/dimensions` is the sole terminal-dimension implementation. It is Unix-only for this effort and returns width and height together. A stateful `Viewer` owns the output target, current snapshot, and resize notifications. `SIGWINCH` only invalidates dimensions; rendering remains serialized by the consumer loop.
+
+For implementation, the viewer contract must define the selected file descriptor, the exact fallback/error result for non-terminals and zero sizes, notification coalescing semantics, and ownership of `signal.Notify` registration. A consumer must be able to inject both signal events and dimension reads without sending process-global signals from unit tests.
+
+The implementation must be easy to test and must exercise the meaningful error
+edges: provider failure, zero-size dimensions, fallback, signal bursts,
+cancellation, stop, and writer errors. Aim for very high coverage in the new
+`pkg/dimensions` package, preferably near 100%, but do not shape the API or
+production design around an arbitrary percentage. The clai integration must
+test its important failure behavior at the real boundary. Coverage is evidence
+of design quality, not a substitute for a clear lifecycle and behavioral tests.
+
+`pkg/table` consumes that package. Existing `TermWidth` APIs may remain as compatibility wrappers, but they must delegate to `dimensions` and must not retain a separate ioctl or `COLUMNS` implementation. Snapshot-aware table helpers are required so callers can use one resolved dimension set for a complete operation.
+
+clai owns one dimensions snapshot per interactive output session. Every width-aware path uses that snapshot: rolling output, glow, cleanup metadata, photo animation, chat listings, tool listings, MCP descriptions, and tool activity. No clai production code may call `table.TermWidth` or hidden width-discovery helpers. The snapshot binds to the fd of the session's output writer: the viewer must observe the same file the writer writes to, not a fixed global fd. Today `table.TermWidth` queries stderr while clai writes to stdout, so `clai 2>/dev/null` on a wide terminal renders at the 80-column fallback.
+
+The rolling viewport retains logical activity blocks so a width change can rewrap reasoning, assistant text, and tool output. A resize invalidates the previous render bookkeeping and emits one complete redraw. Height is bounded by the configured rolling-window cap and the current terminal height; the effective viewport height equals min(cap, terminal height) at every point of the viewport lifecycle, including creation — the constructor must never render taller than the terminal it writes to (R5-01). Retained logical blocks need a bounded retention policy: overflowing and compacted tool/reasoning content is currently dropped at append time, so phase 4 must define what "retain" means under the row cap.
+
+## Decisions and invariants
+
+| Decision                          | Invariant                                                                                    |
+| --------------------------------- | -------------------------------------------------------------------------------------------- |
+| Unix only                         | No Windows implementation is required or added.                                              |
+| ioctl is authoritative            | `COLUMNS` must not override the live PTY size in production.                                 |
+| One implementation                | ioctl and fallback logic exist only in `pkg/dimensions`.                                     |
+| One snapshot per render operation | Related output uses identical width and height values.                                       |
+| Signal-safe design                | `SIGWINCH` handlers never write to stdout or mutate viewport render state.                   |
+| Logical viewport state            | Reflow never reconstructs content from already wrapped rows.                                 |
+| Noninteractive safety             | Raw, structured, debug, and non-terminal output do not start an interactive resize renderer. |
+
+## Phase decision log
+
+| #   | Decision                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Rationale                                                                                                                                                                                                                                                                                                                       |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | `Viewer` binds to the fd of the actual output writer and borrows it: it never closes the fd                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | R2-02: the observed size must match the written file; `table.TermWidth` queries stderr today, so `clai 2>/dev/null` renders at the 80-column fallback (2026-08-07, worker session 1)                                                                                                                                            |
+| D2  | One size policy: a read is usable only when it succeeds and reports positive width and height; failures wrap `ErrUnavailable`; `Snapshot` returns the last valid size or `Fallback` (80x24) plus the wrapped error                                                                                                                                                                                                                                                                                                                                                                                        | R1-02: the legacy silent 80-column fallback stays reachable while callers can detect non-terminals with `errors.Is`; the viewer normalizes injected readers too, so the policy is uniform (2026-08-07, worker session 1)                                                                                                        |
+| D3  | `Events` is a capacity-one channel of fresh `Dimensions`; bursts coalesce via non-blocking sends; the channel closes on stop and receivers use the two-value receive or `range`                                                                                                                                                                                                                                                                                                                                                                                                                           | The consumer needs one snapshot per redraw and must distinguish stop from resize; closing the channel gives `range` and `select` a uniform end-of-life signal (2026-08-07, worker session 1)                                                                                                                                    |
+| D4  | The viewer owns the `signal.Notify(SIGWINCH)` registration when no source is injected; `WithSignalSource` replaces it in tests; a closed source stops the viewer                                                                                                                                                                                                                                                                                                                                                                                                                                          | R1-01/R1-06: unit tests must never send process-global signals; `signal.Stop` runs in the watcher's deferred cleanup so no registration leaks (2026-08-07, worker session 1)                                                                                                                                                    |
+| D5  | Lifecycle: `New(ctx, fd, opts...)` performs the initial read and starts the watcher; `Stop` is idempotent, blocks until the watcher exited, and stays safe after context cancellation or a closed source; `Snapshot` stays usable after stop                                                                                                                                                                                                                                                                                                                                                              | Context cancellation, explicit stop, and source close must all release resources exactly once without deadlock or goroutine leak (2026-08-07, worker session 1)                                                                                                                                                                 |
+| D6  | Platform split: the `TIOCGWINSZ` implementation is `unix`-tagged; `!unix` builds get an `ErrUnavailable` stub reader and a no-op SIGWINCH registration                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Unix-only per the plan, but the package still compiles on other platforms; no Windows terminal implementation is added (2026-08-07, worker session 1)                                                                                                                                                                           |
+| D7  | `table.TermWidth` is a pure compatibility wrapper: it delegates to `dimensions.DefaultReader(stderr)` and maps every provider failure to `(Fallback.Width, nil)`; new explicit-width truncation helpers (`WidthAppropriateStringTruncColoredWithWidth` and friends) use a supplied width exactly and never query the terminal                                                                                                                                                                                                                                                                             | The legacy implementation never returned an error, so preserving `(80, nil)` keeps existing callers usable; snapshot-aware helpers let phase 3 render one operation with one resolved dimension set (2026-08-07, worker session 2)                                                                                              |
+| D8  | `utils.SessionDimensions(w)` is clai's single width-discovery point: it binds to the writer's fd and returns `dimensions.Fallback` on any non-terminal/failure path; `Querier` and `ChatHandler` each store one snapshot per session from their output writer, and standalone operations (glow, photo animation, tools listing, MCP debug) resolve one snapshot from the writer they use                                                                                                                                                                                                                  | R2-02: the observed size must match the written file; a single discovery point plus explicit-width table helpers makes the phase-3 acceptance criteria provable by repository search (2026-08-07, worker session 3)                                                                                                             |
+| D9  | Phase 4 storage: `ActivityViewport` keeps an ordered list of logical `activityBlock`s (kind, full sanitized content, tool-call metadata, tool body budget) plus a derived visible-row cache; `NewActivityViewport(width, maxRows, terminalHeight)` binds the initial effective height to min(cap, terminal height) (R5-01 fix); `Resize(width, terminalHeight)` mutates state only (rewrap, effective height = min(cap, terminal height), dirty flag, no-op on equal dimensions) and `Render` emits one complete atomic frame on dirty state while the diff path stays for normal streaming appends; retention is bounded by `maxActivityBlocks` (16) and `maxActivityBlockRunes` (64 KiB) with over-budget content reduced to head and tail | R2-01: reflow must reconstruct content from logical blocks, never from wrapped rows; R1-04: a partial frame write leaves the viewport dirty so the next `Render` retries the full frame; the phase-5 watcher will be the only caller of `Resize`, invoked from the serialized session loop (2026-08-07, worker session 4; R5-01 fix in worker session 7)       |
+| D10 | One dimensions watcher per query, started in `Querier.Query` via `startResizeWatcher` exactly when `usesActivityViewport()` holds and the writer is an `*os.File`; the viewer's `Events` channel is passed to the `sessionRunner` as `resizeEvents`, consumed in the `executeModelStep` select; `applyResize` stores the event as the new `q.dims`, resizes the viewport, and redraws; the three lazy viewport creation sites are unified in `ensureActivityViewport` reading the current snapshot; the watcher is stopped by a deferred `viewer.Stop` on success, error, and cancellation                | R2-03: the watcher gate must equal the viewport predicate and the first render after a pre-creation resize must use the new dimensions; R1-06: clai tests inject a channel into the runner, so no unit test sends a process-global signal; the observed fd must match the session writer (R2-02) (2026-08-07, worker session 5) |
+| D11 | The temporary local `replace` stays until a maintainer tags and pushes a go_away_boilerplate release containing `pkg/dimensions`; phase 6 records the exact hand-off (tag, `go get`, remove replace, `go mod tidy`)                                                                                                                                                                                                                                                                                                                                                                                       | The final clai change must consume a released module version; removing the replace now would break the build because no released version contains `pkg/dimensions` (v1.33.8 is the newest release, verified via module proxy and `go list -m -versions`) (2026-08-07, worker session 6)                                         |
+
+## Error severity
+
+Critical, major, and normal findings reopen a phase. Minor findings do not reopen a phase unless they affect a stated invariant or acceptance criterion.
+
+## Cross-repository integration
+
+The implementation starts in `/home/imago/Projects/public/go_away_boilerplate`. During development clai may use a temporary local `replace` directive, but the final clai change must consume a released module version and must not retain the local replace.
+
+## Session journal
+
+### 2026-08-07
+
+Created the worklog after investigating clai's cached `termWidth`, direct `table.TermWidth` calls, indirect `WidthAppropriateStringTrunc` calls, and the existing ioctl implementation in `go_away_boilerplate/pkg/table`.
+
+### Phase 1 execution — 2026-08-07 (worker session 1)
+
+Implemented phase 1 in `go_away_boilerplate/pkg/dimensions`. The API contract,
+zero-size policy, and phase 2 mapping are recorded in the phase 1 spec
+implementation notes; material decisions are D1-D6. Baseline and post-change
+commands and results are in the phase 1 spec.
+
+### Phase 2 execution — 2026-08-07 (worker session 2)
+
+Implemented phase 2 in `go_away_boilerplate/pkg/table`. `TermWidth` now
+delegates to `pkg/dimensions` through an injectable core; the private ioctl,
+`COLUMNS` precedence, and `unsafe` code are gone. Explicit-width truncation
+helpers were added, and the table tests now assert the shared provider
+contract instead of environment precedence. The wrapper failure policy
+resolves R1-02: `TermWidth` returns `(Fallback.Width, nil)` on any provider
+failure. The API contract, error-coverage mapping, and commands and results
+are in the phase 2 spec; material decision D7. All repository QA gates
+passed; cross-platform builds passed for darwin/amd64, linux/arm64, and
+windows/amd64.
+
+### Phase 3 execution — 2026-08-07 (worker session 3)
+
+Implemented phase 3 in clai. Completed the in-flight migration (broken photo
+import, `messagePickerRow` arity, test `termWidth` field removal) and removed
+the last terminal-querying truncation calls (`tools/cmd.go`, `tools/mcp`,
+`chat/obfuscated_print.go`). `utils.SessionDimensions` is the single
+width-discovery point; `Querier.dims` and `ChatHandler.dims` are the per-
+session snapshots bound to the session writer's fd (R2-02). Material
+decisions are recorded as D8; snapshot lifecycle (R1-03), the width-source
+inventory (R1-05), and the error-coverage mapping are in the phase 3 spec.
+Baseline and post-change commands and results are in the phase 3 spec.
+
+### Phase 4 execution — 2026-08-07 (worker session 4)
+
+Implemented phase 4 in clai (`internal/utils/print.go`). `ActivityViewport`
+now stores logical blocks (kind, full sanitized content, tool-call metadata,
+tool body budget) with a derived visible-row cache; the old wrapped-row
+storage, builders, and `appendBlock`/`trim` are gone. `Resize` mutates state
+only (clamped dimensions, effective height = min(cap, terminal height),
+full rewrap, dirty flag, no-op on equal dimensions) and never writes;
+`Render` emits one complete atomic frame on dirty state (move up, clear
+down, rewrite) and keeps the diff path for normal appends, updating
+bookkeeping only on success so a partial write leaves the viewport dirty
+and the next render retries the full frame. Retention is bounded by
+`maxActivityBlocks` (16) and `maxActivityBlockRunes` (64 KiB). The dupl
+check flagged the pre-existing `AppendReasoning`/`AppendText` clone, merged
+into the shared `appendCoalescing` helper. Material decisions are recorded
+as D9; the storage model, retention policy, rewrap algorithm, frame
+contract, and error-coverage mapping are in the phase 4 spec. Baseline and
+post-change commands and results are in the phase 4 spec; all repository QA
+gates pass (`go test ./... -race -cover -count=3 -timeout=30s` exit 0,
+internal/utils coverage 81.4%).
+
+### Phase 5 execution — 2026-08-07 (worker session 5)
+
+Implemented phase 5 in clai (`internal/text/querier.go`,
+`internal/text/session_runner.go`, `internal/text/tool_executor.go`).
+`Querier.Query` starts one dimensions watcher via `startResizeWatcher`
+exactly when `usesActivityViewport()` holds and the writer is an `*os.File`,
+and defers `viewer.Stop` so the watcher ends on success, error, and
+cancellation. The viewer's `Events` channel is passed to the `sessionRunner`
+as `resizeEvents`; the `executeModelStep` select consumes it and
+`applyResize` stores the fresh snapshot as `q.dims`, resizes the viewport,
+and redraws before subsequent output. The three lazy viewport creation sites
+are unified in `ensureActivityViewport`, which reads the current snapshot so
+a resize before the first reasoning/tool event makes the first render use
+the new dimensions (R2-03). Material decision D10; the watcher gate,
+consumption ordering (R1-03), signal-injection strategy (R1-06), and the
+error-coverage mapping are in the phase 5 spec. Architecture docs
+`colours.md` and `query.md` gained the resize behavior. Baseline and
+post-change commands and results are in the phase 5 spec; all repository QA
+gates pass (`go test ./... -race -cover -count=3 -timeout=30s` exit 0,
+internal/text coverage 72.3%).
+
+### Review 1 — 2026-08-07
+
+Baseline verification: `go test ./...` passed in both clai and `/home/imago/Projects/public/go_away_boilerplate`. No implementation exists yet, so implementation-specific acceptance criteria and repository QA gates could not be verified. The plan is not ready for execution without resolving the findings below. The main risk is that “snapshot”, “fallback”, and “complete atomic frame” currently describe desired behavior but not testable API contracts.
+
+### Review 2 — 2026-08-07
+
+Re-ran `go test ./... -count=1 -timeout=120s` in both repositories: clai passed, go_away_boilerplate passed. No implementation exists; all phases remain Not Started. Verified the motivation against source: cached `Querier.termWidth` (querier_setup.go:207-210); direct `table.TermWidth` calls (photo/funimation_0.go:16, utils/print.go:148, chat/handler_list_chat.go:637, text/tool_executor.go:330); indirect truncation discovery (tools/cmd.go:55, tools/mcp/tool.go:92, chat/handler_dir.go:99, chat/obfuscated_print.go:126, chat/handler_list_chat.go:683/699/845/998); the single width implementation in go_away_boilerplate/pkg/table/term.go (COLUMNS precedence, stderr ioctl, fallback 80); and no SIGWINCH handling in clai. clai consumes released go_away_boilerplate v1.33.8 with no local replace. The R1 findings remain open and are confirmed against code. Two new findings refine the specs: R2-01 (major, phase 4 — the viewport stores wrapped rows, not logical blocks, so the retention/reflow model must be specified) and R2-02/R2-03 (normal, phases 1/3/5 — fd binding and watcher-gate/ordering). Verdict unchanged: the plan is not ready for execution until R1-01, R1-02, and R1-03 are resolved in the phase specs; R1-04 and R2-01 were resolved in the phase 4 spec amendment (review 2). Direction and motivation are sound; the work will increase clai quality if executed against the tightened contracts.
+
+### Review 3 — 2026-08-07
+
+Phase 3 is complete and all repository QA gates pass (`go test ./... -race
+-cover -count=3 -timeout=30s` exit 0; gofumpt, staticcheck, go vet, go fix,
+dupl clean; dupl clones are pre-existing and outside phase-3 files).
+Acceptance criteria verified by search: no production `table.TermWidth` call
+and no terminal-querying truncation helper remain in clai source; every
+width-aware path uses `q.dims`/`cq.dims` or `utils.SessionDimensions`.
+`clai 2>/dev/null` now observes stdout (R2-02): the querier and chat handler
+bind the snapshot to the session output writer. Phase 4 (viewport reflow) is
+the next eligible phase.
+
+### Phase 6 execution — 2026-08-07 (worker session 6)
+
+Implemented phase 6 in both repositories. `make qa` in clai and the
+individual mandated commands in both repositories all pass unedited
+(gofumpt, staticcheck, go vet, go fix, `go test ./... -race -cover -count=3
+-timeout=30s`, dupl). Coverage: `pkg/dimensions` 100.0%, `pkg/table`
+96.6%, internal/utils 81.3%, internal/text 72.3%. Cross-platform builds
+pass for darwin/amd64, linux/arm64, and windows/amd64; `go mod verify`
+passes. Repository searches confirm the single-system state: no production
+`table.TermWidth` call and no terminal-querying truncation helper remain in
+clai; `TIOCGWINSZ`/`unsafe`/`COLUMNS` exist only in `pkg/dimensions`;
+`SIGWINCH` writes never happen in a signal callback. Dupl findings are all
+pre-existing and outside the changed regions. The released-dependency
+verification recorded v1.33.8 as the newest released version; no released
+version contains `pkg/dimensions`, so the temporary local `replace` remains
+until the maintainer tags and pushes the boilerplate release (D11, exact
+hand-off in the phase 6 spec). Architecture documentation required no
+further update. Material decision D11.
+
+### Review 4 — 2026-08-07
+
+Holistic review of the completed worklog (all six phases). Re-ran every
+gate independently in both repositories: `make qa` in clai; gofumpt,
+staticcheck, go vet, go fix, `go test ./... -race -cover -count=3
+-timeout=30s`, and dupl in both; cross-platform builds for darwin/amd64,
+linux/arm64, and windows/amd64; `go mod verify`. All pass. Traced the
+invariants through the code: the viewer lifecycle (D1-D6), the table wrapper
+(D7), the per-session snapshots (D8), the viewport storage/Resize/Render
+contract (D9), and the watcher gate and resize consumption (D10) hold on
+every branch examined, including the failure and teardown paths. No code
+defect was found; the only open item is the maintainer-only release hand-off
+(R4-01, also D11). R4-02 is a minor non-reopening observation. Verdict:
+ready.
+
+### Review 5 — 2026-08-07
+
+Independent re-review of the completed worklog. Re-ran the gates myself in
+both repositories: `go test ./... -race -cover -count=3 -timeout=30s` (exit
+0, twice, coverage matching the records: pkg/dimensions 100.0%, pkg/table
+96.6%, internal/utils 81.3%, internal/text 72.3%), gofumpt, staticcheck,
+`go vet`, `go fix`, dupl (clai 31 groups, boilerplate 6, all pre-existing
+and outside the changed regions), `go mod verify`, and cross-platform builds
+for darwin/amd64, linux/arm64, and windows/amd64 — all pass. One `make qa`
+run failed on the pre-existing vendored `Test_context` flake
+(claude_stream_test.go:267, untouched by this work); the identical mandated
+test command passed in the other two full-suite runs and the package passed
+in isolation (R5-02). Traced the invariants through the code again: the
+viewer lifecycle, the table wrapper, the per-session snapshots, the
+viewport storage/Resize/Render contract, and the watcher gate and resize
+consumption all hold on the failure and teardown branches examined. One
+contract deviation found: the initial viewport height is the cap, not
+min(cap, terminal height), so the phase-4 AC "effective height never
+exceeds terminal height or configured cap" and the colours.md statement
+"The effective window height is min(window-cell-height, terminal height)"
+are unmet until the first SIGWINCH (R5-01, normal, reopens phase 5). The
+release hand-off (R4-01/D11) remains the only other open item. Verdict:
+not ready as recorded — phase 5 is reopened for R5-01; everything else
+verified good.
+
+### Phase 5 R5-01 fix — 2026-08-07 (worker session 7)
+
+Closed R5-01 in clai. `ActivityViewport` construction now binds the initial
+effective height: `NewActivityViewport(width, maxRows, terminalHeight)` sets
+`height = min(maxRows, max(terminalHeight, 1))` from the start, and
+`ensureActivityViewport` passes `q.dims.Height`, so the first frame renders
+at `min(cap, terminal height)` even without a resize. The phase-4 AC
+"Effective height never exceeds terminal height or configured cap" and the
+`colours.md` statement hold from the first frame; no doc amendment was
+needed. `Test_sessionRunner_Run_InitialHeightBindsTerminalHeight` proves the
+session-boundary behavior (5-row terminal, default 30-row cap, no resize:
+the first reasoning render shows five rows and drops the middle), and the
+viewport unit test `initial height binds the terminal height at creation`
+pins the constructor and the live grow. Test fixtures with a bare
+`dims.Width` gained `Height: 24` (the fallback height) to match the D2
+invariant that the snapshot always carries positive width and height. All
+repository QA gates pass; material decision updated in D9 (constructor now
+binds the initial height).
+
+## Feedback index
+
+| ID    | Severity | Phase                                                                            | Summary                                                                                                                                                                                                                                                                  |
+| ----- | -------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| R1-01 | Major    | [1](./phase-1-dimensions-package.md)                                             | Define the Viewer API, lifecycle, fd ownership, and injectable signal source.                                                                                                                                                                                            |
+| R1-02 | Major    | [1](./phase-1-dimensions-package.md), [2](./phase-2-table-migration.md)          | Resolve zero-size, ioctl failure, and fallback semantics before migration.                                                                                                                                                                                               |
+| R1-03 | Major    | [3](./phase-3-clai-width-unification.md), [5](./phase-5-sigwinch-integration.md) | Define snapshot ownership and refresh timing for every render operation. Resolved in phase 5 implementation notes.                                                                                                                                                       |
+| R1-04 | Major    | [4](./phase-4-viewport-reflow.md), [5](./phase-5-sigwinch-integration.md)        | Specify atomic frame writes and failure behavior at the writer boundary. Resolved in phase 4 spec (review 2 amendment).                                                                                                                                                  |
+| R1-05 | Normal   | [3](./phase-3-clai-width-unification.md)                                         | Turn the broad width-aware-path list into an auditable source/test inventory.                                                                                                                                                                                            |
+| R1-06 | Normal   | [5](./phase-5-sigwinch-integration.md)                                           | Make SIGWINCH injection and process-global signal ownership testable. Resolved in phase 5 implementation notes.                                                                                                                                                          |
+| R1-07 | Normal   | [6](./phase-6-quality-gates.md)                                                  | Name the exact required QA commands and cross-repository evidence.                                                                                                                                                                                                       |
+| R2-01 | Major    | [4](./phase-4-viewport-reflow.md)                                                | Specify the viewport's logical-block storage model; wrapped-row storage cannot reflow. Resolved in phase 4 spec (review 2 amendment).                                                                                                                                    |
+| R2-02 | Normal   | [1](./phase-1-dimensions-package.md), [3](./phase-3-clai-width-unification.md)   | Bind the snapshot fd to the session writer; `table.TermWidth` queries stderr today.                                                                                                                                                                                      |
+| R2-03 | Normal   | [5](./phase-5-sigwinch-integration.md)                                           | Name the watcher gate and handle resize-before-lazy-viewport-creation. Resolved in phase 5 implementation notes.                                                                                                                                                         |
+| R4-01 | Normal   | [6](./phase-6-quality-gates.md)                                                  | Release the go_away_boilerplate changes and remove the local replace (maintainer-only; tracked as D11). Open in review 4.                                                                                                                                                |
+| R4-02 | Minor    | [1](./phase-1-dimensions-package.md), [6](./phase-6-quality-gates.md)            | `dimensions.New` documents but does not guard a nil ctx; panic on documented precondition violation is idiomatic, so no guard or test is required. Non-reopening.                                                                                                        |
+| R5-01 | Normal   | [4](./phase-4-viewport-reflow.md), [5](./phase-5-sigwinch-integration.md)        | Initial viewport height is the cap, never the terminal height, so "effective height never exceeds terminal height or configured cap" is unmet until the first resize; fix at `ensureActivityViewport` creation or amend the AC/docs. Resolved in phase 5 (worker session 7): the constructor now binds the initial height to min(cap, terminal height). |
+| R5-02 | Minor    | [6](./phase-6-quality-gates.md)                                                  | `make qa` flaked once on the pre-existing vendored `Test_context` (anthropic) — timing flake in untouched code; the mandated command passed in the other full-suite runs. Non-reopening.                                                                                 |
+
+The review should question untested meaningful behavior, especially error and
+cleanup paths, but should not require artificial tests for unreachable or
+mechanical branches. Prefer focused behavioral tests over coverage-driven API
+or implementation choices.

--- a/worklogs/2026-08-07-terminal-dimensions/phase-1-dimensions-package.md
+++ b/worklogs/2026-08-07-terminal-dimensions/phase-1-dimensions-package.md
@@ -1,0 +1,145 @@
+# Phase 1 — Shared dimensions package
+
+**Status:** Done  
+[Back to README](./README.md)
+
+## Goal
+
+Add a reusable Unix terminal-dimensions viewer to `go_away_boilerplate/pkg/dimensions`.
+
+## Specification
+
+Provide width and height as one `Dimensions` value. Provide a stateful `Viewer` bound to an output terminal, an initial/current read, and resize notifications driven by `SIGWINCH`. Query `TIOCGWINSZ` from the selected terminal; do not invoke tmux or external commands. Keep all ioctl and fallback logic in this package. Support injected readers or dimensions for deterministic tests.
+
+The package must not write to the terminal from a signal callback. It must be safe to stop watching through context cancellation and must not leak signal registrations or goroutines. This phase is Unix-only.
+
+## Integration contract
+
+| Trigger | Collaborator | Observable result | Required side effect | Prohibited side effect |
+|---|---|---|---|---|
+| Current dimensions requested | PTY/file descriptor | Width and height are returned together | One live ioctl query | No tmux subprocess |
+| `SIGWINCH` received | Viewer watcher | A fresh dimension snapshot is delivered | Query after notification | No terminal write in signal path |
+| Context cancelled | Viewer watcher | Notification channel closes or stops | Signal registration is released | No goroutine leak |
+| Non-terminal/failing ioctl | Fallback policy | Documented safe dimensions/error | Deterministic fallback | No stale `COLUMNS` override |
+
+## Acceptance criteria
+
+- `pkg/dimensions` exposes a reusable `Dimensions` and `Viewer` API.
+- Width and height are obtained through one Unix implementation.
+- `SIGWINCH` produces a fresh query.
+- Cancellation releases resources.
+- Tests cover successful reads, invalid/zero sizes, signal delivery, cancellation, and failure behavior.
+- New package code has very high, meaningful coverage, with deterministic tests for injected provider, signal, cancellation, stop, fallback, and error behavior. Do not add production seams solely to increase a percentage.
+- `go test ./...` passes in `go_away_boilerplate`.
+
+## Error coverage
+
+| Failure | Expected behavior | Test |
+|---|---|---|
+| ioctl fails | Return documented fallback or wrapped error | provider failure test |
+| ioctl returns zero dimension | Clamp or fallback according to API contract | zero-size test |
+| watcher context ends | Stop and release signal notification | cancellation test |
+| notification channel is full | Coalesce resize invalidations | burst-signal test |
+| injected signal source stops or closes | Viewer exits without blocking or leaking | source-close test |
+| stop called more than once | Cleanup remains idempotent | repeated-stop test |
+| refresh fails after a valid snapshot | Last valid snapshot and documented error policy are preserved | refresh-after-valid test |
+
+## Implementation notes (2026-08-07, worker session 1 — execution)
+
+Implemented in `go_away_boilerplate/pkg/dimensions` as the sole
+terminal-dimension implementation of the module. The API contract below
+resolves R1-01, R1-02, and R2-02 and is the policy that phase 2 must consume.
+
+### API contract
+
+- `Dimensions{Width, Height int}` carries the size as one value; both fields
+  are greater than zero for a usable size.
+- `Fallback` is the documented safe size `80x24` and preserves the historical
+  `table.TermWidth` fallback of 80 columns.
+- `ErrUnavailable` is the sentinel every read failure wraps. Callers use
+  `errors.Is(err, ErrUnavailable)` to detect "this file descriptor has no
+  usable terminal size".
+- `Reader func() (Dimensions, error)` performs one live query and never
+  fabricates a size.
+- `DefaultReader(fd)` queries `TIOCGWINSZ` on fd. A failed ioctl (including
+  `ENOTTY` on non-terminals) or a reported zero width or height returns zero
+  `Dimensions` and a wrapped `ErrUnavailable`. The unix build is the only
+  real implementation; the `!unix` stub returns `ErrUnavailable`.
+- `New(ctx, fd, opts...) *Viewer` binds the viewer to the fd of the actual
+  output writer (R2-02). The viewer borrows the fd and never closes it. `New`
+  performs one initial read and starts the watcher goroutine.
+- `Snapshot() (Dimensions, error)` performs one live read per call. On
+  failure it returns the last valid snapshot, or `Fallback` when no valid
+  snapshot exists, together with the wrapped error. It stays usable after
+  stop.
+- `Events() <-chan Dimensions` is the resize channel (capacity one). A
+  successful signal-driven refresh delivers a fresh snapshot; bursts
+  coalesce via non-blocking sends. The channel closes when the viewer stops;
+  receivers use the two-value receive or `range`.
+- `Stop()` is idempotent, releases the owned `signal.Notify` registration,
+  closes `Events`, and blocks until the watcher has exited. Context
+  cancellation and a closed injected signal source stop the watcher the same
+  way; `Stop` remains safe afterwards.
+- `WithReader(r)` injects deterministic reads; `WithSignalSource(src)`
+  injects signals so unit tests never send process-global signals. A closed
+  source stops the viewer. A nil source or nil reader selects the default
+  registration or ioctl reader.
+
+### Zero-size and failure policy (R1-02)
+
+One policy applies to every reader, injected or default: a read is usable
+only when it succeeds and reports positive width and height. The viewer
+normalizes all reads (`normalizeRead`), so an injected reader that reports a
+zero size follows the same `ErrUnavailable` policy as the ioctl reader.
+`COLUMNS` is never consulted; the ioctl is authoritative. No subprocess is
+invoked.
+
+Phase 2 mapping: the `TermWidth` compatibility wrapper will map
+`ErrUnavailable` to `(Fallback.Width, nil)` to preserve the legacy silent
+80-column fallback; callers that need terminal awareness check `errors.Is`.
+
+### Test coverage
+
+Behavioral tests with injected readers and signal sources cover live reads,
+initial-read failure, zero width and height, refresh failure after a valid
+snapshot (last valid size preserved, no event on failure), signal delivery,
+burst coalescing (1000 signals, one buffered event), repeated stop,
+context cancellation, closed signal source, post-stop snapshot, nil reader,
+and default signal registration. A subprocess test (`TestViewer_RealSIGWINCH`)
+exercises the process-wide signal path end to end without contaminating other
+tests. Real-PTY tests on linux verify a live `TIOCGWINSZ` success and a
+zero-size failure; a pipe test verifies the `ENOTTY` path deterministically.
+Statement coverage on the linux build is 100%.
+
+### Commands and results
+
+Baseline before changes: `go test ./... -race -count=3 -timeout=30s` passed
+in `go_away_boilerplate`. After the change the same command passed, plus
+`go vet ./...`, `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`,
+`go run mvdan.cc/gofumpt@latest -w -l .`, and `go fix ./...` were clean.
+Cross-platform compile checks passed: darwin/amd64 and linux/arm64 for the
+whole module, windows/amd64 for the dimensions package.
+
+## Review findings (review 1, 2026-08-07)
+
+**R1-01 — Major — resolved.** [x] The `Viewer` API is defined in the
+implementation notes: fd binding and borrowing, initial read in `New`,
+notification channel behavior, idempotent stop, and injected readers and
+signal sources that replace OS facilities in tests.
+
+**R1-02 — Major — resolved.** [x] One zero-size and failure policy is
+documented and enforced by `normalizeRead` and `DefaultReader`: a usable size
+requires a successful read with positive width and height; failures wrap
+`ErrUnavailable`; `Snapshot` returns the last valid snapshot or `Fallback`
+(80x24). The phase 2 mapping is stated in the implementation notes.
+
+Verified good: the phase correctly prohibits terminal writes from the signal
+callback and requires cancellation cleanup, burst coalescing, and failure tests.
+
+## Review findings (review 2, 2026-08-07)
+
+**R2-02 — Normal — resolved.** [x] The viewer takes the fd of the actual
+writer and never closes it; `table.TermWidth` keeps stderr semantics in
+phase 2 only as a deliberate compatibility wrapper, while clai binds the
+snapshot to `querier.out` in phase 3. The snapshot-fd-equals-writer-fd
+assertion is a phase 3 acceptance criterion.

--- a/worklogs/2026-08-07-terminal-dimensions/phase-2-table-migration.md
+++ b/worklogs/2026-08-07-terminal-dimensions/phase-2-table-migration.md
@@ -1,0 +1,120 @@
+# Phase 2 — Table migration
+
+**Status:** Done  
+[Back to README](./README.md)
+
+## Goal
+
+Refactor `go_away_boilerplate/pkg/table` to use `pkg/dimensions` as its only terminal-size implementation.
+
+## Specification
+
+Remove the private ioctl and `COLUMNS` precedence from `pkg/table/term.go`. Preserve compatible `TermWidth` behavior as a wrapper where needed, but delegate it to `dimensions`. Add snapshot-aware width/truncation APIs so callers can avoid repeated discovery during one render operation. Update table tests to assert the shared provider contract rather than environment precedence.
+
+## Integration contract
+
+| Trigger | Collaborator | Observable result | Required side effect | Prohibited side effect |
+|---|---|---|---|---|
+| `table.TermWidth` called | dimensions viewer/provider | Current width returned | Delegates to shared package | No table-local ioctl |
+| Width-aware truncation called with snapshot | Dimensions value | Text fits supplied width | Uses supplied width exactly | No second terminal query |
+| Existing table caller used | Compatibility wrapper | Existing API remains usable | Same documented fallback | No breaking unrelated table behavior |
+
+## Acceptance criteria
+
+- `pkg/table` has no `TIOCGWINSZ`, `syscall` width query, or `COLUMNS` precedence.
+- Snapshot-aware truncation is available and tested.
+- Existing table tests are updated and pass.
+- A repository search proves the old implementation is gone.
+- New or changed table code has focused coverage for provider errors, invalid supplied dimensions, and compatibility-wrapper paths.
+
+## Error coverage
+
+| Failure | Expected behavior | Test |
+|---|---|---|
+| Shared provider fails | Preserve table's documented fallback/error behavior | wrapper failure test |
+| Supplied width is zero/negative | Clamp safely | truncation edge test |
+| Dimensions change between operations | Each explicit snapshot is respected | snapshot isolation test |
+| explicit-width helper receives writer/formatting failure | Error is returned without a second query or partial silent fallback | helper error test |
+
+## Implementation notes (2026-08-07, worker session 2 — execution)
+
+Implemented in `go_away_boilerplate/pkg/table`. The package now consumes
+`pkg/dimensions` as its only terminal-size implementation.
+
+### API contract
+
+- `TermWidth()` delegates to `dimensions.DefaultReader(os.Stderr.Fd())`
+  through the injectable core `termWidth(read dimensions.Reader)`. The ioctl
+  query, zero-size policy, and fallback value live in `pkg/dimensions`;
+  `pkg/table` has no `TIOCGWINSZ`, `syscall`, `COLUMNS`, or `unsafe` code
+  left.
+- Failure policy (R1-02): on any provider failure `TermWidth` returns
+  `(dimensions.Fallback.Width, nil)` = `(80, nil)`. This preserves the
+  legacy silent fallback exactly: the historical implementation never
+  returned a non-nil error either, so existing callers keep usable output.
+  The wrapped `ErrUnavailable` is intentionally not observable through
+  `TermWidth`; callers that need terminal awareness use `pkg/dimensions`
+  directly and check `errors.Is(err, dimensions.ErrUnavailable)` (phase 3).
+- Snapshot-aware APIs added so callers can render one operation with a
+  resolved dimension set and no second query:
+  - `WidthAppropriateStringTruncWithWidth(toShorten, prefix string, padding, width int) string`
+  - `WidthAppropriateStringTruncColoredWithWidth(toShorten, prefix, prefixColor, truncColor string, padding, width int) string`
+  Both use `width` exactly as supplied, never query the terminal, and clamp
+  zero or negative widths to the prefix only.
+- `WidthAppropriateStringTruncColored` now composes `TermWidth` with
+  `WidthAppropriateStringTruncColoredWithWidth`; its `(string, error)`
+  signature is unchanged for compatibility.
+
+### Error-coverage mapping
+
+| Failure | Expected behavior | Test |
+|---|---|---|
+| Shared provider fails | `TermWidth` returns `(Fallback.Width, nil)`; no error propagates | wrapper failure test (injected failing reader) |
+| Supplied width is zero/negative | Clamp to prefix only, no panic | truncation edge test |
+| Dimensions change between operations | Each explicit width is respected exactly | snapshot isolation test |
+| explicit-width helper misuse | Resolved: the string truncation helpers have no writer or formatting failure surface, so the equivalent guarantee is “no second terminal query and no silent fallback to another width”. The helpers take `width` directly (their signatures contain no reader), and the snapshot-isolation and clamp tests prove the guarantee | helper error test (amended) |
+
+### Test changes
+
+- Removed the COLUMNS-precedence tests; replaced them with provider-contract
+  tests that inject a `dimensions.Reader` (success and failure), plus one
+  ambient-independent smoke test that `TermWidth()` always returns a
+  positive width and nil error.
+- Legacy wrapper tests (`WidthAppropriateStringTrunc`,
+  `WidthAppropriateStringTruncColored`) now assert only ambient-independent
+  properties (nil error, prefix preserved), because they query real stderr
+  whose size varies by environment.
+- The explicit-width tests are deterministic: fits, infix truncation, empty
+  string, infix-length boundary, escaping, colors, clamp, and snapshot
+  isolation.
+- Removed the vestigial `COLUMNS` environment from `Test_table_selectNumbers`.
+
+### Commands and results
+
+Baseline before changes: `go test ./pkg/table/... -count=1 -timeout=120s`
+passed; full module `go test ./... -race -count=1 -timeout=120s` passed.
+
+After the change: `go test ./... -race -cover -count=3 -timeout=30s` passed
+(table package coverage 96.6%), plus `go vet ./...`, `go run
+honnef.co/go/tools/cmd/staticcheck@latest ./...`, `go run
+mvdan.cc/gofumpt@latest -w -l .`, and `go fix ./...` were clean.
+Cross-platform builds passed for darwin/amd64, linux/arm64, and
+windows/amd64 (the whole module, including `pkg/table`). A repository search
+finds no `TIOCGWINSZ`, `SYS_IOCTL`, `syscall`, `COLUMNS`, or `unsafe` in
+`pkg/table`.
+
+`dupl -t 80` reports only pre-existing clones in legacy test files and
+`pkg/testboil`; none are in the changed code.
+
+## Review findings (review 1, 2026-08-07)
+
+**R1-02 — Major — resolved.** [x] The wrapper behavior is defined above and
+in the phase 1 implementation notes: `TermWidth` returns `(80, nil)`
+(`dimensions.Fallback.Width`) whenever the shared provider fails, preserving
+usable output for existing callers; terminal-aware callers use
+`pkg/dimensions` and `errors.Is`. Concrete cases and expected values are in
+the error-coverage mapping.
+
+Verified good: the phase explicitly requires removal of table-local ioctl and
+`COLUMNS` precedence, and it requires explicit-width helpers that can prove no
+second query occurs.

--- a/worklogs/2026-08-07-terminal-dimensions/phase-3-clai-width-unification.md
+++ b/worklogs/2026-08-07-terminal-dimensions/phase-3-clai-width-unification.md
@@ -1,0 +1,155 @@
+# Phase 3 — clai width unification
+
+**Status:** Done  
+[Back to README](./README.md)
+
+## Goal
+
+Replace all independent clai terminal-width paths with one dimensions snapshot supplied by the shared package.
+
+## Specification
+
+Update querier setup, tool execution, printing, glow sizing, photo animation, chat listings, tool listings, MCP descriptions, and related helpers. Remove `Querier.termWidth` as an independently refreshed width; use a dimensions snapshot and explicit width-aware table helpers. Keep noninteractive fallbacks deterministic. Do not change vendor code.
+
+## Integration contract
+
+| Trigger | Collaborator | Observable result | Required side effect | Prohibited side effect |
+|---|---|---|---|---|
+| Interactive query starts | dimensions viewer | One initial snapshot is stored | All render paths can consume it | No duplicate width source |
+| Glow renders | shared snapshot | Glow receives current width | Width is passed explicitly | No hidden `table.TermWidth` query |
+| Tool/chat listing renders | shared snapshot | Consistent truncation | One operation-level snapshot | No environment lookup |
+| Non-terminal output runs | output-mode detection | Safe noninteractive behavior | No signal watcher | No ANSI-only width corruption |
+
+## Acceptance criteria
+
+- No clai production source directly calls `table.TermWidth`.
+- No clai production source uses hidden width-discovery truncation APIs.
+- All width-aware output uses the shared dimensions snapshot or an explicitly supplied snapshot.
+- The dimensions snapshot is taken from the session output writer's fd (R2-02): the querier binds to `userConf.Out` and the chat handler binds to `out`, so `clai 2>/dev/null` observes stdout, not stderr.
+- Existing output behavior and tests remain valid.
+- A repository search documents every intentional compatibility wrapper use.
+- Important new integration behavior, including initialization, non-terminal fallback, refresh failure, and output-helper errors, has boundary tests. Do not require tests that only mirror trivial implementation branches.
+
+## Error coverage
+
+| Failure | Expected behavior | Test |
+|---|---|---|
+| Initial dimensions unavailable | Safe fallback without query failure where current behavior allows | querier setup test |
+| Output is not a terminal | Raw/noninteractive path is selected | output mode tests |
+| Width is narrow | Truncation and wrapping remain bounded | utility and command tests |
+| width-aware collaborator returns an error | Caller follows the documented fallback and does not emit malformed output | collaborator error tests |
+
+## Implementation notes
+
+### Snapshot lifecycle (R1-03)
+
+`utils.SessionDimensions(w)` (internal/utils/dimensions.go) is clai's single
+width-discovery point. It binds to the writer's fd, so the observed size
+matches the file clai actually writes to (R2-02). A non-terminal writer, a
+failed read, or a reported zero size deterministically yields
+`dimensions.Fallback` (80x24); no error propagates, matching the legacy
+silent fallback.
+
+- Session owner: `Querier` owns the snapshot for text-query sessions
+  (`NewQuerier` resolves `utils.SessionDimensions(output)` once);
+  `ChatHandler` owns it for chat-command sessions (`New` resolves
+  `utils.SessionDimensions(out)` once). The stored `dims` value is the one
+  snapshot for the whole session; every listing/tool operation receives it
+  (`cq.dims.Width`, `q.dims.Width`) instead of taking a fresh one, so one
+  complete operation renders with one resolved dimension set.
+- Standalone render operations (glow sizing in `AttemptPrettyPrint`, photo
+  animation, `clai tools` listing, MCP debug output) resolve one snapshot at
+  the start of the operation from the writer they actually write to
+  (`os.Stdout` or the passed writer).
+- No live refresh exists in phase 3: the snapshot is static for the session.
+  SIGWINCH refresh (a fresh snapshot replacing the stored one) is phase 5;
+  `dimensions.Viewer.Snapshot` already returns the last valid snapshot or
+  `Fallback` plus a wrapped `ErrUnavailable` on failure, so the
+  preserve-last-valid-value rule is inherited unchanged.
+
+### Width-source inventory (R1-05)
+
+| Production width source (before) | Replacement | Where |
+|---|---|---|
+| `Querier.termWidth` cached from `table.TermWidth()` | `Querier.dims` from `utils.SessionDimensions(output)` | querier_setup.go, querier.go, tool_executor.go, session_runner.go |
+| `toolDisplayWidth()` fallback chain (cached width, then `table.TermWidth`, then 80) | removed; callers use `q.dims.Width` | tool_executor.go |
+| `table.TermWidth()` wide-table gate in `listChats` | `cq.dims.Width > 120` | handler_list_chat.go |
+| `table.WidthAppropriateStringTrunc` for chat summaries | `WidthAppropriateStringTruncWithWidth(..., cq.dims.Width)` | handler_list_chat.go |
+| `table.WidthAppropriateStringTrunc` in `messagePickerRow` | `WidthAppropriateStringTruncWithWidth(..., width)` threaded from `cq.dims.Width` | handler_list_chat.go |
+| `table.WidthAppropriateStringTrunc` in `initialPrompt` | `WidthAppropriateStringTruncWithWidth(..., width)` threaded from `cq.dims.Width` | handler_dir.go |
+| `table.WidthAppropriateStringTruncColored` in the obfuscated bridge | `WidthAppropriateStringTruncColoredWithWidth(..., width)` threaded from `cq.dims.Width` | obfuscated_print.go, handler.go |
+| `table.TermWidth()` in photo animation | `utils.SessionDimensions(os.Stdout).Width` | funimation_0.go |
+| `table.TermWidth()` in glow sizing | `utils.SessionDimensions(w).Width` | print.go (`AttemptPrettyPrint`) |
+| `table.WidthAppropriateStringTrunc` in the `clai tools` listing | `WidthAppropriateStringTruncWithWidth(..., utils.SessionDimensions(os.Stdout).Width)` | tools/cmd.go |
+| `table.WidthAppropriateStringTrunc` in MCP debug output | `WidthAppropriateStringTruncWithWidth(..., utils.SessionDimensions(os.Stdout).Width)` | tools/mcp/tool.go |
+
+Intentionally excluded from the inventory: the go_away_boilerplate
+compatibility wrappers `table.TermWidth`,
+`table.WidthAppropriateStringTrunc`, and
+`table.WidthAppropriateStringTruncColored` remain for external consumers but
+have no clai production caller; a repository search confirms the only
+remaining matches are in worklog/architecture documents. Non-interactive
+commands (`clai photo`, `clai tools`, MCP debug output) resolve one
+standalone snapshot from stdout and never start a signal watcher.
+
+### Error coverage mapping
+
+| Failure | Behavior | Test |
+|---|---|---|
+| Initial dimensions unavailable | `NewQuerier` succeeds and stores `dimensions.Fallback` | `Test_Querier_NewQuerier_dimsBoundToOutputWriter` (querier_setup_test.go) |
+| Output is not a terminal | Raw/noninteractive path is selected | existing `Test_Querier_SuppressCompletionNotification` and `Test_Querier_Query_DebugRedirectedOutputPrintsFinalAssistantAnswer` |
+| Width is narrow | Truncation and wrapping stay bounded | existing `UpdateMessageTerminalMetadata`/`glowRenderArgs`/`PrintToolActivity` tests; `TestListChats_NarrowWidthShowsCostAndPrompt` now drives width through `cq.dims` |
+| width-aware collaborator returns an error | Caller surfaces the error instead of malformed output | new `TestAttemptPrettyPrint_GlowFailureSurfacesError` and `TestPrintToolActivity_WriterErrorSurfaces` (utils) |
+
+### Commands and results
+
+Baseline (start of session, in-flight phase-3 work from the previous session):
+
+```bash
+cd /home/imago/Projects/public/clai && go build ./...
+```
+
+Failed: `internal/photo/funimation_0.go:25:5: undefined: fmt` (import
+removed while `fmt.Printf` remained), and `go vet ./...` additionally
+reported the `messagePickerRow` arity change and the removed `termWidth`
+field against tests. These were the known in-flight breakages.
+
+After the change:
+
+```bash
+go test ./... -race -cover -count=3 -timeout=30s
+```
+
+All packages ok, exit 0 (root package 54.9% coverage; internal/text 71.8%;
+internal/chat 70.7%; internal/utils 76.5%; internal/tools 82.3%;
+internal/photo 13.6%).
+
+```bash
+go run mvdan.cc/gofumpt@latest -w -l .
+go run honnef.co/go/tools/cmd/staticcheck@latest ./...
+go vet ./...
+go fix ./...
+go run github.com/mibk/dupl@latest -t 80 .
+```
+
+All clean; dupl reports only pre-existing clones, none in phase-3 files.
+
+## Review findings (review 1, 2026-08-07)
+
+**R1-03 — Major — resolved in implementation notes.** [x] The snapshot
+lifecycle is defined: `Querier`/`ChatHandler` own one snapshot per session
+resolved from the session writer's fd; standalone operations resolve one
+snapshot from the writer they use; listing/tool operations receive the
+session snapshot; phase 5 owns live refresh and inherits the
+preserve-last-valid-value rule from `dimensions.Viewer.Snapshot`.
+
+**R1-05 — Normal — resolved in implementation notes.** [x] The width-source
+inventory table lists every production width source and its replacement and
+names the intentionally excluded compatibility wrappers.
+
+Verified good: the phase preserves raw/structured safety and prohibits vendor
+changes, matching the existing streaming architecture.
+
+## Review findings (review 2, 2026-08-07)
+
+Cross-reference R2-02 (phase 1): the snapshot fd must equal the session writer fd. Today `table.TermWidth` queries stderr while clai writes to `querier.out`, so `clai 2>/dev/null` on a wide terminal renders at the 80-column fallback. Add the acceptance criterion "the dimensions snapshot is taken from the session output writer's fd".

--- a/worklogs/2026-08-07-terminal-dimensions/phase-4-viewport-reflow.md
+++ b/worklogs/2026-08-07-terminal-dimensions/phase-4-viewport-reflow.md
@@ -1,0 +1,228 @@
+# Phase 4 — Rolling viewport reflow
+
+**Status:** Done  
+[Back to README](./README.md)
+
+## Goal
+
+Make the rolling activity viewport rebuild its visible content when width or height changes.
+
+## Specification
+
+The viewport keeps an ordered list of logical blocks. Each block stores its kind (reasoning, assistant-text, tool-activity), the full sanitized content (uncolored), the tool-call metadata for tool headers, and the display policy (header color, role color, 2-space body indentation, tool-output-marker and `ERROR:` handling). The active reasoning/text blocks still coalesce streamed tokens into one open block; finished blocks keep their logical content until the retention policy evicts them. Colors and indentation are re-derived at rewrap time from the display policy; wrapped rows never carry the source of truth.
+
+Each block keeps at most a documented rune budget of content, and the viewport keeps at most a documented number of blocks, so memory stays bounded. The display policy "keep header and trailing rows, drop middle" is re-applied at each rewrap: the policy is width-stable even though the visible result changes with the current width. Height-grow reappearance is bounded by retention, not by the cap.
+
+`Resize(width, terminalHeight)` mutates state only: it stores the new dimensions, computes the effective height as min(configured cap, terminalHeight), re-wraps all retained blocks at the new width with terminal-cell-aware wrapping, re-trims to the effective height, invalidates the previous render bookkeeping (`drawnRows`, `lastRendered`), and marks the viewport dirty. It never writes to the writer, and it is a no-op when the supplied dimensions equal the current ones. `Render` emits the complete atomic frame when the viewport is dirty (move up `drawnRows`, clear down, full rewrite); the diff path is used only for normal appends. A partial frame writer error leaves the viewport dirty; the next `Render` retries the full frame. The constructor binds the initial effective height to min(configured cap, terminal height); `Resize` keeps the same bound on later dimension changes (R5-01).
+
+When the terminal height shrinks below the drawn window, rows scrolled off the top cannot be erased by ANSI escapes; the redraw clears from the current cursor down and rewrites the new effective window. The unerasable scrolled-off rows are a documented residual artifact, not a cursor-drift failure.
+
+`Resize` is invoked only from the serialized session loop, never from a signal callback, and adds no mutex; mutation and rendering stay on the loop.
+
+## Integration contract
+
+| Trigger | Collaborator | Observable result | Required side effect | Prohibited side effect |
+|---|---|---|---|---|
+| Width narrows | viewport blocks | Rows rewrap within new width | One coherent redraw on next render | No stale old-width rows |
+| Height shrinks | viewport history | Only effective-height rows remain | Old region is cleared | No cursor drift |
+| Height grows | retained blocks | More retained content can reappear | Rebuild from logical blocks | No loss of tool/reasoning content |
+| Same dimensions supplied | viewport | No state invalidation | No redraw | No output |
+| `Resize` called | retained logical blocks | New width and effective height applied, viewport dirty | Next `Render` emits the full frame | No write from `Resize` |
+
+## Acceptance criteria
+
+- Reasoning, assistant prose, and tool activity survive resize/reflow.
+- Effective height never exceeds terminal height or configured cap.
+- Render state is invalidated safely after dimension changes.
+- Final-answer pop and tool transitions remain correct after resize.
+- Tests cover narrow/wide, short/tall, unchanged, and post-render resize cases.
+- New viewport code has focused coverage for nil inputs, clamp paths, empty blocks, partial renders, writer failures, and redraw invalidation, without introducing artificial complexity for coverage numbers.
+- `Resize` never writes to the writer (verified with a failing writer).
+- `Resize` with unchanged dimensions leaves the viewport clean (no redraw).
+- Effective height equals min(configured cap, terminal height).
+- Retention bounds memory; height-grow reappearance is bounded by retention, not the cap.
+- Resize before the first append (lazy viewport creation) renders at the new dimensions.
+- Resize during the final-answer pop sequence keeps the pop correct.
+
+## Error coverage
+
+| Failure | Expected behavior | Test |
+|---|---|---|
+| Nil viewport/writer | Existing safe behavior is preserved | nil receiver/writer tests |
+| Width or height below one | Clamp to safe minimum | dimension clamp test |
+| Empty logical block | Render stable empty rows | empty block test |
+| Resize after partial render | Complete redraw replaces stale region | render transition test |
+| frame writer fails midway | Error and dirty-state behavior match the frame contract | partial-writer failure test |
+| Resize with equal dimensions | No dirty state, no redraw | unchanged-dimension test |
+| Resize before first append | First render uses new dimensions | lazy-creation test |
+| Two consecutive resizes | Last dimensions win; one dirty transition | double-resize test |
+| Resize while text block active | Coalescing continues at new width | active-block test |
+| Resize during final-answer pop | Pop sequence stays correct | pop-resize test |
+| Terminal shrinks below drawn window | Full clear and rewrite; scrolled-off rows are a documented artifact | shrink test |
+| Writer fails mid full frame | Viewport stays dirty; next `Render` retries the full frame | partial-writer failure test |
+
+## Implementation notes
+
+### Logical-block storage model (R2-01)
+
+`internal/utils/print.go` now stores logical blocks, not wrapped rows:
+`ActivityViewport` keeps an ordered `blocks []*activityBlock` history, two
+open-block pointers (`activeReasoning`, `activeText`), and a derived visible
+row cache (`rows []activityRow`) rebuilt from the blocks at each mutation.
+Each `activityBlock` stores its `kind` (reasoning, text, tool), the full
+sanitized content (the source of truth, uncolored), the tool-call metadata
+for tool headers, the tool body compaction budget, and its wrapped rows as a
+re-wrap cache. Colours and indentation are re-derived by `wrapBlock` at
+rewrap time from the display policy; wrapped rows never carry the source of
+truth.
+
+### Retention bounds
+
+- `maxActivityBlocks` (16) bounds the retained block count. `evict` drops
+  the oldest finished blocks once the history exceeds the budget; the open
+  coalescing blocks always survive because they still receive streamed
+  tokens.
+- `maxActivityBlockRunes` (64 KiB) bounds the sanitized content per block.
+  `boundContent` reduces over-budget content to its head and tail around a
+  `...[content truncated]...` marker, mirroring the display policy, so a
+  later rewrap still has the content the policy would show.
+
+### Rewrap algorithm
+
+`Resize(width, terminalHeight)` clamps width to at least 1, computes the
+new effective height as `min(configured cap, max(terminalHeight, 1))`, and
+returns without mutation when both equal the current values (no-op).
+Otherwise it stores the new dimensions, re-wraps every retained block with
+`wrapBlock` at the new width, rebuilds the visible cache with `rewrap`
+(trailing effective-height rows only), and sets `dirty`. It never writes to
+the writer.
+
+`wrapBlock` re-applies each block's display policy: the reasoning/text
+header row plus the 2-space-indented body wrapped by terminal cells
+(`terminalRows`), compacted by `compactActivityBlock` to the "keep header
+and trailing rows, drop middle" policy with the effective height as budget;
+the tool header plus the body compacted by `compactTerminalRows` with the
+stored tool body budget, marker and `ERROR:` colouring, and the trailing
+blank row. The policy is width-stable: the same policy runs at every width,
+even though the visible rows change because wrapping changes. A
+terminal-height grow brings retained content back into view, bounded by
+retention, not by the cap.
+
+### Frame contract (R1-04)
+
+`Render` emits one complete atomic frame when `dirty` (after `Resize` or a
+partial write): move up `drawnRows`, clear down with `\x1b[J`, rewrite the
+full window. The diff path is used only for normal streaming appends
+(unchanged rows are a no-op, pure appends print below, a changed tail
+clears from the first changed row down). Render bookkeeping (`drawnRows`,
+`lastRendered`, `dirty`) updates only after a successful write; a partial
+or failed write leaves the viewport dirty and the next `Render` retries the
+full frame. When the terminal height shrinks below the drawn window, the
+full clear starts from the current cursor down and the scrolled-off rows
+above the window top are a documented residual artifact, not a cursor-drift
+failure.
+
+`RemoveTextBlock` returns the number of rows the removed block occupied in
+the visible cache (`min(len(rows), len(activeText.rows))`, the active text
+block is always the cache tail) and rebuilds the cache without it.
+
+### Error-coverage mapping
+
+| Failure | Behavior | Test |
+|---|---|---|
+| Nil viewport/writer | All methods no-op safely | `nil viewport is safe` (print_test.go) |
+| Width or height below one | Clamp to 1 | `clamps width and height below one`, `effective height is the cap capped by terminal height` |
+| Empty logical block | Stable empty rows, no re-render | `empty text block renders stable empty rows` |
+| Resize after partial render | Full frame replaces the stale region | `width narrows rewraps retained blocks`, `two consecutive resizes converge on the last dimensions` |
+| Frame writer fails midway | Error; viewport stays dirty; next `Render` retries the full frame | `partial frame write leaves the viewport dirty and retries`, `write failure on the diff path marks the viewport dirty`, `short write without error leaves the viewport dirty` |
+| Resize with equal dimensions | No dirty state, no redraw | `unchanged dimensions leave the viewport clean` |
+| Resize before first append | First render uses the new dimensions | `resize before the first append renders at the new dimensions`, `resize with no content renders nothing and stays clean` |
+| Two consecutive resizes | Last dimensions win, one dirty transition | `two consecutive resizes converge on the last dimensions` |
+| Resize while text block active | Coalescing continues at the new width | `resize while a text block is active keeps coalescing` |
+| Resize during final-answer pop | Pop stays correct, reasoning survives | `resize during the final-answer pop keeps the pop correct` |
+| Terminal shrinks below drawn window | Full clear and rewrite; scrolled-off rows are a documented artifact | `terminal shrink below the drawn window clears and rewrites` |
+| Height grows | Retained content reappears, bounded by retention | `height grow brings retained content back into view` |
+| Retention over budget | Oldest finished blocks evicted; content bounded per block | `retention evicts the oldest finished blocks`, `retention bounds content per block` |
+| Resize never writes | No writer is involved; `Render` is the only writer | `resize never writes to the writer` |
+
+### Commands and results
+
+Baseline (start of session):
+
+```bash
+cd /home/imago/Projects/public/clai && go test ./internal/utils/ ./internal/text/ -count=1 -timeout=120s
+```
+
+Passed: exit 0. This confirmed the pre-change behaviour (phase-3 state).
+
+After the change:
+
+```bash
+go test ./... -race -cover -count=3 -timeout=30s
+```
+
+All packages ok, exit 0 (internal/utils 81.4% coverage, up from 76.5% at
+phase 3; the new viewport functions measure 100% for `NewActivityViewport`,
+`AppendReasoning`, `AppendText`, `AppendTool`, `FinishReasoning`,
+`FinishText`, `RemoveTextBlock`, `TextBlockActive`, `Content`, `Rows`,
+`Resize`, `DetachRenderedRegion`, `evict`, `rewrap`, `boundContent`, and
+`commonRowPrefix`).
+
+```bash
+go run mvdan.cc/gofumpt@latest -w -l .
+go run honnef.co/go/tools/cmd/staticcheck@latest ./...
+go vet ./...
+go fix ./...
+go run github.com/mibk/dupl@latest -t 80 .
+```
+
+All clean. The dupl check flagged the pre-existing `AppendReasoning` /
+`AppendText` clone, which phase 4 merged into the shared
+`appendCoalescing` helper; no phase-4 clone remains.
+
+## Review findings (review 2, 2026-08-07)
+
+**R2-01 — Major — resolved in spec (amendment, review 2).** [x] Specify the viewport's logical-block storage model. The Specification above now pins the storage, the retention bound, and the rewrap algorithm. Today `ActivityViewport` keeps only wrapped rows (`internal/utils/print.go` `rows []activityRow`, lines 358-361); finished blocks lose their logical content (`FinishReasoning`/`FinishText` reset the builders, print.go:414-430); oversized blocks drop their middle at append time (print.go:453-466, "keep header and trailing rows"); and tool output is compacted lossily at the append-time width (`compactTerminalRows`, print.go:663-676). The acceptance criterion "Reasoning, assistant prose, and tool activity survive resize/reflow" cannot be met by re-wrapping stored rows. Define the new storage (per-block type, full content, tool-call metadata, compaction policy), a bounded retention policy for content that overflowed the cap, the re-wrap algorithm `Resize` runs, and the methods that change (`Rows`, `Content`, `RemoveTextBlock`, `appendBlock`, `trim`, `Render`, `DetachRenderedRegion`). Concrete failure scenario: a 60-row reasoning block at width 120 is trimmed to 30 rows on append; `FinishReasoning` then discards the logical text; a resize to width 40 can only rewrap the 30 surviving wrapped rows and the dropped middle is unrecoverable.
+
+Verified good: phase 4 correctly requires terminal-cell-aware rewrapping, effective-height bounds (cap and terminal height), unchanged-dimension no-op behavior, and post-render resize coverage; the phase-5 dependency on this phase is sound.
+
+## Review findings (review 1, 2026-08-07)
+
+**R1-04 — Major — resolved in spec (amendment, review 2).** [x] Specify the frame/writer boundary for a complete
+redraw: define the operations for clearing the old region, positioning the
+cursor, writing rebuilt rows, and restoring the cursor. Also define whether a
+partial writer error leaves the viewport dirty and whether the next render
+retries the full frame. Without this, “atomic” can mean only that the caller
+holds a mutex while users still observe half a redraw or cursor drift. The
+Specification above now defines the dirty-state model, the full-frame clear
+sequence, and the retry-on-partial-write behavior.
+
+Verified good: logical blocks, terminal-cell wrapping, effective-height bounds,
+unchanged-dimension no-op behavior, and post-render resize coverage are the
+right invariants for this phase.
+
+## Review findings (review 5, 2026-08-07)
+
+Cross-reference R5-01 (phase 5): the acceptance criterion "Effective height
+never exceeds terminal height or configured cap" is unmet on the initial
+path. The constructor keeps the cap (D9: "The constructor keeps the cap;
+Resize takes raw terminal dimensions"), and `ensureActivityViewport` creates
+the viewport with the cap height and never consults `q.dims.Height` until a
+SIGWINCH arrives, so a terminal shorter than the cap renders a window taller
+than the screen for the whole query. The fix (binding the initial height to
+min(cap, terminal height) at creation, or amending the AC and colours.md to
+state the initial-cap exception) is tracked in phase 5 and resolved in
+worker session 7: `NewActivityViewport(width, cap, terminalHeight)` binds the
+initial effective height to min(cap, terminal height) and
+`ensureActivityViewport` passes `q.dims.Height`. No phase-4 test pins the
+cap-at-creation behavior: every viewport-height test calls `Resize`
+before asserting the effective height, so the fix is testable without
+breaking current assertions.
+
+Verified good in this phase: logical-block storage, per-block content bounds
+(`maxActivityBlockRunes` head/tail reduction), `maxActivityBlocks` eviction
+(open coalescing blocks always survive), `Resize` mutating state only with a
+no-op on equal dimensions, single-write atomic frames on the dirty path,
+the diff path for normal appends, partial/short-write dirty-retry, and the
+height-grow reappearance bounded by retention — all confirmed against the
+code and the tests in review 5.

--- a/worklogs/2026-08-07-terminal-dimensions/phase-5-sigwinch-integration.md
+++ b/worklogs/2026-08-07-terminal-dimensions/phase-5-sigwinch-integration.md
@@ -1,0 +1,259 @@
+# Phase 5 — SIGWINCH integration
+
+**Status:** Done  
+[Back to README](./README.md)
+
+## Goal
+
+Reflect tmux pane resizes in clai's interactive streaming output without concurrent terminal writes.
+
+## Specification
+
+Start one dimensions watcher only for terminal rolling-output sessions. Consume resize notifications in the serialized session loop alongside completion events. Refresh dimensions, resize the viewport, and redraw before subsequent output. Coalesce bursts. Never render in the signal callback. Stop the watcher on query completion, cancellation, error, or noninteractive mode.
+
+## Integration contract
+
+| Trigger | Collaborator | Observable result | Required side effect | Prohibited side effect |
+|---|---|---|---|---|
+| tmux pane resized | SIGWINCH/viewer | Next frame reflects new width/height | Fresh ioctl query and viewport redraw | No tmux command |
+| Resize during token handling | session loop | Resize is applied before next render | Writes remain serialized | No concurrent writer use |
+| Burst of resize signals | buffered watcher | Final/latest dimensions are used | Notifications coalesce | No unbounded queue |
+| Query ends/cancels | watcher | Resources stop cleanly | Signal registration removed | No post-query redraw |
+| Raw/structured/non-terminal mode | output mode | No interactive resize behavior | Watcher is not started | No ANSI viewport output |
+
+## Acceptance criteria
+
+- A simulated `SIGWINCH` changes rolling output dimensions during streaming.
+- No concurrent terminal writes occur under race testing.
+- Resize bursts are safe and converge on the latest dimensions.
+- Watcher cleanup is verified on success, error, and cancellation.
+- Final answer and tool transitions remain valid after a resize.
+- New watcher/session integration code has focused tests for startup rejection, refresh failure, termination paths, pending notifications, and writer errors.
+
+## Error coverage
+
+| Failure | Expected behavior | Test |
+|---|---|---|
+| Dimension refresh fails after signal | Preserve last valid snapshot and continue or report documented warning | refresh failure test |
+| Stream ends while resize pending | Finish once without late redraw | termination race test |
+| Context cancellation during watch | Stop watcher and query cleanly | cancellation integration test |
+| Output writer fails | Return render error without goroutine leak | writer failure test |
+| watcher startup is rejected | Session falls back or returns the documented error without starting partial cleanup | watcher-start failure test |
+| notification arrives after termination | No redraw or write occurs after teardown | late-notification test |
+
+## Implementation notes
+
+### Watcher gate and lifecycle (R2-03)
+
+One dimensions watcher runs only for terminal rolling-output sessions. It
+starts exactly when `usesActivityViewport()` holds —
+`RollingOutputEnabled && !rawDisplay && !debug && !structuredOutput`, where
+`rawDisplay` encodes the terminal check — and the session writer is an
+`*os.File`. `Querier.Query` starts it via `startResizeWatcher(ctx)` before the
+runner and `defer`s the viewer's `Stop`, so the watcher ends on success,
+error, and cancellation alike. Non-rolling terminal sessions, raw,
+structured, debug, and redirected output never start a watcher and keep
+phase 3's one-shot `q.dims` read (D8). The watcher binds to the session
+writer's fd — the file clai actually writes to — so the observed size always
+matches the output target (R2-02).
+
+The watcher's event channel is passed to the `sessionRunner` as
+`resizeEvents`; the runner consumes it in the serialized `executeModelStep`
+select alongside completion events. `signal.Notify(SIGWINCH)` ownership and
+the injectable signal source live in `pkg/dimensions` (D4); clai injects a
+channel into the runner in tests, so no unit test sends a process-global
+signal (R1-06). The viewer releases the registration on stop (verified in
+go_away_boilerplate viewer tests and in
+`Test_Querier_startResizeWatcher`).
+
+### Resize consumption and ordering (R1-03)
+
+When the select receives a fresh `dimensions.Dimensions` value,
+`applyResize` (1) stores it as the new session snapshot `q.dims`, (2) calls
+`ActivityViewport.Resize(width, height)`, which rewraps every retained
+logical block at the new width and marks the viewport dirty, and (3) calls
+`Render`, which emits the complete atomic frame (phase 4 contract). The
+snapshot used for the next frame is therefore the event's dimensions, and
+all subsequent renders — tokens, tools, the final-answer pop — use it. A
+failed re-query never delivers an event (the viewer keeps the last valid
+snapshot), so the session loop simply continues with the last applied
+`q.dims` and viewport state: preserve-last-valid-value, no warning needed.
+
+The viewer's `Events` channel has capacity one and coalesces bursts (D3); a
+burst of resizes converges on the latest dimensions because each delivered
+value is applied in order and `Resize` is a no-op for equal dimensions.
+When a token, completion, error, and resize are simultaneously ready, Go's
+select picks arbitrarily; every order converges because the resize redraw
+happens before the loop continues and the redraw replaces the stale region.
+When the stream ends while a resize is pending, the pending value is never
+applied: the query finishes once without a late redraw.
+
+### Resize before lazy viewport creation (R2-03)
+
+The three lazy viewport creation sites (reasoning event, tool activity,
+assistant-text finalization) are unified in `Querier.ensureActivityViewport`,
+which reads the current `q.dims` snapshot. Because `applyResize` stores the
+fresh snapshot before any later event can create the viewport, a resize that
+arrives before the first reasoning/tool event makes the first render use the
+new dimensions immediately. The constructor receives the session snapshot's
+height (`NewActivityViewport(width, cap, q.dims.Height)`), so the initial
+effective height is `min(cap, terminal height)` from the first frame; the
+first render never exceeds the terminal even without a resize (R5-01). Every
+later resize keeps the same bound.
+
+### Error-coverage mapping
+
+| Failure | Behavior | Test |
+|---|---|---|
+| Dimension refresh fails after signal | Viewer keeps last valid snapshot and delivers no event; the loop continues with the applied `q.dims` (viewer-side: `TestSnapshot_RefreshFailsAfterValid_KeepsLastValid` in go_away_boilerplate; loop-side: `Test_sessionRunner_Run_NoWatcherFallsBackToOneShotRead` and the unchanged-dims assertions) | refresh failure test |
+| Stream ends while resize pending | Query finishes once; no late redraw; output unchanged after teardown | `Test_sessionRunner_Run_StreamEndsWhileResizePendingNoLateRedraw` |
+| Context cancellation during watch | Loop returns promptly on `ctx.Done`; watcher stops via `Query`'s deferred stop | `Test_sessionRunner_Run_ContextCancellationStopsCleanly` |
+| Output writer fails during resize redraw | Render error propagates (`render activity viewport after resize`); run stops without goroutine leak | `Test_sessionRunner_Run_ResizeRenderWriterFailureReturnsError` |
+| Watcher startup is rejected | Nil event channel + no-op stop; session falls back to the one-shot read without partial cleanup | `Test_sessionRunner_Run_NoWatcherFallsBackToOneShotRead`, `Test_Querier_startResizeWatcher` (raw, structured, non-file) |
+| Notification arrives after termination | Never applied; no redraw or write after teardown | `Test_sessionRunner_Run_StreamEndsWhileResizePendingNoLateRedraw` |
+| Watcher channel closes mid-stream | Resize case nils out; stream finishes normally | `Test_sessionRunner_Run_ResizeChannelClosedMidStreamKeepsStreaming` |
+| Resize before first reasoning/tool event | First render uses the new dimensions (no old-width row) | `Test_sessionRunner_Run_ResizeBeforeViewportCreationUsesNewDimensions` |
+| Resize burst | Each redraw serialized; last event wins | `Test_sessionRunner_Run_ResizeBurstConvergesOnLatestDimensions` |
+| Resize during streaming | Rolling output rewraps at the new width; trailing tokens render at it | `Test_sessionRunner_Run_ResizeDuringStreamingRewrapsRollingOutput` |
+| Resize across a tool transition | Thinking/prose/tool order and final answer stay valid | `Test_sessionRunner_Run_ResizeKeepsToolTransitionAndFinalAnswerValid` |
+
+### Commands and results
+
+Baseline (start of session):
+
+```bash
+cd /home/imago/Projects/public/clai && go test ./internal/text/ ./internal/utils/ -count=1 -timeout=120s
+```
+
+Passed: exit 0 (phase-4 state).
+
+After the change:
+
+```bash
+go test ./... -race -cover -count=3 -timeout=30s
+```
+
+All packages ok, exit 0 (internal/text 72.3% coverage). The new
+`resize_runner_test.go` measures 100% for `applyResize`,
+`startResizeWatcher`, and `ensureActivityViewport`; the resize select case
+is exercised by every streaming resize test.
+
+```bash
+go run mvdan.cc/gofumpt@latest -w -l .
+go run honnef.co/go/tools/cmd/staticcheck@latest ./...
+go vet ./...
+go fix ./...
+go run github.com/mibk/dupl@latest -t 80 .
+```
+
+All clean; dupl reports only pre-existing clones outside phase-5 files.
+
+```bash
+cd /home/imago/Projects/public/go_away_boilerplate && go test ./pkg/dimensions/... -count=1 -timeout=60s
+```
+
+Passed: exit 0 (no library change in phase 5).
+
+### R5-01 fix — 2026-08-07 (worker session 7)
+
+```bash
+cd /home/imago/Projects/public/clai && go test ./... -count=1 -timeout=120s
+```
+
+All packages ok, exit 0. `NewActivityViewport` gained the terminal-height
+parameter (`NewActivityViewport(width, maxRows, terminalHeight)`, effective
+height `min(maxRows, max(terminalHeight, 1))` from the start) and
+`ensureActivityViewport` passes `q.dims.Height`, closing R5-01: the initial
+frame renders at `min(cap, terminal height)` even without a resize. New
+tests: `Test_sessionRunner_Run_InitialHeightBindsTerminalHeight` (session
+boundary) and `initial height binds the terminal height at creation`
+(viewport unit).
+
+```bash
+go run mvdan.cc/gofumpt@latest -w -l .
+go run honnef.co/go/tools/cmd/staticcheck@latest ./...
+go vet ./...
+go fix ./...
+go run github.com/mibk/dupl@latest -t 80 .
+```
+
+All clean.
+
+## Review findings (review 1, 2026-08-07)
+
+**R1-03 — Major — resolved in implementation notes.** [x] The snapshot used
+for the next frame is the delivered event's dimensions, stored as `q.dims`
+and applied to the viewport before the redraw; a failed refresh delivers no
+event, so the last valid snapshot survives. Ordering among simultaneously
+ready token/completion/error/resize cases converges because the resize
+redraw replaces the stale region before the loop continues, and a pending
+resize at stream end is never applied (no late redraw).
+
+**R1-06 — Normal — resolved in implementation notes.** [x] clai tests inject
+a channel into the runner and never send process-global signals; signal
+registration ownership and release stay in `pkg/dimensions` (D4) and are
+verified by the library's viewer tests plus `Test_Querier_startResizeWatcher`
+(cleanup on stop). Cleanup on success, error, and cancellation is verified by
+the runner termination tests.
+
+Verified good: rendering stays in the serialized loop, bursts coalesce, and
+raw, structured, redirected, and non-terminal output never start the
+watcher.
+
+## Review findings (review 2, 2026-08-07)
+
+**R2-03 — Normal — resolved in implementation notes.** [x] The watcher gate
+is `usesActivityViewport()` and the writer must be an `*os.File`; the
+watcher starts exactly then, and non-rolling terminal sessions keep the
+one-shot read. The three lazy creation sites are unified in
+`ensureActivityViewport`, which reads the current snapshot; a resize before
+the first reasoning/tool event is applied to `q.dims` first, so the first
+render uses the new dimensions immediately.
+
+Verified good: the resize case plugs into the single streaming entry point
+(`executeModelStep` select), and the cleanup-on-termination matrix
+(success, error, cancellation, late notification) is covered by tests.
+
+## Review findings (review 5, 2026-08-07)
+
+**R5-01 — Normal — resolved.** [x] The initial viewport height is the configured
+cap, never the terminal height, so the phase-4 acceptance criterion
+"Effective height never exceeds terminal height or configured cap" is unmet
+on the initial path until the first `Resize`. `ensureActivityViewport`
+(querier.go:252) creates `NewActivityViewport(q.dims.Width,
+RollingOutputWindowCellHeight())`; `q.dims.Height` (available since
+`NewQuerier`) is never consulted at creation, and no `Resize` runs until a
+SIGWINCH arrives. `colours.md` states unconditionally "The effective window
+height is min(window-cell-height, terminal height)", which is false before
+the first resize. Concrete failure scenario: a 24-row terminal with the
+default 30-row cap and no resize during the whole query. The first reasoning
+render emits 30 rows; rows 1-6 scroll off the top immediately, so the
+"∴ thinking" header is invisible; the first dirty redraw (for example the
+final-answer pop) emits `\x1b[30A\r\x1b[J`, which the terminal clamps to the
+top of the visible region and clears the entire screen instead of the
+window region. The phase-5 implementation notes document this as deliberate
+("The initial effective height stays the configured cap until the first
+resize, matching the phase-4 contract"), but the phase-4 AC and the
+architecture doc state the min() guarantee without an exception.
+
+The fix: `NewActivityViewport` now takes the raw terminal height as a third
+parameter and binds the effective height to `min(cap, max(terminalHeight, 1))`
+at creation; `ensureActivityViewport` passes `q.dims.Height`, so the initial
+height is `min(cap, terminal height)` and the first frame never exceeds the
+terminal. The phase-4 AC "Effective height never exceeds terminal height or
+configured cap" and the `colours.md` statement now hold from the first frame
+without amending either document. The concrete scenario now renders a
+24-row window: the "∴ thinking" header stays visible and the final-answer
+pop clears exactly the drawn window. Tests:
+`Test_sessionRunner_Run_InitialHeightBindsTerminalHeight` (session boundary,
+first render bounded without any resize) and `initial height binds the
+terminal height at creation` (viewport unit).
+
+Verified good in this phase: the watcher gate equals the viewport predicate
+(`usesActivityViewport() && *os.File`), the deferred `viewer.Stop` runs on
+success, error, and cancellation, the resize event is consumed only in the
+serialized `executeModelStep` select, a closed channel nils the case,
+`applyResize` stores the event as `q.dims` before any lazy viewport
+creation, a pending resize at stream end is never applied, and a resize
+redraw writer error propagates and stops the run. Every one of these holds
+on the failure and teardown branches I re-traced in review 5.

--- a/worklogs/2026-08-07-terminal-dimensions/phase-6-quality-gates.md
+++ b/worklogs/2026-08-07-terminal-dimensions/phase-6-quality-gates.md
@@ -1,0 +1,244 @@
+# Phase 6 — Quality gates
+
+**Status:** Done  
+[Back to README](./README.md)
+
+## Goal
+
+Prove the cross-repository dimensions change is complete, clean, and regression-free.
+
+## Specification
+
+Run the required quality commands in both repositories where applicable. Verify formatting, static analysis, vet, race tests, coverage, fix, duplication, and package tests. Search for stale terminal-width implementations and direct clai calls. Verify the released dependency version is used and no local `replace` remains. Update architecture documentation for streaming/rolling output and the shared package if required.
+
+## Integration contract
+
+| Trigger | Collaborator | Observable result | Required side effect | Prohibited side effect |
+|---|---|---|---|---|
+| Full clai test suite | shared dependency | All tests pass with race detector | Resize behavior is covered | No test skips or timeout changes |
+| Full boilerplate test suite | dimensions/table | All tests pass | Public API remains stable | No stale ioctl path |
+| Repository search | source tree | No duplicate production width system | Findings recorded | No hidden lookup remains |
+| Packaging check | Go modules | clai uses released dependency | Reproducible build | No local replace directive |
+
+## Acceptance criteria
+
+- Required project QA commands pass unedited.
+- Both repositories are formatted and statically clean.
+- Race tests cover watcher and rendering lifecycle.
+- Coverage is high and meaningful for the new dimensions package and clai integration, with error and cleanup paths represented; aggregate legacy coverage remains at least the project requirement. Review uncovered new behavior rather than optimizing an arbitrary percentage.
+- Duplication findings are reviewed and either fixed or documented.
+- Architecture/worklog documentation reflects the final design.
+- `SIGWINCH`, `TIOCGWINSZ`, `COLUMNS`, `table.TermWidth`, and truncation searches confirm the intended single-system state.
+
+## Error coverage
+
+| Failure | Expected behavior | Test/evidence |
+|---|---|---|
+| Formatter changes files | Diff is reviewed and tests rerun | format command output |
+| Staticcheck/vet finding | Finding fixed or justified | command output |
+| Race failure | Fix synchronization before completion | race command output |
+| Duplicate implementation found | Remove or document compatibility wrapper | repository search |
+| Local module replace remains | Remove before completion | `go.mod` inspection |
+| Meaningful new behavior lacks a test | Add a focused behavioral test or document why it is unreachable/mechanical | per-package coverage report and error-path review |
+
+## Implementation notes
+
+### Repository QA gates (R1-07)
+
+Both repositories were run with the mandated commands. clai has `make qa`;
+go_away_boilerplate has no Makefile, so its gates run individually.
+
+clai (`/home/imago/Projects/public/clai`):
+
+```bash
+make qa
+```
+
+exit 0. The target runs staticcheck, gofumpt, and go fix, then the race
+suite. The individual commands were also recorded (all exit 0):
+
+```bash
+go run mvdan.cc/gofumpt@latest -w -l .
+go run honnef.co/go/tools/cmd/staticcheck@latest ./...
+go vet ./...
+go fix ./...
+go test ./... -race -cover -count=3 -timeout=30s
+go run github.com/mibk/dupl@latest -t 80 .
+```
+
+`go test ./... -race -cover -count=3 -timeout=30s` passed unedited: all
+packages ok, exit 0. Coverage: internal/utils 81.3%, internal/text 72.3%,
+internal/chat 70.7%, internal/tools 82.3%, internal/tools/mcp 63.9%,
+internal/photo 13.6% (unchanged legacy low, already recorded in phase 3).
+The new `resize_runner_test.go` measures 100% for `applyResize`,
+`startResizeWatcher`, and `ensureActivityViewport`.
+
+go_away_boilerplate (`/home/imago/Projects/public/go_away_boilerplate`, no
+Makefile):
+
+```bash
+go run mvdan.cc/gofumpt@latest -w -l .
+go run honnef.co/go/tools/cmd/staticcheck@latest ./...
+go vet ./...
+go fix ./...
+go test ./... -race -cover -count=3 -timeout=30s
+go run github.com/mibk/dupl@latest -t 80 .
+```
+
+All exit 0. Coverage: pkg/dimensions 100.0%, pkg/table 96.6%, pkg/shutdown
+100.0%, pkg/num 100.0%, pkg/cmd 100.0%, pkg/testboil 86.2%, pkg/misc 92.3%.
+The dimensions package reaches the near-100% target with the meaningful
+error edges exercised (provider failure, zero size, fallback, signal bursts,
+cancellation, stop, writer errors, closed source).
+
+Cross-platform builds pass for darwin/amd64, linux/arm64, and
+windows/amd64 (`GOOS=... GOARCH=... go build ./...`), which verifies the
+`!unix` stub reader and no-op signal registration compile. `go mod verify`
+reports all modules verified. No test skips and no timeout/count changes
+were introduced: the changed test files and the new `resize_runner_test.go`
+and `dimensions_test.go` contain no `t.Skip` and the mandated test command
+ran unedited.
+
+### Repository searches (single-system state)
+
+| Search | clai | go_away_boilerplate |
+|---|---|---|
+| `table.TermWidth` | no production call (worklog and architecture text only) | compatibility wrapper only; delegates to `dimensions.DefaultReader(os.Stderr.Fd())` (D7) |
+| `TIOCGWINSZ`/`SYS_IOCTL`/`unsafe` | none in production code (test comments only) | only in `pkg/dimensions` (`ioctl_unix.go`, `ioctl_other.go` stub, `pty_linux_test.go`) |
+| `COLUMNS` | never consulted | no reference outside the worklog history |
+| `SIGWINCH` | only the viewer event consumed in the serialized session loop; no signal-callback write | registration only in `pkg/dimensions/sigwinch_unix.go` |
+| truncation helpers | only `*WithWidth` variants driven by a resolved snapshot | legacy querying variants kept as wrappers (D7) |
+| `termWidth` as a name | only explicit-width parameters (`UpdateMessageTerminalMetadata`, `PrintToolActivity`, `glowRenderArgs`) | n/a |
+
+`pkg/shutdown`'s `syscall` import handles SIGINT/SIGTERM and is unrelated
+and pre-existing. The only `replace` directive in clai's `go.mod` is the
+documented temporary boilerplate replace.
+
+### Packaging check and released dependency
+
+The module proxy and `go list -m -versions github.com/baalimago/go_away_boilerplate`
+agree: v1.33.8 is the newest released version and no released version
+contains `pkg/dimensions`. go_away_boilerplate origin/main is at 385532d
+(2026-07-23), before the dimensions work; the phase 1-2 changes exist only
+in the local working tree. clai therefore still carries the documented
+temporary replace, and the `go.mod` comment states the removal condition.
+
+**Release hand-off (required external action):** the maintainer must commit
+and tag the boilerplate changes (for example v1.34.0) and push the tag,
+then in clai run `go get github.com/baalimago/go_away_boilerplate@v1.34.0`,
+delete the replace block, and run `go mod tidy`. The `go.mod`/`go.sum`
+diff then proves the released version is used with no local replace. This
+step requires git write access and a module-proxy publish, which are
+outside this worklog's execution authority; D11 records the decision to
+keep the replace until then. `go.sum` still carries the v1.33.8 hashes
+(`go mod tidy` would drop them while the replace is in place); they are
+left as the record of the released baseline.
+
+### Documentation
+
+The architecture documents already reflect the final design and needed no
+further phase-6 update: colours.md describes the logical-block viewport,
+reflow, and resize behavior; query.md lists the resize case in the session
+loop; tools-command.md names `utils.SessionDimensions` and the explicit-width
+helper. `pkg/dimensions` carries a package comment stating the
+single-implementation contract.
+
+### Duplication review
+
+clai: 31 clone groups; go_away_boilerplate: 6 clone groups. Every clone is
+pre-existing test scaffolding or vendored-adjacent code. The only clones in
+worklog-modified files are fixture loops in `handler_list_chat_test.go` and
+mock-stream scaffolding in `querier_test.go`; the worklog diffs to those
+files are unrelated to the cloned regions. The one clone this work
+introduced (phase 4 `AppendReasoning`/`AppendText`) was already merged into
+the shared `appendCoalescing` helper.
+
+### Error-coverage mapping
+
+| Failure | Expected behavior | Evidence |
+|---|---|---|
+| Formatter changes files | Diff reviewed and tests rerun | gofumpt listed no files in either repository |
+| Staticcheck/vet finding | Fixed or justified | both repositories clean |
+| Race failure | Fixed before completion | race suite passes in both repositories |
+| Duplicate implementation found | Removed or documented compatibility wrapper | searches above; wrappers documented as D7 |
+| Local module replace remains | Removed before completion | release hand-off above; removal needs a maintainer tag+push (git write, out of scope) |
+| Meaningful new behavior lacks a test | Focused behavioral test or documented unreachable/mechanical | pkg/dimensions 100%, resize runner 100% for `applyResize`/`startResizeWatcher`/`ensureActivityViewport`; error paths mapped in phases 1-5 |
+
+## Review findings (review 1, 2026-08-07)
+
+**R1-07 — Normal — resolved in implementation notes.** [x] The exact
+commands are recorded for both repositories, including `make qa` in clai
+and the individual gofumpt, staticcheck, vet, race/coverage/count, `go fix`,
+and dupl runs in both. The released-module verification records v1.33.8 as
+the newest release (module proxy + `go list -m -versions`) and the
+`go.mod`/`go.sum` state; removing the temporary local `replace` requires a
+maintainer tag+push of the boilerplate changes, recorded as the release
+hand-off.
+
+Verified good: stale-symbol searches, race coverage, released-dependency
+verification, and architecture documentation are appropriate final checks.
+
+## Review findings (review 4, 2026-08-07)
+
+Holistic review of all six phases, executed per the runbook's final step.
+Re-ran every gate independently in both repositories: `make qa` in clai and
+the individual gofumpt, staticcheck, go vet, go fix,
+`go test ./... -race -cover -count=3 -timeout=30s`, and dupl runs in both,
+plus cross-platform builds (darwin/amd64, linux/arm64, windows/amd64) and
+`go mod verify`. All exit 0; coverage as recorded above. Verified the code
+rather than the notes: the dimensions Viewer lifecycle (D1-D6), the table
+wrapper (D7), `SessionDimensions` and both session snapshots (D8), the
+viewport storage/Resize/Render contract (D9), and the watcher gate and
+resize consumption (D10) all match their contracts on every traced branch
+(initial read failure, zero-size, signal bursts, closed source, stop after
+cancellation, writer failure, partial write retry, resize-before-viewport
+creation, resize-at-stream-end, tool transitions, final-answer pop after
+resize). No code defect was found.
+
+**R4-01 — Normal — open (maintainer-only).** [ ] Release the
+go_away_boilerplate changes (commit, tag for example v1.34.0, push), then
+in clai run `go get github.com/baalimago/go_away_boilerplate@v1.34.0`,
+delete the local `replace`, and run `go mod tidy`. The worklog cannot
+execute this: git writes and module-proxy publishes are outside its
+authority. Tracked as D11 and in the packaging check above; this is the
+single remaining item before the final clai change consumes a released
+module version.
+
+**R4-02 — Minor — non-reopening observation.** [ ] `dimensions.New`
+documents that ctx must not be nil but does not guard it; a nil ctx panics
+inside the watcher's first select. Every production and test caller passes a
+non-nil ctx, and a panic on documented precondition violation matches Go
+convention, so no guard or test is required.
+
+Verdict: ready, with the release hand-off as the only open item. The gates
+are green and the traced invariants hold; the release is a process step, not
+a code change.
+
+## Review findings (review 5, 2026-08-07)
+
+**R5-02 — Minor — non-reopening observation.** [ ] `make qa` is not
+deterministically reproducible: one of three full-suite runs in review 5
+failed on `Test_context` (internal/vendors/anthropic/claude_stream_test.go:267,
+untouched by this worklog) with `httptest.Server blocked in Close after 5
+seconds` and a 30-second test timeout. The identical mandated command
+`go test ./... -race -count=3 -timeout=30s` passed twice in full-suite runs
+and the anthropic package passed in isolation. The test's cleanup calls
+`testServer.Close()` before `close(testDone)`, so a slow context-cancel
+propagation leaves the handler blocked and `Close()` waits the full 5
+seconds — a pre-existing timing flake in vendored code, aggravated by load,
+not a defect of this worklog. Fixing it belongs to the vendored package
+(out of scope per the phase-3 "Do not change vendor code" rule).
+
+Verified good in review 5, re-run independently: `make qa`'s lint targets and
+all six mandated commands pass in both repositories (gofumpt, staticcheck,
+`go vet`, `go fix`, `go test ./... -race -cover -count=3 -timeout=30s` exit
+0, dupl); `go mod verify` passes; cross-platform builds pass for
+darwin/amd64, linux/arm64, and windows/amd64. Coverage matches the records:
+pkg/dimensions 100.0%, pkg/table 96.6%, internal/utils 81.3%, internal/text
+72.3%. Repository searches confirm the single-system state: no production
+`table.TermWidth` or terminal-querying truncation call remains in clai;
+`TIOCGWINSZ`/`COLUMNS`/`unsafe` exist only in pkg/dimensions; `SIGWINCH`
+registration exists only in pkg/dimensions/sigwinch_unix.go; the only
+`replace` is the documented temporary boilerplate replace with the
+release hand-off (R4-01/D11) still open and correctly recorded (origin/main
+at 385532d, go.sum carrying the v1.33.8 hashes).


### PR DESCRIPTION
I didn't like how I had to scroll up all the time. And also, 90% of the output while the agent is
working is kind of pointless, mostly curiosities.

So, two changes:
* There is now a rolling window, configured under `theme.json` -> `rollingOutput`
  *  With `rollingOutput.enabled=false` this can be disabled
* Updated look and feel while agentic work with new colours and fonts