### PR TITLE
feat: Allow toolcalls after stoploss (configurable)

### DIFF
--- a/architecture/config.md
+++ b/architecture/config.md
@@ -51,7 +51,7 @@ They contain settings that are broadly applicable to that “mode” (text vs im
 - system prompt
 - tool use selection defaults
 - tool-call budget (`max-tool-calls`; nil or 0 = unlimited)
-- token stoploss policy (`stoploss`: `max-tokens` + `max-tokens-handover-instructions`)
+- token stoploss policy (`stoploss`: `max-tokens` + `max-tokens-handover-instructions` + `max-tool-calls-after-handover`; absent or 0 = unlimited post-handover tools)
 - globbing selection (via `-g` flag which then modifies prompt building)
 
 The pre-query interactive token-count warning prompt is **sunset**: a legacy
@@ -77,7 +77,10 @@ remain, but are idempotent after the united migration.
 - optionally running a migration callback
 - **upgrading the file in place**: keys absent from the on-disk JSON are filled
   from the non-zero defaults (recursively into nested objects) and the file is
-  rewritten. Keys already present are never touched, even when their value is
+  rewritten. Fields tagged `migrate:"true"` are filled even when their default
+  is the zero value, so new feature knobs whose natural default is 0 (e.g.
+  `stoploss.max-tool-calls-after-handover`, 0 = unlimited) surface in upgraded
+  configs. Keys already present are never touched, even when their value is
   the zero value — the file is the user’s source of truth. When a
   pre-existing file is upgraded, clai announces the added fields, e.g.
   `added new field(s) to textConfig.json: stoploss`. This is what appends the
@@ -86,10 +89,14 @@ remain, but are idempotent after the united migration.
 
 `LoadConfigFromFileCollect` is the same loader without the stdout
 announcement: it returns the added field paths instead. `internal.Setup` uses
-it for the united migration and defers the announcement until after the
-interactive setup wizard exits — the wizard’s TUI erases pre-wizard stdout
-when it redraws (`go_away_boilerplate/pkg/table` `ClearTermTo`), so printing
-before it would lose the message. All other commands announce immediately.
+it for the united migration and prints the announcements just before the
+interactive setup wizard starts. The wizard's TUI redraws by clearing its own
+frame plus one line above the header (`go_away_boilerplate/pkg/table`
+`ClearTermTo` clears `upTo+1` lines), so the announcement block ends with a
+blank separator line that absorbs the overshoot; without it the first redraw
+would wipe the announcement. Deep multi-table navigation can still scroll it
+off (each `Run()` exit consumes one line). All other commands announce
+immediately.
 
 Raw (machine-readable) runs — `-r`/`-raw` — are read-only: `internal.Setup`
 sets `utils.ReadonlyConfig` before any load, and the loaders fill missing

--- a/architecture/query.md
+++ b/architecture/query.md
@@ -102,15 +102,20 @@ loop (`internal/text/session_runner.go`). Each model step:
    (`internal/text/tool_executor.go`). Refused calls never reach their
    implementation; their tool result carries the escalation text.
 4. **Stoploss check** (after the tool batch, so the chat order stays
-   `[assistant tool-call] [tool results] [handover user msg]`): the latest
-   request footprint (`prompt_tokens + completion_tokens`, else
-   `total_tokens`, else the model's `InputTokenCounter` estimate) is compared
-   to `stoploss.max-tokens`. On the first crossing clai appends the handover
-   user message (`stoploss.max-tokens-handover-instructions`, default
-   `DefaultHandoverInstructions`), prints a notice, and marks the session
-   handover-requested. Every later tool call runs the refusal ladder until
-   the run ends cleanly (`io.EOF`). A step that ends with a plain reply ends
-   the run without a handover — there is nothing to hand over.
+    `[assistant tool-call] [tool results] [handover user msg]`): the latest
+    request footprint (`prompt_tokens + completion_tokens`, else
+    `total_tokens`, else the model's `InputTokenCounter` estimate) is compared
+    to `stoploss.max-tokens`. On the first crossing clai appends the handover
+    user message (`stoploss.max-tokens-handover-instructions`, default
+    `DefaultHandoverInstructions`), prints a notice, and marks the session
+    handover-requested. The handover starts the wrap-up phase: post-handover
+    tool calls are counted against `stoploss.max-tool-calls-after-handover`
+    (absent or 0 = unlimited, the default) with a fresh counter, so the agent
+    can keep working — e.g. summarizing context into a file — until it
+    produces a plain reply. Only when a configured wrap-up allowance is
+    exhausted do later tool calls run the refusal ladder until the run ends
+    cleanly (`io.EOF`). A step that ends with a plain reply ends the run
+    without a handover — there is nothing to hand over.
 5. **Post-processing** (`postProcess()`):
    - Appends assistant message to chat
    - Saves conversation via `SaveAsPreviousQuery()` (unless in chat mode)
@@ -126,9 +131,10 @@ When a model step returns one or more `pub_models.Call` events, the
 `toolExecutor` (`internal/text/tool_executor.go`) processes them as one batch:
 
 1. Every call is preflighted against the stoploss controller before any tool
-   side effect runs. Within the `max-tool-calls` budget a call is allowed and
-   its result carries the remaining-count prefix; over budget (or after a
-   handover) the call is refused and never invoked.
+    side effect runs. Within the phase budget (`max-tool-calls` before a
+    handover, `stoploss.max-tool-calls-after-handover` after it) a call is
+    allowed and its result carries the remaining-count prefix; over budget the
+    call is refused and never invoked.
 2. The transcript keeps immediate assistant→tool pairing in the model's
    emission order. `load_skill` self-emits its assistant tool-call at
    execution time (the trust prompt and load errors precede the call echo, and
@@ -148,8 +154,10 @@ When a model step returns one or more `pub_models.Call` events, the
 Tool call limits (`max-tool-calls` in config) enforce a soft cap with
 escalating warnings. `max-tool-calls: 0` (or nil) means **unlimited** — no
 budget prefix, no warnings. After a stoploss handover the effective budget is
-0, so every tool call is refused by the same escalation ladder until the run
-ends cleanly.
+`stoploss.max-tool-calls-after-handover` with a fresh counter: absent or 0
+means unlimited post-handover tool calls (the default), and a positive value
+bounds the wrap-up phase, after which the same escalation ladder applies until
+the run ends cleanly.
 
 ## Directory Scope Binding
 

--- a/architecture/tooling.md
+++ b/architecture/tooling.md
@@ -127,8 +127,11 @@ preflights a complete model tool batch before any side effect runs.
 - `max-tool-calls` caps the number of tool calls per run with the escalating
   refusal ladder. `max-tool-calls: 0` (or nil) means **unlimited**.
 - `stoploss.max-tokens` is the token stoploss: after the crossing step's tool
-  batch, clai injects the handover user message; every subsequent tool call is
-  refused before its implementation runs.
+  batch, clai injects the handover user message. The handover starts a fresh
+  wrap-up phase: post-handover tool calls are counted against
+  `stoploss.max-tool-calls-after-handover` (absent or 0 = **unlimited**, the
+  default), never against the pre-handover `max-tool-calls` consumption. Once
+  the wrap-up allowance is exhausted, the refusal ladder applies.
 
 A refused call never reaches its executor: the tool result carries the refusal
 text instead of tool output.

--- a/internal/setup.go
+++ b/internal/setup.go
@@ -482,6 +482,7 @@ func printHelp(usage string, args []string) {
 		cfgDir,
 		cfgDir,
 		cfgDir,
+		cfgDir,
 		cacheDir,
 	)
 }
@@ -537,17 +538,18 @@ func Setup(ctx context.Context, usage string, allArgs []string) (models.Querier,
 	// United config migration: upgrade every mode config before any command
 	// runs, so each command sees the current schema (config migration
 	// design, Q5). Broken configs downgrade to warnings, same policy as
-	// LoadTheme above. The setup wizard's TUI erases pre-wizard stdout when
-	// it redraws (go_away_boilerplate/pkg/table ClearTermTo), so for SETUP
-	// the announcements are deferred until after the wizard exits.
-	var deferredUpgradeAnnouncements []string
+	// LoadTheme above. For SETUP the announcements are printed just before
+	// the wizard starts; the SETUP branch pads the block with a blank
+	// separator line that absorbs the wizard's one-line clear overshoot
+	// (table ClearTermTo clears upTo+1 lines).
+	var setupUpgradeAnnouncements []string
 	announceUpgrade := func(configFileName string, added []string) {
 		if len(added) == 0 {
 			return
 		}
 		msg := utils.ConfigUpgradeMessage(configFileName, added)
 		if mode == SETUP {
-			deferredUpgradeAnnouncements = append(deferredUpgradeAnnouncements, msg)
+			setupUpgradeAnnouncements = append(setupUpgradeAnnouncements, msg)
 			return
 		}
 		ancli.PrintOK(msg + "\n")
@@ -667,14 +669,21 @@ func Setup(ctx context.Context, usage string, allArgs []string) (models.Querier,
 	case VERSION:
 		return printVersion()
 	case SETUP:
-		err := setup.InitCmd()
-		// Announce upgrades after the wizard: its TUI erases pre-wizard
-		// stdout, so printing before it would lose the message (config
-		// migration design, Q5). Printed even on exit, which InitCmd reports
+		// Announce upgrades before the wizard starts, so the user sees what
+		// the united migration changed while the configs were upgraded. The
+		// wizard's TUI redraws by clearing its own frame plus one line above
+		// the header (table ClearTermTo clears upTo+1 lines), so the
+		// announcement block ends with a blank separator line that absorbs
+		// that overshoot; without it the first redraw would wipe the
+		// announcement. Printed even when InitCmd fails, which reports exit
 		// as table.ErrUserInitiatedExit.
-		for _, msg := range deferredUpgradeAnnouncements {
+		for _, msg := range setupUpgradeAnnouncements {
 			ancli.PrintOK(msg + "\n")
 		}
+		if len(setupUpgradeAnnouncements) > 0 {
+			fmt.Println()
+		}
+		err := setup.InitCmd()
 		if err != nil {
 			return nil, fmt.Errorf("failed to run setup: %w", err)
 		}

--- a/internal/setup_flags.go
+++ b/internal/setup_flags.go
@@ -59,9 +59,16 @@ type Configurations struct {
 	// MaxToolCallsSet is true when -mtc/-max-tool-calls was explicitly passed,
 	// so an explicit 0 can override a file-configured max-tool-calls.
 	MaxToolCallsSet bool
-	Glob            string
-	Profile         string
-	ProfilePath     string
+	// MaxToolCallsAfterHandover is the -max-tool-calls-after-handover value.
+	// Meaningful only when MaxToolCallsAfterHandoverSet is true.
+	MaxToolCallsAfterHandover int
+	// MaxToolCallsAfterHandoverSet is true when
+	// -max-tool-calls-after-handover was explicitly passed, so an explicit 0
+	// can override a file-configured stoploss.max-tool-calls-after-handover.
+	MaxToolCallsAfterHandoverSet bool
+	Glob                         string
+	Profile                      string
+	ProfilePath                  string
 	// ShellContext is the selected shell context name (ASC).
 	ShellContext string
 	// ResponseFormatPath is a path to a JSON file describing the OpenAI response_format.
@@ -146,6 +153,7 @@ func parseFlags(defaults Configurations, args []string) (Configurations, []strin
 	maxTokensLong := fs.Int("max-tokens", defaults.MaxTokens, "Set the max context tokens for this run. 0 = unlimited. Overrides stoploss.max-tokens in textConfig.json.")
 	maxToolCallsShort := fs.Int("mtc", defaults.MaxToolCalls, "Set the max tool calls for this run. 0 = unlimited. Overrides max-tool-calls in textConfig.json.")
 	maxToolCallsLong := fs.Int("max-tool-calls", defaults.MaxToolCalls, "Set the max tool calls for this run. 0 = unlimited. Overrides max-tool-calls in textConfig.json.")
+	maxToolCallsAfterHandover := fs.Int("max-tool-calls-after-handover", defaults.MaxToolCallsAfterHandover, "Set the max tool calls for the post-handover phase of this run. 0 = unlimited. Overrides stoploss.max-tool-calls-after-handover in textConfig.json.")
 
 	nonInteractiveShort := fs.Bool("n", defaults.NonInteractive, "Disable interactive stdin fallback after macro inputs; instead auto-exit with trailing quits.")
 	nonInteractiveLong := fs.Bool("non-interactive", defaults.NonInteractive, "Disable interactive stdin fallback after macro inputs; instead auto-exit with trailing quits.")
@@ -179,6 +187,7 @@ func parseFlags(defaults Configurations, args []string) (Configurations, []strin
 	maxTokensSet := false
 	mtcSet := false
 	maxToolCallsSet := false
+	maxToolCallsAfterHandoverSet := false
 	fs.Visit(func(f *flag.Flag) {
 		switch f.Name {
 		case "lb", "lookback":
@@ -191,6 +200,8 @@ func parseFlags(defaults Configurations, args []string) (Configurations, []strin
 			mtcSet = true
 		case "max-tool-calls":
 			maxToolCallsSet = true
+		case "max-tool-calls-after-handover":
+			maxToolCallsAfterHandoverSet = true
 		}
 	})
 	profile, err := utils.ReturnNonDefault(*pShort, *pLong, defaults.Profile)
@@ -226,33 +237,35 @@ func parseFlags(defaults Configurations, args []string) (Configurations, []strin
 	}
 
 	newConf := Configurations{
-		ChatModel:          chatModel,
-		PhotoModel:         photoModel,
-		PhotoDir:           pictureDir,
-		PhotoPrefix:        picturePrefix,
-		VideoModel:         videoModel,
-		VideoDir:           videoDir,
-		VideoPrefix:        videoPrefix,
-		StdinReplace:       stdinReplace,
-		PrintRaw:           printRaw,
-		ReplyMode:          replyMode,
-		DirReplyMode:       dirReplyMode,
-		UseTools:           useTools,
-		UseSkills:          useSkills,
-		CmdBan:             *cmdBan,
-		UseLookback:        useLookback,
-		UseLookbackSet:     useLookbackSet,
-		MaxTokens:          maxTokens,
-		MaxTokensSet:       maxTokensSet,
-		MaxToolCalls:       maxToolCalls,
-		MaxToolCallsSet:    maxToolCallsSet,
-		Glob:               glob,
-		ExpectReplace:      *expectReplace,
-		Profile:            profile,
-		ProfilePath:        profilePath,
-		ShellContext:       shellContext,
-		ResponseFormatPath: responseFormatPath,
-		NonInteractive:     *nonInteractiveShort || *nonInteractiveLong,
+		ChatModel:                    chatModel,
+		PhotoModel:                   photoModel,
+		PhotoDir:                     pictureDir,
+		PhotoPrefix:                  picturePrefix,
+		VideoModel:                   videoModel,
+		VideoDir:                     videoDir,
+		VideoPrefix:                  videoPrefix,
+		StdinReplace:                 stdinReplace,
+		PrintRaw:                     printRaw,
+		ReplyMode:                    replyMode,
+		DirReplyMode:                 dirReplyMode,
+		UseTools:                     useTools,
+		UseSkills:                    useSkills,
+		CmdBan:                       *cmdBan,
+		UseLookback:                  useLookback,
+		UseLookbackSet:               useLookbackSet,
+		MaxTokens:                    maxTokens,
+		MaxTokensSet:                 maxTokensSet,
+		MaxToolCalls:                 maxToolCalls,
+		MaxToolCallsSet:              maxToolCallsSet,
+		MaxToolCallsAfterHandover:    *maxToolCallsAfterHandover,
+		MaxToolCallsAfterHandoverSet: maxToolCallsAfterHandoverSet,
+		Glob:                         glob,
+		ExpectReplace:                *expectReplace,
+		Profile:                      profile,
+		ProfilePath:                  profilePath,
+		ShellContext:                 shellContext,
+		ResponseFormatPath:           responseFormatPath,
+		NonInteractive:               *nonInteractiveShort || *nonInteractiveLong,
 	}
 
 	return newConf, postParseArgs, nil
@@ -299,6 +312,12 @@ func applyFlagOverridesForText(tConf *text.Configurations, flagSet, defaultFlags
 	}
 	if flagSet.MaxToolCallsSet {
 		tConf.MaxToolCalls = &flagSet.MaxToolCalls
+	}
+	if flagSet.MaxToolCallsAfterHandoverSet {
+		if tConf.Stoploss == nil {
+			tConf.Stoploss = &text.Stoploss{}
+		}
+		tConf.Stoploss.MaxToolCallsAfterHandover = flagSet.MaxToolCallsAfterHandover
 	}
 }
 

--- a/internal/setup_flags_test.go
+++ b/internal/setup_flags_test.go
@@ -359,6 +359,30 @@ func TestSetupFlags(t *testing.T) {
 			wantErrContains: "mutually exclusive",
 		},
 		{
+			name:     "Max tool calls after handover flag",
+			args:     []string{"cmd", "-max-tool-calls-after-handover", "3"},
+			defaults: Configurations{},
+			want: Configurations{
+				MaxToolCallsAfterHandover:    3,
+				MaxToolCallsAfterHandoverSet: true,
+			},
+		},
+		{
+			name:     "Max tool calls after handover explicit zero is detected as set",
+			args:     []string{"cmd", "-max-tool-calls-after-handover=0"},
+			defaults: Configurations{},
+			want: Configurations{
+				MaxToolCallsAfterHandover:    0,
+				MaxToolCallsAfterHandoverSet: true,
+			},
+		},
+		{
+			name:            "Max tool calls after handover non-integer value rejected",
+			args:            []string{"cmd", "-max-tool-calls-after-handover=abc"},
+			defaults:        Configurations{},
+			wantErrContains: "invalid value",
+		},
+		{
 			name:     "No stoploss flags leaves both limits unset",
 			args:     []string{"cmd", "q", "hello"},
 			defaults: Configurations{},
@@ -722,6 +746,42 @@ func Test_applyFlagOverridesForText_Stoploss(t *testing.T) {
 			given:   text.Configurations{MaxToolCalls: intPtr(5)},
 			flagSet: Configurations{},
 			want:    text.Configurations{MaxToolCalls: intPtr(5)},
+		},
+		{
+			desc:    "max-tool-calls-after-handover flag creates the stoploss object",
+			given:   text.Configurations{},
+			flagSet: Configurations{MaxToolCallsAfterHandover: 3, MaxToolCallsAfterHandoverSet: true},
+			want:    text.Configurations{Stoploss: &text.Stoploss{MaxToolCallsAfterHandover: 3}},
+		},
+		{
+			desc: "max-tool-calls-after-handover flag overrides the file value and keeps the rest",
+			given: text.Configurations{
+				Stoploss: &text.Stoploss{MaxTokens: 100, MaxTokensHandoverMsg: "wrap up", MaxToolCallsAfterHandover: 5},
+			},
+			flagSet: Configurations{MaxToolCallsAfterHandover: 2, MaxToolCallsAfterHandoverSet: true},
+			want: text.Configurations{
+				Stoploss: &text.Stoploss{MaxTokens: 100, MaxTokensHandoverMsg: "wrap up", MaxToolCallsAfterHandover: 2},
+			},
+		},
+		{
+			desc: "explicit zero max-tool-calls-after-handover disables a file budget",
+			given: text.Configurations{
+				Stoploss: &text.Stoploss{MaxToolCallsAfterHandover: 5},
+			},
+			flagSet: Configurations{MaxToolCallsAfterHandover: 0, MaxToolCallsAfterHandoverSet: true},
+			want: text.Configurations{
+				Stoploss: &text.Stoploss{MaxToolCallsAfterHandover: 0},
+			},
+		},
+		{
+			desc: "omitted max-tool-calls-after-handover flag leaves the file value untouched",
+			given: text.Configurations{
+				Stoploss: &text.Stoploss{MaxTokens: 100, MaxToolCallsAfterHandover: 5},
+			},
+			flagSet: Configurations{},
+			want: text.Configurations{
+				Stoploss: &text.Stoploss{MaxTokens: 100, MaxToolCallsAfterHandover: 5},
+			},
 		},
 	}
 

--- a/internal/text/conf.go
+++ b/internal/text/conf.go
@@ -97,10 +97,15 @@ type Configurations struct {
 // Stoploss is the token stoploss policy. MaxTokens <= 0 disables the
 // stoploss. MaxTokensHandoverMsg is the user message injected into the chat
 // when the limit is crossed; empty means the default message
-// (DefaultHandoverInstructions).
+// (DefaultHandoverInstructions). MaxToolCallsAfterHandover is the wrap-up
+// tool-call budget for the post-handover phase: <= 0 (or absent) means
+// unlimited tool calls after the handover fires. It carries migrate:"true"
+// so the presence-based config migration surfaces it in upgraded files as an
+// explicit 0 (and never omitempty, or the rewrite would drop the zero).
 type Stoploss struct {
-	MaxTokens            int    `json:"max-tokens"`
-	MaxTokensHandoverMsg string `json:"max-tokens-handover-instructions"`
+	MaxTokens                 int    `json:"max-tokens"`
+	MaxTokensHandoverMsg      string `json:"max-tokens-handover-instructions"`
+	MaxToolCallsAfterHandover int    `json:"max-tool-calls-after-handover" migrate:"true"`
 }
 
 // DefaultHandoverInstructions is the user message injected into the chat when

--- a/internal/text/session.go
+++ b/internal/text/session.go
@@ -18,8 +18,15 @@ type QuerySession struct {
 	FinalUsage         *pub_models.Usage
 	CompletedCalls     []CompletedModelCall
 	ToolCallsUsed      int
+	// PostHandoverToolCallsUsed counts tool calls made after the token
+	// stoploss handover fired. It is the phase counter for the
+	// max-tool-calls-after-handover wrap-up budget: the handover starts a
+	// fresh allowance that pre-handover consumption never eats into.
+	PostHandoverToolCallsUsed int
 	// HandoverRequested is set once the token stoploss has injected the
-	// handover user message. It forces the tool-call refusal ladder.
+	// handover user message. It switches the tool-budget phase: the
+	// wrap-up allowance (max-tool-calls-after-handover) replaces the
+	// pre-handover max-tool-calls budget.
 	HandoverRequested   bool
 	ShouldSaveReply     bool
 	Raw                 bool

--- a/internal/text/stoploss.go
+++ b/internal/text/stoploss.go
@@ -11,13 +11,16 @@ import (
 )
 
 // stoploss owns both run budgets: the token stoploss (max-tokens + handover
-// injection) and the tool-call budget (max-tool-calls). It composes them so
-// that once a handover has been requested, further tool calls are treated as
-// over-budget and run the existing refusal ladder.
+// injection) and the tool-call budgets. It composes them so that the handover
+// starts a fresh wrap-up phase: post-handover tool calls are counted against
+// maxToolCallsAfterHandover (nil or <= 0 means unlimited), never against the
+// pre-handover maxToolCalls consumption. Once the wrap-up allowance is
+// exhausted, further tool calls run the existing refusal ladder.
 type stoploss struct {
-	maxTokens            int    // <= 0 disables the token stoploss
-	maxToolCalls         *int   // nil or <= 0 means no tool-call limit
-	maxTokensHandoverMsg string // effective handover message, resolved once at construction
+	maxTokens                 int    // <= 0 disables the token stoploss
+	maxToolCalls              *int   // pre-handover tool-call budget; nil or <= 0 means no limit
+	maxToolCallsAfterHandover int    // post-handover wrap-up budget; <= 0 means unlimited
+	maxTokensHandoverMsg      string // effective handover message, resolved once at construction
 }
 
 // newStoploss builds the controller from the querier's configured policies.
@@ -29,21 +32,44 @@ func (q *Querier[C]) newStoploss() *stoploss {
 	if q.stoploss != nil {
 		ctrl.maxTokens = q.stoploss.MaxTokens
 		ctrl.maxTokensHandoverMsg = q.stoploss.HandoverInstructions()
+		ctrl.maxToolCallsAfterHandover = q.stoploss.MaxToolCallsAfterHandover
 	}
 	return ctrl
 }
 
-// effectiveBudget returns the tool-call budget in effect for the session: 0
-// after a handover (every tool call is over budget), the configured positive
-// limit, or -1 when unlimited.
+// effectiveBudget returns the tool-call budget in effect for the session
+// phase: the wrap-up allowance (max-tool-calls-after-handover) after a
+// handover, the configured positive max-tool-calls limit before it, or -1
+// when unlimited.
 func (s *stoploss) effectiveBudget(session *QuerySession) int {
 	if session.HandoverRequested {
-		return 0
+		if s.maxToolCallsAfterHandover > 0 {
+			return s.maxToolCallsAfterHandover
+		}
+		return -1
 	}
 	if s.maxToolCalls != nil && *s.maxToolCalls > 0 {
 		return *s.maxToolCalls
 	}
 	return -1
+}
+
+// effectiveUsed returns the tool-call counter of the session phase: the
+// post-handover counter after a handover, the pre-handover counter before it.
+func (s *stoploss) effectiveUsed(session *QuerySession) int {
+	if session.HandoverRequested {
+		return session.PostHandoverToolCallsUsed
+	}
+	return session.ToolCallsUsed
+}
+
+// incUsed reserves one budget slot on the phase-appropriate counter.
+func (s *stoploss) incUsed(session *QuerySession) {
+	if session.HandoverRequested {
+		session.PostHandoverToolCallsUsed++
+		return
+	}
+	session.ToolCallsUsed++
 }
 
 // ladderText builds the escalating refusal for an over-budget tool call at the
@@ -83,9 +109,9 @@ func (s *stoploss) PreflightToolCallBudget(session *QuerySession, calls []pub_mo
 }
 
 func (s *stoploss) preflightToolCall(session *QuerySession, call pub_models.Call) toolCallBudgetPlan {
-	// load_skill is exempt from the positive max-tool-calls budget, but never
-	// from the post-handover refusal: no tool, including load_skill, executes
-	// after handover.
+	// load_skill is exempt from the positive pre-handover budget, but never
+	// from an exhausted-budget refusal in either phase: no tool, including
+	// load_skill, executes once the phase budget is exhausted.
 	if call.Name == string(pub_models.LoadSkillTool) && !session.HandoverRequested {
 		return toolCallBudgetPlan{call: call, allowed: true}
 	}
@@ -93,18 +119,23 @@ func (s *stoploss) preflightToolCall(session *QuerySession, call pub_models.Call
 	if budget < 0 {
 		return toolCallBudgetPlan{call: call, allowed: true}
 	}
-	used := session.ToolCallsUsed
+	used := s.effectiveUsed(session)
 	debugStoplossf("tool call %q: budget=%d used=%d", call.Name, budget, used)
 	if used >= budget {
 		refusal, hardStop := ladderText(used - budget)
 		plan := toolCallBudgetPlan{call: call, out: refusal, hardStop: hardStop}
 		debugStoplossf("tool call %q refused (persistence %d, hardStop %v)", call.Name, used-budget, hardStop)
 		if !hardStop {
-			session.ToolCallsUsed = used + 1
+			s.incUsed(session)
 		}
 		return plan
 	}
-	session.ToolCallsUsed = used + 1
+	if call.Name == string(pub_models.LoadSkillTool) {
+		// Post-handover load_skill rides free of the wrap-up allowance while
+		// it has room: allowed, no slot reserved.
+		return toolCallBudgetPlan{call: call, allowed: true}
+	}
+	s.incUsed(session)
 	debugStoplossf("tool call %q allowed, %d remaining", call.Name, budget-used-1)
 	return toolCallBudgetPlan{
 		call:    call,

--- a/internal/text/stoploss_controller_test.go
+++ b/internal/text/stoploss_controller_test.go
@@ -272,7 +272,7 @@ func Test_stoploss_PreflightToolCallBudget(t *testing.T) {
 		}
 	})
 
-	t.Run("handover forces refusal for every call", func(t *testing.T) {
+	t.Run("default (no post-handover budget) allows every call", func(t *testing.T) {
 		ctrl := &stoploss{}
 		session := &QuerySession{HandoverRequested: true}
 
@@ -280,14 +280,97 @@ func Test_stoploss_PreflightToolCallBudget(t *testing.T) {
 			{ID: "a", Name: "cmd"},
 			{ID: "b", Name: string(pub_models.LoadSkillTool)},
 		})
-		if plans[0].allowed || plans[1].allowed {
-			t.Fatalf("expected both calls refused after handover, got %+v / %+v", plans[0], plans[1])
+		for _, p := range plans {
+			if !p.allowed || p.prefix != "" || p.hardStop || p.out != "" {
+				t.Fatalf("expected unlimited post-handover call allowed, got %+v", p)
+			}
 		}
-		if !strings.Contains(plans[0].out, "No more tool calls allowed") {
-			t.Fatalf("expected plain refusal first, got %q", plans[0].out)
+		if session.PostHandoverToolCallsUsed != 0 {
+			t.Fatalf("expected no slots reserved post-handover, got %d", session.PostHandoverToolCallsUsed)
 		}
-		if !strings.Contains(plans[1].out, "HARD SHUT DOWN") {
-			t.Fatalf("expected escalated refusal second, got %q", plans[1].out)
+	})
+
+	t.Run("post-handover budget is a fresh allowance", func(t *testing.T) {
+		maxCalls := 1
+		ctrl := &stoploss{maxToolCalls: &maxCalls, maxToolCallsAfterHandover: 2}
+		// The pre-handover budget is exhausted; the wrap-up allowance must not
+		// be eaten by pre-handover consumption.
+		session := &QuerySession{ToolCallsUsed: 1, HandoverRequested: true}
+
+		plans := ctrl.PreflightToolCallBudget(session, []pub_models.Call{{ID: "a"}, {ID: "b"}})
+		if !plans[0].allowed || plans[0].prefix != "[ Tool calls remaining: 2 ] " {
+			t.Fatalf("expected first post-handover call allowed with a fresh budget, got %+v", plans[0])
+		}
+		if !plans[1].allowed || plans[1].prefix != "[ Tool calls remaining: 1 ] " {
+			t.Fatalf("expected second post-handover call allowed, got %+v", plans[1])
+		}
+		if session.PostHandoverToolCallsUsed != 2 {
+			t.Fatalf("expected post-handover slots on the fresh counter, got %d", session.PostHandoverToolCallsUsed)
+		}
+		if session.ToolCallsUsed != 1 {
+			t.Fatalf("expected the pre-handover counter untouched, got %d", session.ToolCallsUsed)
+		}
+	})
+
+	t.Run("post-handover budget escalates the ladder when exhausted", func(t *testing.T) {
+		ctrl := &stoploss{maxToolCallsAfterHandover: 1}
+		session := &QuerySession{HandoverRequested: true}
+
+		plans := ctrl.PreflightToolCallBudget(session, []pub_models.Call{{ID: "a"}, {ID: "b"}, {ID: "c"}, {ID: "d"}, {ID: "e"}})
+		if !plans[0].allowed {
+			t.Fatalf("expected the first post-handover call within budget, got %+v", plans[0])
+		}
+		if plans[1].allowed || plans[1].out != "ERROR: No more tool calls allowed. " {
+			t.Fatalf("expected plain refusal for the first over-budget call, got %+v", plans[1])
+		}
+		if plans[2].allowed || !strings.Contains(plans[2].out, "HARD SHUT DOWN") {
+			t.Fatalf("expected hard-shutdown warning, got %+v", plans[2])
+		}
+		if plans[3].allowed || !strings.Contains(plans[3].out, "LAST WARNING") || plans[3].hardStop {
+			t.Fatalf("expected last warning without hard stop, got %+v", plans[3])
+		}
+		if plans[4].allowed || !strings.Contains(plans[4].out, "LAST WARNING") || !plans[4].hardStop {
+			t.Fatalf("expected last-warning hard stop, got %+v", plans[4])
+		}
+		if session.PostHandoverToolCallsUsed != 4 {
+			t.Fatalf("expected no slot reserved for the io.EOF refusal, got %d", session.PostHandoverToolCallsUsed)
+		}
+	})
+
+	t.Run("zero post-handover budget means unlimited", func(t *testing.T) {
+		ctrl := &stoploss{maxToolCallsAfterHandover: 0}
+		session := &QuerySession{HandoverRequested: true}
+
+		plans := ctrl.PreflightToolCallBudget(session, []pub_models.Call{{ID: "a"}})
+		if !plans[0].allowed || plans[0].prefix != "" {
+			t.Fatalf("expected 0 post-handover limit to behave as unlimited, got %+v", plans[0])
+		}
+	})
+
+	t.Run("load_skill allowed post-handover while budget has room, refused when exhausted", func(t *testing.T) {
+		ctrl := &stoploss{maxToolCallsAfterHandover: 1}
+		session := &QuerySession{HandoverRequested: true}
+
+		skill := pub_models.Call{ID: "s", Name: string(pub_models.LoadSkillTool)}
+		cmd := pub_models.Call{ID: "c", Name: "cmd"}
+
+		first := ctrl.PreflightToolCallBudget(session, []pub_models.Call{skill})[0]
+		if !first.allowed || first.prefix != "" {
+			t.Fatalf("expected post-handover load_skill allowed without a prefix, got %+v", first)
+		}
+		cmdPlan := ctrl.PreflightToolCallBudget(session, []pub_models.Call{cmd})[0]
+		if !cmdPlan.allowed {
+			t.Fatalf("expected the cmd call to consume the budget, got %+v", cmdPlan)
+		}
+		refused := ctrl.PreflightToolCallBudget(session, []pub_models.Call{skill})[0]
+		if refused.allowed || !strings.Contains(refused.out, "No more tool calls allowed") {
+			t.Fatalf("expected load_skill refused once the post-handover budget is exhausted, got %+v", refused)
+		}
+		// The plain refusal (persistence 0) still reserves a ladder slot, so
+		// the counter moves past the exhausted budget; load_skill itself never
+		// reserves a slot.
+		if session.PostHandoverToolCallsUsed != 2 {
+			t.Fatalf("expected the refusal slot on the post-handover counter, got %d", session.PostHandoverToolCallsUsed)
 		}
 	})
 
@@ -302,6 +385,17 @@ func Test_stoploss_PreflightToolCallBudget(t *testing.T) {
 		}
 		if session.ToolCallsUsed != 0 {
 			t.Fatalf("expected load_skill to reserve no slot, got %d", session.ToolCallsUsed)
+		}
+	})
+
+	t.Run("pre-handover load_skill exemption survives budget exhaustion", func(t *testing.T) {
+		maxCalls := 1
+		ctrl := &stoploss{maxToolCalls: &maxCalls}
+		session := &QuerySession{ToolCallsUsed: 1} // budget exhausted pre-handover
+
+		plan := ctrl.PreflightToolCallBudget(session, []pub_models.Call{{ID: "s", Name: string(pub_models.LoadSkillTool)}})[0]
+		if !plan.allowed {
+			t.Fatalf("expected pre-handover load_skill exempt even when the budget is exhausted, got %+v", plan)
 		}
 	})
 }

--- a/internal/text/stoploss_runner_test.go
+++ b/internal/text/stoploss_runner_test.go
@@ -127,12 +127,12 @@ func Test_sessionRunner_Run_StoplossCrossingInjectsHandoverAfterToolResults(t *t
 	}
 }
 
-// Test_sessionRunner_Run_PostHandoverToolRefusedBeforeInvocation pins
-// acceptance criterion 4 and R2-01 (ordinary tools): after handover a tool
-// call is refused before its side effect runs, the tool result carries the
-// ladder warning, the agent then produces the summary, and the run ends
-// cleanly.
-func Test_sessionRunner_Run_PostHandoverToolRefusedBeforeInvocation(t *testing.T) {
+// Test_sessionRunner_Run_PostHandoverToolExecutesByDefault pins the
+// post-handover tool budget contract: with no max-tool-calls-after-handover
+// configured (the default), a tool call after the handover fires EXECUTES —
+// the agent can summarize context into a file — and the run ends with the
+// summary.
+func Test_sessionRunner_Run_PostHandoverToolExecutesByDefault(t *testing.T) {
 	inttools.WithTestRegistry(t, func() {
 		invocations := 0
 		inttools.Registry.Set("stoploss_probe", countingStubTool{name: "stoploss_probe", calls: &invocations, output: "probe side effect"})
@@ -164,29 +164,30 @@ func Test_sessionRunner_Run_PostHandoverToolRefusedBeforeInvocation(t *testing.T
 		if err := runner.Run(context.Background(), session); err != nil {
 			t.Fatalf("Run: %v", err)
 		}
-		if invocations != 1 {
-			t.Fatalf("expected only the pre-handover crossing tool to run, got %d invocations", invocations)
+		if invocations != 2 {
+			t.Fatalf("expected both the crossing and the post-handover tool to run, got %d invocations", invocations)
 		}
 		if session.FinalAssistantText != "done" {
 			t.Fatalf("expected summary as final assistant text, got %q", session.FinalAssistantText)
 		}
-		// user, crossing pair, handover, refusal pair
+		// user, crossing pair, handover, post-handover pair
 		if len(session.Chat.Messages) != 6 {
-			t.Fatalf("expected user + crossing pair + handover + refusal pair, got %d messages", len(session.Chat.Messages))
+			t.Fatalf("expected user + crossing pair + handover + post-handover pair, got %d messages", len(session.Chat.Messages))
 		}
-		refusal := session.Chat.Messages[5]
-		if refusal.Role != "tool" || !strings.Contains(refusal.Content, "No more tool calls allowed") {
-			t.Fatalf("expected refusal ladder text in the post-handover tool result, got %+v", refusal)
+		last := session.Chat.Messages[5]
+		if last.Role != "tool" || !strings.Contains(last.Content, "probe side effect") {
+			t.Fatalf("expected the post-handover tool result to carry real output, got %+v", last)
 		}
 		assertValidToolExchanges(t, session.Chat.Messages)
 	})
 }
 
-// Test_sessionRunner_Run_PostHandoverPersistenceEndsCleanly pins acceptance
-// criterion 5 and R2-02: persisting past the final warning returns io.EOF,
-// Run returns nil, and the transcript still contains a valid assistant/tool
-// exchange for every refused call.
-func Test_sessionRunner_Run_PostHandoverPersistenceEndsCleanly(t *testing.T) {
+// Test_sessionRunner_Run_PostHandoverBudgetExhaustionEndsCleanly pins the
+// bounded wrap-up contract: with max-tool-calls-after-handover 1 the agent
+// gets exactly one post-handover execution, persisting past the final warning
+// returns io.EOF, Run returns nil, and the transcript still contains a valid
+// assistant/tool exchange for every call.
+func Test_sessionRunner_Run_PostHandoverBudgetExhaustionEndsCleanly(t *testing.T) {
 	inttools.WithTestRegistry(t, func() {
 		invocations := 0
 		inttools.Registry.Set("stoploss_probe", countingStubTool{name: "stoploss_probe", calls: &invocations, output: "probe side effect"})
@@ -205,7 +206,7 @@ func Test_sessionRunner_Run_PostHandoverPersistenceEndsCleanly(t *testing.T) {
 		q := &Querier[*MockQuerier]{
 			out:      &strings.Builder{},
 			Model:    model,
-			stoploss: &Stoploss{MaxTokens: 100, MaxTokensHandoverMsg: "wrap up"},
+			stoploss: &Stoploss{MaxTokens: 100, MaxTokensHandoverMsg: "wrap up", MaxToolCallsAfterHandover: 1},
 		}
 		session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
 		runner := newStoplossRunner(q)
@@ -213,32 +214,32 @@ func Test_sessionRunner_Run_PostHandoverPersistenceEndsCleanly(t *testing.T) {
 		if err := runner.Run(context.Background(), session); err != nil {
 			t.Fatalf("expected clean end past the final warning, got %v", err)
 		}
-		if invocations != 1 {
-			t.Fatalf("expected only the crossing tool to run, got %d invocations", invocations)
+		// crossing (1) + post-handover allowed (1) + plain refusal + HARD SHUT
+		// DOWN + LAST WARNING + io.EOF = 6 model steps.
+		if callCount != 6 {
+			t.Fatalf("expected 6 model steps, got %d", callCount)
+		}
+		if invocations != 2 {
+			t.Fatalf("expected the crossing and the first post-handover call to run, got %d invocations", invocations)
 		}
 		if !session.HandoverRequested {
 			t.Fatal("expected handover requested")
 		}
-		// 1 crossing step + 4 refused post-handover steps (warn, HARD SHUT
-		// DOWN, LAST WARNING, io.EOF).
-		if callCount != 5 {
-			t.Fatalf("expected 5 model steps, got %d", callCount)
-		}
-		// user + crossing pair + handover + 4 refusal pairs
-		if len(session.Chat.Messages) != 12 {
-			t.Fatalf("expected 12 messages, got %d", len(session.Chat.Messages))
+		// user + crossing pair + handover + 5 post-handover pairs
+		if len(session.Chat.Messages) != 14 {
+			t.Fatalf("expected 14 messages, got %d", len(session.Chat.Messages))
 		}
 		assertValidToolExchanges(t, session.Chat.Messages)
-		if last := session.Chat.Messages[11]; last.Role != "tool" || !strings.Contains(last.Content, "LAST WARNING") {
+		if last := session.Chat.Messages[13]; last.Role != "tool" || !strings.Contains(last.Content, "LAST WARNING") {
 			t.Fatalf("expected the final refusal to carry the last-warning text, got %+v", last)
 		}
 	})
 }
 
-// Test_sessionRunner_Run_PostHandoverLoadSkillRefusedBeforeLoading pins R2-01
-// (load_skill): a post-handover load_skill call is refused before the skill
-// loader runs.
-func Test_sessionRunner_Run_PostHandoverLoadSkillRefusedBeforeLoading(t *testing.T) {
+// Test_sessionRunner_Run_PostHandoverLoadSkillLoadsByDefault pins R2-01
+// (load_skill) under the new default: without a post-handover budget a
+// post-handover load_skill call loads normally.
+func Test_sessionRunner_Run_PostHandoverLoadSkillLoadsByDefault(t *testing.T) {
 	loads := 0
 	model := &MockQuerier{}
 	callCount := 0
@@ -271,13 +272,68 @@ func Test_sessionRunner_Run_PostHandoverLoadSkillRefusedBeforeLoading(t *testing
 	if err := runner.Run(context.Background(), session); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if loads != 0 {
-		t.Fatalf("load_skill must not load after handover, got %d loads", loads)
+	if loads != 1 {
+		t.Fatalf("expected load_skill to load after handover by default, got %d loads", loads)
 	}
-	refusal := session.Chat.Messages[5]
-	if refusal.Role != "tool" || !strings.Contains(refusal.Content, "No more tool calls allowed") {
-		t.Fatalf("expected refusal ladder text for load_skill, got %+v", refusal)
+	last := session.Chat.Messages[len(session.Chat.Messages)-1]
+	if last.Role != "tool" || !strings.Contains(last.Content, "loaded skill body") {
+		t.Fatalf("expected the skill body as the post-handover tool result, got %+v", last)
 	}
+}
+
+// Test_sessionRunner_Run_PostHandoverLoadSkillRefusedWhenBudgetExhausted pins
+// that once the post-handover budget is exhausted, load_skill is refused
+// before the skill loader runs.
+func Test_sessionRunner_Run_PostHandoverLoadSkillRefusedWhenBudgetExhausted(t *testing.T) {
+	loads := 0
+	model := &MockQuerier{}
+	callCount := 0
+	model.streamFn = func(_ context.Context, _ pub_models.Chat) (chan models.CompletionEvent, error) {
+		callCount++
+		out := make(chan models.CompletionEvent, 2)
+		model.usage = &pub_models.Usage{PromptTokens: 60, CompletionTokens: 60}
+		switch callCount {
+		case 1, 2:
+			out <- pub_models.Call{ID: fmt.Sprintf("call-%d", callCount), Name: "stoploss_probe", Inputs: &pub_models.Input{}}
+		case 3:
+			inputs := pub_models.Input{"skill": "test"}
+			out <- pub_models.Call{ID: "call-3", Name: string(pub_models.LoadSkillTool), Inputs: &inputs}
+		default:
+			out <- "done"
+		}
+		close(out)
+		return out, nil
+	}
+
+	inttools.WithTestRegistry(t, func() {
+		invocations := 0
+		inttools.Registry.Set("stoploss_probe", countingStubTool{name: "stoploss_probe", calls: &invocations, output: "probe side effect"})
+
+		q := &Querier[*MockQuerier]{
+			out:         &strings.Builder{},
+			Model:       model,
+			stoploss:    &Stoploss{MaxTokens: 100, MaxTokensHandoverMsg: "wrap up", MaxToolCallsAfterHandover: 1},
+			skillLoader: countingSkillLoader{loads: &loads},
+		}
+		session := &QuerySession{Chat: pub_models.Chat{Messages: []pub_models.Message{{Role: "user", Content: "hello"}}}}
+		runner := newStoplossRunner(q)
+
+		if err := runner.Run(context.Background(), session); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		// Crossing probe + post-handover probe consume the wrap-up budget; the
+		// load_skill on step 3 is refused before loading.
+		if invocations != 2 {
+			t.Fatalf("expected the two probes to run, got %d invocations", invocations)
+		}
+		if loads != 0 {
+			t.Fatalf("load_skill must not load once the post-handover budget is exhausted, got %d loads", loads)
+		}
+		last := session.Chat.Messages[len(session.Chat.Messages)-1]
+		if last.Role != "tool" || !strings.Contains(last.Content, "No more tool calls allowed") {
+			t.Fatalf("expected refusal ladder text for load_skill, got %+v", last)
+		}
+	})
 }
 
 // Test_sessionRunner_Run_PreHandoverLoadSkillLoads is the positive control for
@@ -317,16 +373,39 @@ func Test_sessionRunner_Run_PreHandoverLoadSkillLoads(t *testing.T) {
 	}
 }
 
-// Test_toolExecutor_PostHandoverLookbackRefusedWithoutExecution pins R2-01
-// (lookback tools): after handover the lookback dispatch never runs; the tool
-// result carries the ladder text.
-func Test_toolExecutor_PostHandoverLookbackRefusedWithoutExecution(t *testing.T) {
+// Test_toolExecutor_PostHandoverLookbackExecutesByDefault pins the lookback
+// tools under the new default: after handover the lookback dispatch runs and
+// the tool result carries real output.
+func Test_toolExecutor_PostHandoverLookbackExecutesByDefault(t *testing.T) {
 	q := &Querier[*MockQuerier]{
 		out:         &strings.Builder{},
 		useLookback: true,
 		configDir:   t.TempDir(),
 	}
 	session := &QuerySession{HandoverRequested: true, Chat: pub_models.Chat{}}
+	call := pub_models.Call{ID: "lb-1", Name: string(pub_models.SearchConversationsTool), Inputs: &pub_models.Input{}}
+
+	err := toolExecutor[*MockQuerier]{querier: q}.ExecuteBatch(context.Background(), session, []pub_models.Call{call})
+	if err != nil {
+		t.Fatalf("ExecuteBatch: %v", err)
+	}
+	last := session.Chat.Messages[len(session.Chat.Messages)-1]
+	if last.Role != "tool" || strings.Contains(last.Content, "No more tool calls allowed") {
+		t.Fatalf("expected the lookback tool to run after handover by default, got %+v", last)
+	}
+}
+
+// Test_toolExecutor_PostHandoverLookbackRefusedWhenBudgetExhausted pins that
+// once the post-handover budget is exhausted, the lookback dispatch never
+// runs; the tool result carries the ladder text.
+func Test_toolExecutor_PostHandoverLookbackRefusedWhenBudgetExhausted(t *testing.T) {
+	q := &Querier[*MockQuerier]{
+		out:         &strings.Builder{},
+		useLookback: true,
+		configDir:   t.TempDir(),
+		stoploss:    &Stoploss{MaxToolCallsAfterHandover: 1},
+	}
+	session := &QuerySession{HandoverRequested: true, PostHandoverToolCallsUsed: 1, Chat: pub_models.Chat{}}
 	call := pub_models.Call{ID: "lb-1", Name: string(pub_models.SearchConversationsTool), Inputs: &pub_models.Input{}}
 
 	err := toolExecutor[*MockQuerier]{querier: q}.ExecuteBatch(context.Background(), session, []pub_models.Call{call})
@@ -398,10 +477,10 @@ func Test_toolExecutor_ExecuteBatch_RefusedCallHasNoSideEffect(t *testing.T) {
 	})
 }
 
-// Test_toolExecutor_ExecuteBatch_PostHandoverBatchRefusesAllCalls pins the
-// R3-02 example: a post-handover batch must not run any call, including the
-// first one, before every call in the batch has been decided.
-func Test_toolExecutor_ExecuteBatch_PostHandoverBatchRefusesAllCalls(t *testing.T) {
+// Test_toolExecutor_ExecuteBatch_PostHandoverBatchExecutesByDefault pins the
+// R3-02 example under the new default: a post-handover batch runs every call
+// when no max-tool-calls-after-handover is configured.
+func Test_toolExecutor_ExecuteBatch_PostHandoverBatchExecutesByDefault(t *testing.T) {
 	inttools.WithTestRegistry(t, func() {
 		cmdCalls := 0
 		otherCalls := 0
@@ -419,17 +498,55 @@ func Test_toolExecutor_ExecuteBatch_PostHandoverBatchRefusesAllCalls(t *testing.
 		if err != nil {
 			t.Fatalf("ExecuteBatch: %v", err)
 		}
-		if cmdCalls != 0 || otherCalls != 0 {
-			t.Fatalf("no post-handover side effect may run, got cmd=%d other=%d", cmdCalls, otherCalls)
+		if cmdCalls != 1 || otherCalls != 1 {
+			t.Fatalf("expected both post-handover tools to run by default, got cmd=%d other=%d", cmdCalls, otherCalls)
 		}
 		if len(session.Chat.Messages) != 3 {
-			t.Fatalf("expected assistant tool-calls + 2 refusal results, got %d messages", len(session.Chat.Messages))
+			t.Fatalf("expected assistant tool-calls + 2 tool results, got %d messages", len(session.Chat.Messages))
 		}
-		if !strings.Contains(session.Chat.Messages[1].Content, "No more tool calls allowed") {
-			t.Fatalf("expected plain refusal for the first call, got %q", session.Chat.Messages[1].Content)
+		if !strings.Contains(session.Chat.Messages[1].Content, "cmd side effect") {
+			t.Fatalf("expected real cmd output, got %q", session.Chat.Messages[1].Content)
 		}
-		if !strings.Contains(session.Chat.Messages[2].Content, "HARD SHUT DOWN") {
-			t.Fatalf("expected escalated refusal for the second call, got %q", session.Chat.Messages[2].Content)
+		if !strings.Contains(session.Chat.Messages[2].Content, "other side effect") {
+			t.Fatalf("expected real other output, got %q", session.Chat.Messages[2].Content)
+		}
+		assertValidToolExchanges(t, session.Chat.Messages)
+	})
+}
+
+// Test_toolExecutor_ExecuteBatch_PostHandoverBatchRefusesAfterBudget pins the
+// bounded wrap-up: with max-tool-calls-after-handover 1 the first call of a
+// post-handover batch executes and the second is refused before invocation,
+// with one tool result per declared call.
+func Test_toolExecutor_ExecuteBatch_PostHandoverBatchRefusesAfterBudget(t *testing.T) {
+	inttools.WithTestRegistry(t, func() {
+		cmdCalls := 0
+		otherCalls := 0
+		inttools.Registry.Set("probe_cmd", countingStubTool{name: "probe_cmd", calls: &cmdCalls, output: "cmd side effect"})
+		inttools.Registry.Set("probe_other", countingStubTool{name: "probe_other", calls: &otherCalls, output: "other side effect"})
+
+		q := &Querier[*MockQuerier]{out: &strings.Builder{}, stoploss: &Stoploss{MaxToolCallsAfterHandover: 1}}
+		session := &QuerySession{HandoverRequested: true, Chat: pub_models.Chat{}}
+		executor := toolExecutor[*MockQuerier]{querier: q}
+
+		err := executor.ExecuteBatch(context.Background(), session, []pub_models.Call{
+			{ID: "cmd", Name: "probe_cmd", Inputs: &pub_models.Input{}},
+			{ID: "other", Name: "probe_other", Inputs: &pub_models.Input{}},
+		})
+		if err != nil {
+			t.Fatalf("ExecuteBatch: %v", err)
+		}
+		if cmdCalls != 1 || otherCalls != 0 {
+			t.Fatalf("expected only the within-budget post-handover tool to run, got cmd=%d other=%d", cmdCalls, otherCalls)
+		}
+		if len(session.Chat.Messages) != 3 {
+			t.Fatalf("expected assistant tool-calls + 2 tool results, got %d messages", len(session.Chat.Messages))
+		}
+		if !strings.Contains(session.Chat.Messages[1].Content, "cmd side effect") {
+			t.Fatalf("expected the first post-handover call to execute, got %q", session.Chat.Messages[1].Content)
+		}
+		if !strings.Contains(session.Chat.Messages[2].Content, "No more tool calls allowed") {
+			t.Fatalf("expected refusal ladder text on the second call, got %q", session.Chat.Messages[2].Content)
 		}
 		assertValidToolExchanges(t, session.Chat.Messages)
 	})
@@ -559,11 +676,11 @@ func Test_toolExecutor_ExecuteBatch_MixedBatchLoadSkillMiddle(t *testing.T) {
 	})
 }
 
-// Test_toolExecutor_ExecuteBatch_PostHandoverMixedBatchRefusesWithPairing pins
-// R9-01 for the refused path: a post-handover [cmd, load_skill] batch keeps
-// immediate pairing — the cmd refusal pair, then the load_skill refusal pair —
-// with the ladder escalating in emission order.
-func Test_toolExecutor_ExecuteBatch_PostHandoverMixedBatchRefusesWithPairing(t *testing.T) {
+// Test_toolExecutor_ExecuteBatch_PostHandoverMixedBatchExecutesWithPairing pins
+// R9-01 under the new default: a post-handover [cmd, load_skill] batch keeps
+// immediate pairing — the cmd pair first, then the load_skill pair — with
+// both tools running.
+func Test_toolExecutor_ExecuteBatch_PostHandoverMixedBatchExecutesWithPairing(t *testing.T) {
 	inttools.WithTestRegistry(t, func() {
 		cmdCalls := 0
 		loads := 0
@@ -579,8 +696,40 @@ func Test_toolExecutor_ExecuteBatch_PostHandoverMixedBatchRefusesWithPairing(t *
 		if err != nil {
 			t.Fatalf("ExecuteBatch: %v", err)
 		}
+		if cmdCalls != 1 || loads != 1 {
+			t.Fatalf("expected both tools to run after handover by default, got cmd=%d loads=%d", cmdCalls, loads)
+		}
+		if len(session.Chat.Messages) != 4 {
+			t.Fatalf("expected 2 assistant tool-call turns + 2 tool results, got %d messages", len(session.Chat.Messages))
+		}
+		assertValidToolExchanges(t, session.Chat.Messages)
+	})
+}
+
+// Test_toolExecutor_ExecuteBatch_PostHandoverMixedBatchRefusesWithPairing pins
+// R9-01 for the refused path: once the post-handover budget is exhausted, a
+// [cmd, load_skill] batch keeps immediate pairing — the cmd refusal pair, then
+// the load_skill refusal pair — with the ladder escalating in emission order
+// and no side effect running.
+func Test_toolExecutor_ExecuteBatch_PostHandoverMixedBatchRefusesWithPairing(t *testing.T) {
+	inttools.WithTestRegistry(t, func() {
+		cmdCalls := 0
+		loads := 0
+		q := mixedBatchQuerier(t, &cmdCalls, &loads)
+		q.stoploss = &Stoploss{MaxToolCallsAfterHandover: 1}
+		session := &QuerySession{HandoverRequested: true, PostHandoverToolCallsUsed: 1, Chat: pub_models.Chat{}}
+		executor := toolExecutor[*MockQuerier]{querier: q}
+
+		inputs := pub_models.Input{"skill": "test"}
+		err := executor.ExecuteBatch(context.Background(), session, []pub_models.Call{
+			{ID: "cmd-1", Name: "mixed_probe", Inputs: &pub_models.Input{}},
+			{ID: "skill-1", Name: string(pub_models.LoadSkillTool), Inputs: &inputs},
+		})
+		if err != nil {
+			t.Fatalf("ExecuteBatch: %v", err)
+		}
 		if cmdCalls != 0 || loads != 0 {
-			t.Fatalf("no post-handover side effect may run, got cmd=%d loads=%d", cmdCalls, loads)
+			t.Fatalf("no post-handover side effect may run past the budget, got cmd=%d loads=%d", cmdCalls, loads)
 		}
 		if len(session.Chat.Messages) != 4 {
 			t.Fatalf("expected 2 refusal pairs, got %d messages", len(session.Chat.Messages))
@@ -602,11 +751,11 @@ func Test_toolExecutor_ExecuteBatch_PostHandoverMixedBatchRefusesWithPairing(t *
 // returned; otherwise the persisted transcript contains a dangling tool_call
 // that a follow-up replay request cannot send to the vendor.
 func Test_toolExecutor_ExecuteBatch_HardStopMidBatchEmitsAllResults(t *testing.T) {
-	q := &Querier[*MockQuerier]{out: &strings.Builder{}}
+	q := &Querier[*MockQuerier]{out: &strings.Builder{}, stoploss: &Stoploss{MaxToolCallsAfterHandover: 1}}
 	session := &QuerySession{HandoverRequested: true, Chat: pub_models.Chat{}}
 	executor := toolExecutor[*MockQuerier]{querier: q}
 
-	// Post-handover budget is 0, so the ladder persists on the 4th call and
+	// Post-handover budget is 1, so the ladder persists on the 4th call and
 	// hardStops on the 5th: the hardStop plan is the last one. Use six calls
 	// so the hardStop lands mid-batch (calls 4 and 5 are hardStop, call 6
 	// follows the first hardStop).
@@ -626,12 +775,11 @@ func Test_toolExecutor_ExecuteBatch_HardStopMidBatchEmitsAllResults(t *testing.T
 	assertValidToolExchanges(t, session.Chat.Messages)
 }
 
-// Test_toolExecutor_ExecuteBatch_PostHandoverMixedBatchLoadSkillFirstRefusesWithPairing
-// pins R9-01 for the refused path with load_skill leading: a post-handover
-// [load_skill, cmd] batch keeps immediate pairing — the load_skill refusal
-// pair first, then the cmd refusal pair — with the ladder escalating in
-// emission order.
-func Test_toolExecutor_ExecuteBatch_PostHandoverMixedBatchLoadSkillFirstRefusesWithPairing(t *testing.T) {
+// Test_toolExecutor_ExecuteBatch_PostHandoverMixedBatchLoadSkillFirstExecutesWithPairing
+// pins R9-01 under the new default with load_skill leading: a post-handover
+// [load_skill, cmd] batch keeps immediate pairing — the load_skill pair first,
+// then the cmd pair — with both tools running.
+func Test_toolExecutor_ExecuteBatch_PostHandoverMixedBatchLoadSkillFirstExecutesWithPairing(t *testing.T) {
 	inttools.WithTestRegistry(t, func() {
 		cmdCalls := 0
 		loads := 0
@@ -647,8 +795,43 @@ func Test_toolExecutor_ExecuteBatch_PostHandoverMixedBatchLoadSkillFirstRefusesW
 		if err != nil {
 			t.Fatalf("ExecuteBatch: %v", err)
 		}
+		if cmdCalls != 1 || loads != 1 {
+			t.Fatalf("expected both tools to run after handover by default, got cmd=%d loads=%d", cmdCalls, loads)
+		}
+		if len(session.Chat.Messages) != 4 {
+			t.Fatalf("expected 2 assistant tool-call turns + 2 tool results, got %d messages", len(session.Chat.Messages))
+		}
+		assertValidToolExchanges(t, session.Chat.Messages)
+		if got := session.Chat.Messages[0].ToolCalls[0].Name; got != string(pub_models.LoadSkillTool) {
+			t.Fatalf("expected the load_skill pair first, got %q", got)
+		}
+	})
+}
+
+// Test_toolExecutor_ExecuteBatch_PostHandoverMixedBatchLoadSkillFirstRefusesWithPairing
+// pins R9-01 for the refused path with load_skill leading: once the
+// post-handover budget is exhausted, a [load_skill, cmd] batch keeps immediate
+// pairing — the load_skill refusal pair first, then the cmd refusal pair —
+// with the ladder escalating in emission order.
+func Test_toolExecutor_ExecuteBatch_PostHandoverMixedBatchLoadSkillFirstRefusesWithPairing(t *testing.T) {
+	inttools.WithTestRegistry(t, func() {
+		cmdCalls := 0
+		loads := 0
+		q := mixedBatchQuerier(t, &cmdCalls, &loads)
+		q.stoploss = &Stoploss{MaxToolCallsAfterHandover: 1}
+		session := &QuerySession{HandoverRequested: true, PostHandoverToolCallsUsed: 1, Chat: pub_models.Chat{}}
+		executor := toolExecutor[*MockQuerier]{querier: q}
+
+		inputs := pub_models.Input{"skill": "test"}
+		err := executor.ExecuteBatch(context.Background(), session, []pub_models.Call{
+			{ID: "skill-1", Name: string(pub_models.LoadSkillTool), Inputs: &inputs},
+			{ID: "cmd-1", Name: "mixed_probe", Inputs: &pub_models.Input{}},
+		})
+		if err != nil {
+			t.Fatalf("ExecuteBatch: %v", err)
+		}
 		if cmdCalls != 0 || loads != 0 {
-			t.Fatalf("no post-handover side effect may run, got cmd=%d loads=%d", cmdCalls, loads)
+			t.Fatalf("no post-handover side effect may run past the budget, got cmd=%d loads=%d", cmdCalls, loads)
 		}
 		if len(session.Chat.Messages) != 4 {
 			t.Fatalf("expected 2 refusal pairs, got %d messages", len(session.Chat.Messages))

--- a/internal/text/stoploss_test.go
+++ b/internal/text/stoploss_test.go
@@ -5,11 +5,41 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/baalimago/clai/internal/utils"
+	"github.com/baalimago/go_away_boilerplate/pkg/testboil"
 )
+
+// TestMigrateTagContract pins the migrate:"true" contract: a field tagged
+// migrate:"true" must not carry the omitempty json option, or the config
+// rewrite would drop the filled zero value again and the field would silently
+// vanish from upgraded files (config migration design, phase 8). The guard
+// walks every struct reachable from the loaded config types, so future
+// migrate-tagged fields are covered automatically.
+func TestMigrateTagContract(t *testing.T) {
+	seen := map[reflect.Type]bool{}
+	var walk func(typ reflect.Type)
+	walk = func(typ reflect.Type) {
+		if typ.Kind() == reflect.Pointer {
+			typ = typ.Elem()
+		}
+		if typ.Kind() != reflect.Struct || seen[typ] {
+			return
+		}
+		seen[typ] = true
+		for sf := range typ.Fields() {
+			if sf.Tag.Get("migrate") == "true" && strings.Contains(sf.Tag.Get("json"), "omitempty") {
+				t.Fatalf("field %s.%s carries migrate:\"true\" and omitempty; the filled zero would be dropped by the rewrite", typ.Name(), sf.Name)
+			}
+			walk(sf.Type)
+		}
+	}
+	walk(reflect.TypeFor[Configurations]())
+	walk(reflect.TypeFor[Profile]())
+}
 
 // TestConfigurations_StoplossLoadsFromTextConfig pins the nested stoploss
 // object contract (Phase 2): max-tokens and
@@ -147,7 +177,7 @@ func TestConfigurations_StoplossMarshalsNestedObject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Marshal(with stoploss): %v", err)
 	}
-	want := `"stoploss":{"max-tokens":200000,"max-tokens-handover-instructions":"wrap up"}`
+	want := `"stoploss":{"max-tokens":200000,"max-tokens-handover-instructions":"wrap up","max-tool-calls-after-handover":0}`
 	if !strings.Contains(string(data), want) {
 		t.Fatalf("expected marshaled config to contain %q, got %s", want, data)
 	}
@@ -159,6 +189,108 @@ func TestConfigurations_StoplossMarshalsNestedObject(t *testing.T) {
 	}
 	if strings.Contains(string(data), "stoploss") {
 		t.Fatalf("expected absent stoploss to marshal to nothing, got %s", data)
+	}
+}
+
+// TestConfigurations_StoplossMaxToolCallsAfterHandoverLoads pins that the
+// post-handover tool budget key loads through utils.LoadConfigFromFile.
+func TestConfigurations_StoplossMaxToolCallsAfterHandoverLoads(t *testing.T) {
+	dir := t.TempDir()
+	confPath := filepath.Join(dir, "textConfig.json")
+	content := `{"model":"test","stoploss":{"max-tokens":100,"max-tool-calls-after-handover":3}}`
+	if err := os.WriteFile(confPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(textConfig.json): %v", err)
+	}
+
+	conf, err := utils.LoadConfigFromFile(dir, "textConfig.json", nil, &Default)
+	if err != nil {
+		t.Fatalf("LoadConfigFromFile: %v", err)
+	}
+	if conf.Stoploss == nil || conf.Stoploss.MaxTokens != 100 {
+		t.Fatalf("expected stoploss with max-tokens 100, got %+v", conf.Stoploss)
+	}
+	if conf.Stoploss.MaxToolCallsAfterHandover != 3 {
+		t.Fatalf("expected MaxToolCallsAfterHandover 3, got %d", conf.Stoploss.MaxToolCallsAfterHandover)
+	}
+}
+
+// TestConfigurations_StoplossMaxToolCallsAfterHandoverAbsentGetsMaterialized
+// pins the migrate:"true" highlight for the new key: a pre-existing stoploss
+// object without the key gains it on the next load as the explicit zero
+// (0 = unlimited), the file is rewritten once, the upgrade announcement lists
+// the path, and a second load is silent.
+func TestConfigurations_StoplossMaxToolCallsAfterHandoverAbsentGetsMaterialized(t *testing.T) {
+	dir := t.TempDir()
+	confPath := filepath.Join(dir, "textConfig.json")
+	content := `{"model":"test","stoploss":{"max-tokens":100,"max-tokens-handover-instructions":"wrap up"}}`
+	if err := os.WriteFile(confPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(textConfig.json): %v", err)
+	}
+
+	var conf Configurations
+	stdout := testboil.CaptureStdout(t, func(t *testing.T) {
+		var err error
+		conf, err = utils.LoadConfigFromFile(dir, "textConfig.json", nil, &Default)
+		if err != nil {
+			t.Fatalf("LoadConfigFromFile: %v", err)
+		}
+	})
+	if conf.Stoploss == nil || conf.Stoploss.MaxToolCallsAfterHandover != 0 {
+		t.Fatalf("expected the absent key materialized as 0 (unlimited), got %+v", conf.Stoploss)
+	}
+	if !strings.Contains(stdout, "stoploss.max-tool-calls-after-handover") {
+		t.Fatalf("expected the upgrade announcement to list the new key, got %q", stdout)
+	}
+	regenerated, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("ReadFile(regenerated): %v", err)
+	}
+	if !strings.Contains(string(regenerated), `"max-tool-calls-after-handover": 0`) {
+		t.Fatalf("expected the materialized zero key in the rewritten file:\n%s", regenerated)
+	}
+	before := string(regenerated)
+	stdout2 := testboil.CaptureStdout(t, func(t *testing.T) {
+		if _, err := utils.LoadConfigFromFile(dir, "textConfig.json", nil, &Default); err != nil {
+			t.Fatalf("second LoadConfigFromFile: %v", err)
+		}
+	})
+	if stdout2 != "" {
+		t.Fatalf("expected the second load to be silent, got %q", stdout2)
+	}
+	after, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("ReadFile(after): %v", err)
+	}
+	if string(after) != before {
+		t.Fatalf("second load must not rewrite the file:\n%s", after)
+	}
+}
+
+// TestConfigurations_StoplossMarshalsPostHandoverBudget pins the marshal
+// contract for the new key: a positive budget marshals into the nested
+// stoploss object, and the zero value marshals explicitly (no omitempty) so
+// the migrate highlight survives the rewrite.
+func TestConfigurations_StoplossMarshalsPostHandoverBudget(t *testing.T) {
+	with := Configurations{
+		Model:    "test",
+		Stoploss: &Stoploss{MaxTokens: 200000, MaxToolCallsAfterHandover: 5},
+	}
+	data, err := json.Marshal(with)
+	if err != nil {
+		t.Fatalf("Marshal(with budget): %v", err)
+	}
+	want := `"stoploss":{"max-tokens":200000,"max-tokens-handover-instructions":"","max-tool-calls-after-handover":5}`
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("expected marshaled config to contain %q, got %s", want, data)
+	}
+
+	without := Configurations{Model: "test", Stoploss: &Stoploss{MaxTokens: 200000}}
+	data, err = json.Marshal(without)
+	if err != nil {
+		t.Fatalf("Marshal(without budget): %v", err)
+	}
+	if !strings.Contains(string(data), `"max-tool-calls-after-handover":0`) {
+		t.Fatalf("expected the zero budget to marshal explicitly, got %s", data)
 	}
 }
 

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -199,9 +199,11 @@ func LoadConfigFromFile[T any](
 // announcement. It returns the JSON paths of every field it added to a
 // pre-existing file, e.g. "stoploss" or
 // "stoploss.max-tokens-handover-instructions"; an empty list means the file
-// needed no upgrade (or was freshly created). Callers whose own output would
-// overwrite the announcement (e.g. the interactive setup wizard, whose TUI
-// erases pre-wizard stdout) use this to announce after their output is done.
+// needed no upgrade (or was freshly created). Callers that must control
+// when the announcement is printed (e.g. the interactive setup wizard,
+// which prints it just before its TUI starts and pads the block with a
+// blank separator line that absorbs the wizard's one-line clear overshoot)
+// use this to announce at the right time.
 func LoadConfigFromFileCollect[T any](
 	configDirPath,
 	configFileName string,
@@ -302,11 +304,16 @@ func loadConfigFromFile[T any](
 }
 
 // fillMissingFromDefaults fills fields of loaded that are absent from the
-// on-disk config (per present) using non-zero defaults from dflt. A key that
-// is present in the file is never touched, even when its value is the zero
+// on-disk config (per present) using defaults from dflt. A key that is
+// present in the file is never touched, even when its value is the zero
 // value: the file is the user's source of truth (Q4). Nested JSON objects are
 // recursed into so missing subfields of a present object are also filled (Q3).
-// It returns the JSON paths of every field it filled, e.g. "stoploss" or
+// Fields tagged `migrate:"true"` are filled even when their default is the
+// zero value, so new feature knobs whose natural default is 0 (e.g.
+// stoploss.max-tool-calls-after-handover, 0 = unlimited) surface in upgraded
+// configs; such fields must not carry the `omitempty` json option, or the
+// marshaled rewrite would drop the filled zero again. It returns the JSON
+// paths of every field it filled, e.g. "stoploss" or
 // "stoploss.max-tokens-handover-instructions".
 func fillMissingFromDefaults(loaded, dflt any, present map[string]json.RawMessage, prefix string) []string {
 	added := []string{}
@@ -358,7 +365,7 @@ func fillMissingFromDefaults(loaded, dflt any, present map[string]json.RawMessag
 			continue
 		}
 		dvf := dv.Field(i)
-		if dvf.IsZero() {
+		if dvf.IsZero() && sf.Tag.Get("migrate") != "true" {
 			continue
 		}
 		lv.Field(i).Set(cloneDefaultValue(dvf))

--- a/internal/utils/config_test.go
+++ b/internal/utils/config_test.go
@@ -275,6 +275,98 @@ func Test_fillMissingFromDefaults(t *testing.T) {
 	})
 }
 
+// migrateZeroFixture distinguishes migrate-tagged fields (surfaced by the
+// migration even at a zero default) from plain zero-default fields (skipped,
+// status quo) and non-zero defaults (standard fill).
+type migrateZeroFixture struct {
+	Tagged   int    `json:"tagged" migrate:"true"`
+	Untagged int    `json:"untagged"`
+	Active   string `json:"active"`
+}
+
+func Test_fillMissingFromDefaults_MigrateTag(t *testing.T) {
+	defaults := &migrateZeroFixture{Active: "on"}
+	loadFixture := func(jsonStr string) (*migrateZeroFixture, map[string]json.RawMessage) {
+		var loaded migrateZeroFixture
+		if err := json.Unmarshal([]byte(jsonStr), &loaded); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		var present map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(jsonStr), &present); err != nil {
+			t.Fatalf("Unmarshal present: %v", err)
+		}
+		return &loaded, present
+	}
+
+	t.Run("migrate-tagged zero-default fields are filled when absent", func(t *testing.T) {
+		loaded, present := loadFixture(`{"active":"user"}`)
+		added := fillMissingFromDefaults(loaded, defaults, present, "")
+		got := strings.Join(added, ",")
+		if !strings.Contains(got, "tagged") {
+			t.Fatalf("expected the migrate-tagged field added, got %q", got)
+		}
+		if strings.Contains(got, "untagged") {
+			t.Fatalf("untagged zero-default field must stay skipped, got %q", got)
+		}
+		if loaded.Tagged != 0 {
+			t.Fatalf("expected the migrate-tagged field at its zero default, got %d", loaded.Tagged)
+		}
+	})
+
+	t.Run("migrate-tagged fields present in the file are never touched", func(t *testing.T) {
+		loaded, present := loadFixture(`{"tagged":7,"active":"user"}`)
+		added := fillMissingFromDefaults(loaded, defaults, present, "")
+		if strings.Contains(strings.Join(added, ","), "tagged") {
+			t.Fatalf("present migrate-tagged field must not be re-added, got %v", added)
+		}
+		if loaded.Tagged != 7 {
+			t.Fatalf("present value must survive, got %d", loaded.Tagged)
+		}
+	})
+
+	t.Run("migrate-tagged zero fills surface through LoadConfigFromFile once", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "app.json")
+		if err := os.WriteFile(configPath, []byte(`{"active":"user"}`), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		conf, added, err := LoadConfigFromFileCollect(dir, "app.json", nil, defaults)
+		if err != nil {
+			t.Fatalf("LoadConfigFromFileCollect: %v", err)
+		}
+		got := strings.Join(added, ",")
+		if !strings.Contains(got, "tagged") || strings.Contains(got, "untagged") {
+			t.Fatalf("expected only the migrate-tagged field added, got %v", added)
+		}
+		if conf.Tagged != 0 || conf.Untagged != 0 || conf.Active != "user" {
+			t.Fatalf("unexpected merge result: %+v", conf)
+		}
+		regenerated, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("ReadFile: %v", err)
+		}
+		if !strings.Contains(string(regenerated), `"tagged": 0`) {
+			t.Fatalf("expected the zero default materialized in the file:\n%s", regenerated)
+		}
+		// Idempotent: a second load adds nothing and does not rewrite.
+		before := string(regenerated)
+		_, added, err = LoadConfigFromFileCollect(dir, "app.json", nil, defaults)
+		if err != nil {
+			t.Fatalf("second LoadConfigFromFileCollect: %v", err)
+		}
+		if len(added) != 0 {
+			t.Fatalf("expected the second load to be silent, got %v", added)
+		}
+		after, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("ReadFile(after): %v", err)
+		}
+		if string(after) != before {
+			t.Fatalf("second load must not rewrite the file:\n%s", after)
+		}
+	})
+}
+
 func TestLoadConfigFromFile_AppendsMissingFieldsAndAnnounces(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "app.json")

--- a/main.go
+++ b/main.go
@@ -26,25 +26,26 @@ Prerequisites:
 Usage: clai [flags] <command>
 
 Flags:
-  -re, -reply bool                 Set to true to reply to the previous query, meaning that it will be used as context for your next query. (default %v)
-  -r, -raw bool                    Set to true to print raw output (no animation, no glow). (default %v)
-  -cm, -chat-model string          Set the chat model to use. (default is found in %v/textConfig.json)
-  -pm, -photo-model string         Set the image model to use. (default is found in %v/photoConfig.json)
-  -pd, -photo-dir string           Set the directory to store the generated pictures. (default is found in %v/photoConfig.json)
-  -pp, -photo-prefix string        Set the prefix for the generated pictures. (default is found in %v/photoConfig.json)
-  -vd, -video-dir string           Set dir for generated videos. Default $HOME/Videos (default %v)
-  -vp, -video-prefix string        Set prefix for generated videos. Default 'clai' (default %v)
-  -t, -tools string                Set to <tool_a>,<tool_b> for specific tool, or */"" to use all built in or MCP tools. See available tools with 'clai tools' (default %v)
-  -s, -skills string               Enable or disable skills for this run. Use '*' to enable or 'none' to disable.
-  -cmd-ban string                  Append comma-separated command bans for this run (e.g. "rm,sudo"). Commands matching a ban are refused before they spawn.
-  -g, -glob string                 Set the glob to use for globbing. (default '%v')
-  -p, -profile string              Set the profile which should be used. For details, see 'clai help profile'. (default '%v')
-  -prp, profile-path string        Set the path to a profile file to use instead of -p/-profile.
-  -asc, -append-shell-context str  Append a named shell context from <config-dir>/shellContexts/<name>.json to the final query prompt.
-  -rf, -response-format string     Block streaming and print only the final structured response (json_object, json_schema).
-  -n, -non-interactive             Disable interactive stdin fallback after macro inputs; auto-exit instead.
-  -mt, -max-tokens int             Set the max context tokens for this run. 0 = unlimited (default is found in %v/textConfig.json)
-  -mtc, -max-tool-calls int        Set the max tool calls for this run. 0 = unlimited (default is found in %v/textConfig.json)
+  -re, -reply bool                    Set to true to reply to the previous query, meaning that it will be used as context for your next query. (default %v)
+  -r, -raw bool                       Set to true to print raw output (no animation, no glow). (default %v)
+  -cm, -chat-model string             Set the chat model to use. (default is found in %v/textConfig.json)
+  -pm, -photo-model string            Set the image model to use. (default is found in %v/photoConfig.json)
+  -pd, -photo-dir string              Set the directory to store the generated pictures. (default is found in %v/photoConfig.json)
+  -pp, -photo-prefix string           Set the prefix for the generated pictures. (default is found in %v/photoConfig.json)
+  -vd, -video-dir string              Set dir for generated videos. Default $HOME/Videos (default %v)
+  -vp, -video-prefix string           Set prefix for generated videos. Default 'clai' (default %v)
+  -t, -tools string                   Set to <tool_a>,<tool_b> for specific tool, or */"" to use all built in or MCP tools. See available tools with 'clai tools' (default %v)
+  -s, -skills string                  Enable or disable skills for this run. Use '*' to enable or 'none' to disable.
+  -cmd-ban string                     Append comma-separated command bans for this run (e.g. "rm,sudo"). Commands matching a ban are refused before they spawn.
+  -g, -glob string                    Set the glob to use for globbing. (default '%v')
+  -p, -profile string                 Set the profile which should be used. For details, see 'clai help profile'. (default '%v')
+  -prp, profile-path string           Set the path to a profile file to use instead of -p/-profile.
+  -asc, -append-shell-context str     Append a named shell context from <config-dir>/shellContexts/<name>.json to the final query prompt.
+  -rf, -response-format string        Block streaming and print only the final structured response (json_object, json_schema).
+  -n, -non-interactive                Disable interactive stdin fallback after macro inputs; auto-exit instead.
+  -mt, -max-tokens int                Set the max context tokens for this run. 0 = unlimited (default is found in %v/textConfig.json)
+  -mtc, -max-tool-calls int           Set the max tool calls for this run. 0 = unlimited (default is found in %v/textConfig.json)
+  -max-tool-calls-after-handover int  Set the max tool calls for the post-handover phase of this run. 0 = unlimited (default is found in %v/textConfig.json)
 
 Config dir: %v
 Cache dir:  %v

--- a/main_help_e2e_test.go
+++ b/main_help_e2e_test.go
@@ -32,8 +32,57 @@ func Test_goldenFile_HELP_prints_usage(t *testing.T) {
 	testboil.AssertStringContains(t, gotStdout, "-asc, -append-shell-context str")
 	testboil.AssertStringContains(t, gotStdout, "-mt, -max-tokens int")
 	testboil.AssertStringContains(t, gotStdout, "-mtc, -max-tool-calls int")
+	testboil.AssertStringContains(t, gotStdout, "-max-tool-calls-after-handover int")
 	testboil.AssertStringContains(t, gotStdout, "clai -asc minimal q \"what changed in this repo?\"")
 	testboil.AssertStringContains(t, gotStdout, confDir)
+	assertFlagDescriptionsAligned(t, gotStdout)
+}
+
+// assertFlagDescriptionsAligned fails when the flag descriptions in the usage
+// text do not all start at the same column. Keeping the column aligned is a
+// manual padding exercise today; this guard turns a misalignment into a test
+// failure instead of a silent cosmetic regression. The structured replacement
+// (generating the flag block from a table of {flag, type, description}) is a
+// future upgrade.
+func assertFlagDescriptionsAligned(t *testing.T, usageOut string) {
+	t.Helper()
+	var descCol int
+	for line := range strings.SplitSeq(usageOut, "\n") {
+		if !strings.HasPrefix(line, "  -") {
+			continue
+		}
+		// The description is the text after the first run of 2+ spaces that
+		// follows the flag spec.
+		rest := line[2:]
+		runStart := -1
+		for i := 0; i+1 < len(rest); i++ {
+			if rest[i] == ' ' && rest[i+1] == ' ' {
+				runStart = i
+				break
+			}
+		}
+		if runStart < 0 {
+			continue
+		}
+		j := runStart
+		for j < len(rest) && rest[j] == ' ' {
+			j++
+		}
+		if j == len(rest) {
+			continue
+		}
+		col := 2 + j
+		if descCol == 0 {
+			descCol = col
+			continue
+		}
+		if col != descCol {
+			t.Fatalf("flag description column mismatch: %q starts at column %d, want %d", line, col+1, descCol+1)
+		}
+	}
+	if descCol == 0 {
+		t.Fatal("expected at least one flag line in the usage output")
+	}
 }
 
 func Test_goldenFile_HELP_profile_prints_profile_help(t *testing.T) {

--- a/main_setup_macro_e2e_test.go
+++ b/main_setup_macro_e2e_test.go
@@ -3,15 +3,24 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
+
+// stripANSI removes ANSI SGR escape sequences so assertions can match plain
+// text regardless of colorization.
+func stripANSI(s string) string {
+	return ansiSGR.ReplaceAllString(s, "")
+}
+
+var ansiSGR = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
 // Test_e2e_setup_migrates_mode_configs_and_announces proves that `clai s`
 // preloads the mode configs through LoadConfigFromFile: an existing
 // textConfig.json that predates the stoploss schema is upgraded in place and
 // the added fields are announced, so the wizard previews the current schema.
-func Test_e2e_setup_migrates_mode_configs_and_announces(t *testing.T) {
+func Test_e2e_setup_migrates_mode_configs_and_announces_before_wizard(t *testing.T) {
 	confDir := setupMainTestConfigDir(t)
 	// Downgrade textConfig.json to the pre-stoploss schema.
 	writeJSONFileAny(t, filepath.Join(confDir, "textConfig.json"), map[string]any{
@@ -25,13 +34,17 @@ func Test_e2e_setup_migrates_mode_configs_and_announces(t *testing.T) {
 	if !strings.Contains(stdout, "added new field(s) to textConfig.json:") {
 		t.Fatalf("expected the config upgrade announcement, got:\n%s", stdout)
 	}
-	// The wizard's TUI erases pre-wizard stdout when it redraws (table
-	// ClearTermTo overshoots by one line), so the upgrade announcement is
-	// deferred until after the wizard exits. Pin that it appears after the
-	// wizard header rather than before it.
+	// The wizard's TUI redraws by clearing its own frame plus one line above
+	// the header (table ClearTermTo clears upTo+1 lines), so the announcement
+	// block ends with a blank separator line that absorbs that overshoot and
+	// the announcement survives interactive redraws. Pin that the announcement
+	// appears before the wizard header with the blank line between them.
 	annIdx := strings.Index(stdout, "added new field(s) to textConfig.json:")
-	if annIdx < 0 || strings.Index(stdout, "Setup categories") > annIdx {
-		t.Fatalf("expected the announcement after the wizard exited, got:\n%s", stdout)
+	if annIdx < 0 || annIdx > strings.Index(stdout, "Setup categories") {
+		t.Fatalf("expected the announcement before the wizard started, got:\n%s", stdout)
+	}
+	if !strings.Contains(stripANSI(stdout[annIdx:]), "\n\nSetup categories") {
+		t.Fatalf("expected a blank separator line between the announcement and the wizard, got:\n%s", stdout)
 	}
 	regenerated, err := os.ReadFile(filepath.Join(confDir, "textConfig.json"))
 	if err != nil {
@@ -42,12 +55,13 @@ func Test_e2e_setup_migrates_mode_configs_and_announces(t *testing.T) {
 	}
 }
 
-// Test_e2e_setup_migrates_profiles_and_announces_after_wizard proves the
+// Test_e2e_setup_migrates_profiles_and_announces_before_wizard proves the
 // united config migration covers profiles during setup too: a profile that
 // predates the current schema is upgraded before the wizard runs, and its
-// announcement is deferred until after the wizard exits (its TUI erases
-// pre-wizard stdout).
-func Test_e2e_setup_migrates_profiles_and_announces_after_wizard(t *testing.T) {
+// announcement is printed before the wizard starts (the announcement block's
+// trailing blank line absorbs the TUI's one-line clear overshoot, so the
+// announcement survives redraws).
+func Test_e2e_setup_migrates_profiles_and_announces_before_wizard(t *testing.T) {
 	confDir := setupMainTestConfigDir(t)
 	writeJSONFileAny(t, filepath.Join(confDir, "profiles", "john.json"), map[string]any{
 		"name":  "john",
@@ -62,8 +76,8 @@ func Test_e2e_setup_migrates_profiles_and_announces_after_wizard(t *testing.T) {
 	if annIdx < 0 {
 		t.Fatalf("expected the profile upgrade announcement, got:\n%s", stdout)
 	}
-	if strings.Index(stdout, "Setup categories") > annIdx {
-		t.Fatalf("expected the profile announcement after the wizard exited, got:\n%s", stdout)
+	if annIdx > strings.Index(stdout, "Setup categories") {
+		t.Fatalf("expected the profile announcement before the wizard started, got:\n%s", stdout)
 	}
 	regenerated, err := os.ReadFile(filepath.Join(confDir, "profiles", "john.json"))
 	if err != nil {

--- a/main_setup_pty_e2e_test.go
+++ b/main_setup_pty_e2e_test.go
@@ -1,0 +1,239 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+// setupPTYHelperEnv gates the child entrypoint of the interactive setup PTY
+// e2e test (see TestSetupPTYHelper).
+const setupPTYHelperEnv = "CLAI_SETUP_PTY_HELPER"
+
+// TestSetupPTYHelper is the child entrypoint of
+// Test_e2e_setup_announcement_survives_interactive_wizard. The parent spawns
+// this test binary on a pseudo-terminal with setupPTYHelperEnv set; the
+// helper then runs the real CLI setup path (united config migration +
+// wizard) on that terminal, exactly like a user would. Without the env it is
+// a no-op, so the regular test suite never enters the wizard.
+func TestSetupPTYHelper(t *testing.T) {
+	if os.Getenv(setupPTYHelperEnv) != "1" {
+		return
+	}
+	os.Exit(run([]string{"s"}))
+}
+
+// openPTY allocates a Linux pseudo-terminal pair and returns the master and
+// slave ends. The parent keeps the master; the slave becomes the child's
+// controlling terminal via SysProcAttr.
+func openPTY(t *testing.T) (master, slave *os.File) {
+	t.Helper()
+	master, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open /dev/ptmx: %v", err)
+	}
+	// Unlock the slave and learn its number.
+	var unlock int32
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, master.Fd(), syscall.TIOCSPTLCK, uintptr(unsafe.Pointer(&unlock))); errno != 0 {
+		master.Close()
+		t.Fatalf("TIOCSPTLCK: %v", errno)
+	}
+	var n int32
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, master.Fd(), syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n))); errno != 0 {
+		master.Close()
+		t.Fatalf("TIOCGPTN: %v", errno)
+	}
+	slave, err = os.OpenFile(fmt.Sprintf("/dev/pts/%d", n), os.O_RDWR|syscall.O_NOCTTY, 0)
+	if err != nil {
+		master.Close()
+		t.Fatalf("open pty slave: %v", err)
+	}
+	return master, slave
+}
+
+// ptyScreen models the visible terminal screen for the ANSI sequences the
+// wizard emits: CR, LF, ESC[K (clear to end of line), ESC[1A (cursor up one),
+// and SGR color codes (ESC[...m). It reconstructs what a user would see so
+// tests assert on screen content instead of raw escape bytes.
+type ptyScreen struct {
+	lines [][]rune
+	row   int
+	col   int
+}
+
+func newPTYScreen() *ptyScreen {
+	return &ptyScreen{lines: [][]rune{{}}}
+}
+
+func (s *ptyScreen) write(b []byte) {
+	for i := 0; i < len(b); i++ {
+		switch c := b[i]; {
+		case c == '\r':
+			s.col = 0
+		case c == '\n':
+			s.row++
+			if s.row == len(s.lines) {
+				s.lines = append(s.lines, []rune{})
+			}
+		case c == 0x1b:
+			i = s.escape(b, i)
+		default:
+			s.putRune(rune(c))
+		}
+	}
+}
+
+// escape consumes the escape sequence starting at b[i] (b[i] == 0x1b) and
+// returns the index of its final byte. Only the sequences the table library
+// emits are interpreted; everything else is skipped as a parameter sequence.
+func (s *ptyScreen) escape(b []byte, i int) int {
+	if i+1 >= len(b) || b[i+1] != '[' {
+		return i
+	}
+	j := i + 2
+	for ; j < len(b); j++ {
+		switch {
+		case b[j] == 'K': // clear to end of line
+			if s.col < len(s.lines[s.row]) {
+				s.lines[s.row] = s.lines[s.row][:s.col]
+			}
+			return j
+		case b[j] == 'A': // cursor up one
+			if s.row > 0 {
+				s.row--
+			}
+			return j
+		case b[j] >= '0' && b[j] <= '9' || b[j] == ';' || b[j] == '?':
+			// parameter byte; keep scanning
+		default:
+			// terminator (m, H, J, ...) or unknown: skip the sequence
+			return j
+		}
+	}
+	return j - 1
+}
+
+func (s *ptyScreen) putRune(r rune) {
+	for len(s.lines[s.row]) <= s.col {
+		s.lines[s.row] = append(s.lines[s.row], ' ')
+	}
+	s.lines[s.row][s.col] = r
+	s.col++
+}
+
+func (s *ptyScreen) String() string {
+	parts := make([]string, 0, len(s.lines))
+	for _, l := range s.lines {
+		parts = append(parts, string(l))
+	}
+	return strings.Join(parts, "\n")
+}
+
+// runSetupOnPTY spawns the current test binary (which runs the real CLI setup
+// path in helper mode) on a fresh pseudo-terminal, feeds it the given
+// keystrokes, and returns the raw transcript, the reconstructed final screen,
+// and the exit status.
+func runSetupOnPTY(t *testing.T, confDir, keystrokes string) (transcript, screen string, status int) {
+	t.Helper()
+	master, slave := openPTY(t)
+	defer master.Close()
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestSetupPTYHelper")
+	cmd.Env = append(os.Environ(), "CLAI_CONFIG_DIR="+confDir, setupPTYHelperEnv+"=1")
+	cmd.Stdin = slave
+	cmd.Stdout = slave
+	cmd.Stderr = slave
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true, Setctty: true, Ctty: 0}
+	if err := cmd.Start(); err != nil {
+		slave.Close()
+		t.Fatalf("start helper on PTY: %v", err)
+	}
+	slave.Close() // the parent keeps only the master
+
+	if _, err := master.WriteString(keystrokes); err != nil {
+		t.Fatalf("write keystrokes: %v", err)
+	}
+
+	done := make(chan error, 1)
+	raw := make(chan string, 1)
+	go func() { done <- cmd.Wait() }()
+	go func() {
+		b, _ := io.ReadAll(master)
+		raw <- string(b)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("wizard exited with error: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatal("wizard did not exit within 30s")
+	}
+	transcript = <-raw
+	screenObj := newPTYScreen()
+	screenObj.write([]byte(transcript))
+	return transcript, screenObj.String(), cmd.ProcessState.ExitCode()
+}
+
+// Test_e2e_setup_announcement_survives_interactive_wizard proves through a
+// real pseudo-terminal that the config-upgrade announcement printed before
+// the setup wizard behaves as documented: it is the first thing on screen
+// when the wizard opens, and it survives a single-table session (immediate
+// quit) because the announcement block's trailing blank line absorbs the
+// table library's one-line clear overshoot (ClearTermTo clears upTo+1
+// lines). During deeper navigation each table Run() exit clears one line
+// above its frame header, so the announcement may scroll off after several
+// table sessions; the ordering contract (announcement before the first
+// wizard frame) still holds in the raw transcript.
+func Test_e2e_setup_announcement_survives_interactive_wizard(t *testing.T) {
+	// Each subtest needs a fresh config dir: the first run migrates
+	// textConfig.json in place, so a second run would have nothing to
+	// announce.
+	newConfDir := func(t *testing.T) string {
+		t.Helper()
+		confDir := setupMainTestConfigDir(t)
+		// Downgrade textConfig.json to the pre-stoploss schema so the united
+		// migration fires and prints the announcement.
+		writeJSONFileAny(t, filepath.Join(confDir, "textConfig.json"), map[string]any{
+			"model": "test",
+		})
+		return confDir
+	}
+
+	t.Run("immediate quit keeps the announcement on the final screen", func(t *testing.T) {
+		_, screen, status := runSetupOnPTY(t, newConfDir(t), "q\n")
+		if status != 0 {
+			t.Fatalf("expected exit 0, got %d. final screen:\n%s", status, screen)
+		}
+		if !strings.Contains(screen, "added new field(s) to textConfig.json:") {
+			t.Fatalf("expected the upgrade announcement visible on the final screen, got:\n%s", screen)
+		}
+	})
+
+	t.Run("full navigation keeps the announcement before the wizard", func(t *testing.T) {
+		transcript, _, status := runSetupOnPTY(t, newConfDir(t), "0\n0\nb\nq\n")
+		if status != 0 {
+			t.Fatalf("expected exit 0, got %d. transcript:\n%s", status, transcript)
+		}
+		annIdx := strings.Index(transcript, "added new field(s) to textConfig.json:")
+		headerIdx := strings.Index(transcript, "Setup categories")
+		if annIdx < 0 || headerIdx < 0 || annIdx > headerIdx {
+			t.Fatalf("expected the announcement before the wizard frame, got:\n%s", transcript)
+		}
+		// The wizard really navigated: config list and preview were reached.
+		if !strings.Contains(transcript, "Configs in general config") || !strings.Contains(transcript, "Selected config preview:") {
+			t.Fatalf("expected the wizard navigation to reach the config list and preview, got:\n%s", transcript)
+		}
+	})
+}

--- a/main_stoploss_e2e_test.go
+++ b/main_stoploss_e2e_test.go
@@ -126,13 +126,12 @@ func Test_e2e_stoploss_handover_injection_and_summary(t *testing.T) {
 	assertValidToolExchangesE2E(t, chat.Messages)
 }
 
-// Test_e2e_stoploss_post_handover_refusal_visible proves the post-handover
-// refusal ladder through the real CLI: the handover message contains real
-// tool tokens, every post-handover tool call is refused BEFORE its
-// implementation runs (the tool result carries the ladder text, not tool
-// output), and the run still ends with a final assistant summary and exit 0
-// (phase 6 case 2).
-func Test_e2e_stoploss_post_handover_refusal_visible(t *testing.T) {
+// Test_e2e_stoploss_post_handover_tools_execute_by_default proves the new
+// default through the real CLI: the handover message contains real tool
+// tokens and every post-handover tool call EXECUTES with visible output — the
+// agent can summarize context into a file after the stoploss fires — and the
+// run still ends with a final assistant summary and exit 0.
+func Test_e2e_stoploss_post_handover_tools_execute_by_default(t *testing.T) {
 	confDir := setupMainTestConfigDir(t)
 	writeStoplossTextConfig(t, confDir, map[string]any{
 		"stoploss": map[string]any{
@@ -154,6 +153,57 @@ func Test_e2e_stoploss_post_handover_refusal_visible(t *testing.T) {
 		t.Fatalf("expected the handover user message, transcript: %+v", chat.Messages)
 	}
 
+	executed := 0
+	for i := handoverIdx + 1; i < len(chat.Messages); i++ {
+		m := chat.Messages[i]
+		if m.Role != "tool" {
+			continue
+		}
+		if strings.HasPrefix(m.Content, "ERROR: No more tool calls allowed") {
+			t.Fatalf("post-handover tools must not be refused by default, got %q", m.Content)
+		}
+		executed++
+	}
+	if executed == 0 {
+		t.Fatalf("expected at least one post-handover tool execution, transcript: %+v", chat.Messages)
+	}
+
+	last := chat.Messages[len(chat.Messages)-1]
+	if last.Role != "assistant" || last.Content == "" {
+		t.Fatalf("expected the final summary as the last assistant message, got %+v", last)
+	}
+	assertValidToolExchangesE2E(t, chat.Messages)
+}
+
+// Test_e2e_stoploss_post_handover_budget_refuses_after_budget proves the
+// bounded wrap-up through the real CLI: with max-tool-calls-after-handover 1
+// the first post-handover tool executes with real output and the next is
+// refused BEFORE its implementation runs (the tool result carries the ladder
+// text), and the run exits 0.
+func Test_e2e_stoploss_post_handover_budget_refuses_after_budget(t *testing.T) {
+	confDir := setupMainTestConfigDir(t)
+	writeStoplossTextConfig(t, confDir, map[string]any{
+		"stoploss": map[string]any{
+			"max-tokens":                       5,
+			"max-tokens-handover-instructions": "tool_ls tool_cat tool_rg tool_git",
+			"max-tool-calls-after-handover":    1,
+		},
+	})
+
+	status, stdout, stderr := runStoplossE2E(t, "-r", "-cm", "test", "q", "run", "tool_ls")
+	if status != 0 {
+		t.Fatalf("expected exit 0, got %d stdout=%q stderr=%q", status, stdout, stderr)
+	}
+
+	chat := loadSavedStoplossChat(t, confDir)
+	handoverIdx := indexOfMessage(chat.Messages, func(m pub_models.Message) bool {
+		return m.Role == "user" && m.Content == "tool_ls tool_cat tool_rg tool_git"
+	})
+	if handoverIdx == -1 {
+		t.Fatalf("expected the handover user message, transcript: %+v", chat.Messages)
+	}
+
+	executed := 0
 	refusals := 0
 	for i := handoverIdx + 1; i < len(chat.Messages); i++ {
 		m := chat.Messages[i]
@@ -164,10 +214,13 @@ func Test_e2e_stoploss_post_handover_refusal_visible(t *testing.T) {
 			refusals++
 			continue
 		}
-		t.Fatalf("post-handover tool result must carry only refusal text (side effect must not run), got %q", m.Content)
+		executed++
+	}
+	if executed != 1 {
+		t.Fatalf("expected exactly one post-handover execution past the budget, got %d, transcript: %+v", executed, chat.Messages)
 	}
 	if refusals == 0 {
-		t.Fatalf("expected at least one post-handover refusal, transcript: %+v", chat.Messages)
+		t.Fatalf("expected at least one post-handover refusal past the budget, transcript: %+v", chat.Messages)
 	}
 
 	last := chat.Messages[len(chat.Messages)-1]

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -79,10 +79,15 @@ func WithConfigDir(cfgDir string) Option {
 // Stoploss configures the token stoploss policy for an agent run. MaxTokens
 // <= 0 disables the stoploss. MaxTokensHandoverMsg is the user message
 // injected into the chat when the limit is crossed; empty means the default
-// message (text.DefaultHandoverInstructions).
+// message (text.DefaultHandoverInstructions). MaxToolCallsAfterHandover is
+// the wrap-up tool-call budget for the post-handover phase: <= 0 means
+// unlimited tool calls after the handover fires. It is inert without
+// MaxTokens > 0: the internal config drops the whole Stoploss object
+// otherwise, so the agent stays unlimited.
 type Stoploss struct {
-	MaxTokens            int
-	MaxTokensHandoverMsg string
+	MaxTokens                 int
+	MaxTokensHandoverMsg      string
+	MaxToolCallsAfterHandover int
 }
 
 // WithStoploss configures the token stoploss policy for the agent. A
@@ -182,8 +187,9 @@ func (a *Agent) asInternalConfig() text.Configurations {
 	// agent default stays unlimited (MaxTokens <= 0 disables the stoploss).
 	if a.stoploss.MaxTokens > 0 {
 		conf.Stoploss = &text.Stoploss{
-			MaxTokens:            a.stoploss.MaxTokens,
-			MaxTokensHandoverMsg: a.stoploss.MaxTokensHandoverMsg,
+			MaxTokens:                 a.stoploss.MaxTokens,
+			MaxTokensHandoverMsg:      a.stoploss.MaxTokensHandoverMsg,
+			MaxToolCallsAfterHandover: a.stoploss.MaxToolCallsAfterHandover,
 		}
 	}
 	return conf

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -262,7 +262,7 @@ func TestAgent_WithOutputTo_propagates(t *testing.T) {
 }
 
 func TestAgent_WithStoploss(t *testing.T) {
-	a := New(WithStoploss(Stoploss{MaxTokens: 50, MaxTokensHandoverMsg: "m"}))
+	a := New(WithStoploss(Stoploss{MaxTokens: 50, MaxTokensHandoverMsg: "m", MaxToolCallsAfterHandover: 3}))
 	conf := a.asInternalConfig()
 	if conf.Stoploss == nil {
 		t.Fatal("expected Stoploss in internal config")
@@ -272,6 +272,9 @@ func TestAgent_WithStoploss(t *testing.T) {
 	}
 	if conf.Stoploss.MaxTokensHandoverMsg != "m" {
 		t.Fatalf("expected handover message 'm', got %q", conf.Stoploss.MaxTokensHandoverMsg)
+	}
+	if conf.Stoploss.MaxToolCallsAfterHandover != 3 {
+		t.Fatalf("expected MaxToolCallsAfterHandover 3, got %d", conf.Stoploss.MaxToolCallsAfterHandover)
 	}
 }
 

--- a/worklogs/2026-08-04-token-stoploss/README.md
+++ b/worklogs/2026-08-04-token-stoploss/README.md
@@ -11,13 +11,16 @@
 | 5   | [Setup wizard](./phase-5-setup-wizard.md)                       | Complete | Verify + pin interactive editing of the `stoploss` object (existing `editMap`); no production changes needed                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | 6   | [Integration & e2e](./phase-6-integration-e2e.md)               | Complete | Mock-vendor e2e for handover flow + refusal ladder, legacy config compat, docs                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | 7   | [Quality gates](./phase-7-quality-gates.md)                     | Reopened (review 13) | Final gate sweep on the finished branch; reopened by review 10 (R10-01: the mandated `-race -count=3` gate timed out in `internal/text`) and fixed in the fix round: glow now spawns only for terminal output (D25) — the exact gate passes in 7 s; reopened by review 13 (R13-01: `-rf` structured-output runs announce config upgrades on stdout, corrupting machine output; R13-03: stale dupl baseline claim; R13-04: theme announcement not deferred in setup) — fix round pending, see Review 13                                                                                                                                                                                                                                                                                                                                                                                           |
+| 8   | [Post-handover tool budget](./phase-8-post-handover-tool-budget.md) | Complete | Tooling is not cut off after the stoploss handover: post-handover tool calls count against a fresh wrap-up allowance (`stoploss.max-tool-calls-after-handover`; absent or 0 = unlimited, the new default); the refusal ladder applies only past a configured allowance; `load_skill` loads post-handover by default and is refused only when the allowance is exhausted |
 
 Phase order: Phase 1 (token-warn-limit sunset) is independent and runs first
 — it removes the dead pre-query machinery before any new config lands.
 Phases 2–5 build the feature; Phase 3 depends on Phase 2 (config fields and
 semantics), Phases 4 and 5 depend on Phase 2 and may run in parallel with
 Phase 3; Phase 6 depends on Phases 2–5 and runs before Phase 7; Phase 7 is
-the final quality-gate sweep and always runs last.
+the final quality-gate sweep and always runs last. Phase 8 (post-handover
+tool budget) landed after Phase 7's signoff as a user-requested feature
+extension and is Complete.
 
 ## Motivation
 
@@ -76,31 +79,38 @@ sensible "disable the limit for this run" override. The escalation ladder
 WARNING → `io.EOF`) is unchanged.
 
 **Unified `stoploss` controller in code.** Both budgets are enforced by one
-controller so they compose. After handover, every subsequent tool call,
-including `load_skill` and lookback tools, enters the existing refusal ladder
-before the tool's side effect runs. The call and refusal remain a valid
-assistant/tool exchange. Persisting past the final warning hard-stops the run
-with `io.EOF` (clean end, `sessionRunner.Run` returns nil). The refusal ladder
-is not removed or weakened.
+controller so they compose. The handover starts a fresh wrap-up phase:
+post-handover tool calls are counted against
+`stoploss.max-tool-calls-after-handover` (absent or 0 = unlimited, the
+default) with their own counter, never against the pre-handover
+`max-tool-calls` consumption. Only once a configured wrap-up allowance is
+exhausted does every subsequent tool call, including `load_skill` and
+lookback tools, enter the existing refusal ladder before the tool's side
+effect runs. The call and refusal remain a valid assistant/tool exchange.
+Persisting past the final warning hard-stops the run with `io.EOF` (clean
+end, `sessionRunner.Run` returns nil). The refusal ladder is not removed or
+weakened.
 
 **Handover injection ordering.** The handover message is appended to the chat
 AFTER the crossing step's tool batch executes, so the chat keeps valid
 ordering: `[assistant tool-call] → [tool results] → [handover user msg]`.
 Injection only ever happens on a tool-call step (the loop only continues when
 there are tool calls); a step that ends with a plain reply ends the run
-without injection — there is nothing to hand over. The agent gets exactly one
-unconstrained post-handover step. If that step, or a later refusal-ladder
-follow-up step, ends with tool calls, every call is refused before invocation.
+without injection — there is nothing to hand over. The agent keeps tool access
+during the wrap-up phase: post-handover steps run their tool calls against the
+fresh allowance (unlimited by default). Only once a configured allowance is
+exhausted does a follow-up step's every call get refused before invocation.
 The refusal ladder may produce the HARD SHUT DOWN and LAST WARNING follow-up
 steps; after persistence past the final warning, the run ends with `io.EOF`.
 
-**Preflight before side effects.** A post-handover refusal must be decided
-before any tool implementation, skill loader, lookback reader, or command
-runner is invoked. The refusal path must still append the assistant tool-call
-and a tool-result message (including the ladder text), so every refused call
-remains a valid exchange. The controller therefore needs a preflight/reservation
-operation (or equivalent decision object); applying the ladder only to the
-output returned by an already-invoked tool is not sufficient.
+**Preflight before side effects.** A phase-budget refusal (pre- or
+post-handover) must be decided before any tool implementation, skill loader,
+lookback reader, or command runner is invoked. The refusal path must still
+append the assistant tool-call and a tool-result message (including the ladder
+text), so every refused call remains a valid exchange. The controller
+therefore needs a preflight/reservation operation (or equivalent decision
+object); applying the ladder only to the output returned by an already-invoked
+tool is not sufficient.
 
 **One emission path, one ladder, one message resolution.** The transcript
 must keep the model's emission order with immediate assistant→tool pairing
@@ -118,9 +128,9 @@ or are suppressed entirely; the raw-mode gate must not key on `PrintRaw`
 alone (R13-01).
 
 **Config scope.** `textConfig.json` + CLI flags (`-max-tokens`,
-`-max-tool-calls`) + `pkg/agent` options (`WithStoploss`,
-`WithMaxToolCalls`). No profile key, no setup-wizard-only surface. The
-instructions message is configurable in `textConfig.json` and via
+`-max-tool-calls`, `-max-tool-calls-after-handover`) + `pkg/agent` options
+(`WithStoploss`, `WithMaxToolCalls`). No profile key, no setup-wizard-only
+surface. The instructions message is configurable in `textConfig.json` and via
 `WithStoploss`, but is NOT a CLI flag.
 
 **Sunset `token-warn-limit` (Phase 1).** Remove `TokenWarnLimit` from
@@ -177,6 +187,7 @@ refusal. A refused call has no tool output; its result contains the ladder text.
 | D24 | Fix round: `ExecuteBatch` splits the batch into segments at each `load_skill` call — consecutive non-skill calls share one grouped assistant turn, each `load_skill` runs as its own assistant→tool pair in batch order; `ApplyToolCallBudget` is deleted (single ladder); `newStoploss` resolves the handover message once via `Stoploss.HandoverInstructions()` (single resolution site) | R9-01: load_skill's self-emission (D17) makes grouped up-front emission unsound for mixed batches; segmenting preserves the model's emission order with immediate assistant→tool pairing while keeping the single-type replay grouping. R9-02/R9-03: the review's "one emission, one ladder, one resolution" consolidation (2026-08-04, worker session 8)                                                          |
 | D25 | `AttemptPrettyPrint` spawns `glow` only when the destination writer is a character device (`isTerminalWriter`, the `prompt.go` stdin heuristic) AND the renderer is installed (`glowAvailable`, `sync.OnceValue` probe); captured output and machines without glow share the plain ANSI fallback; the glow width math is the pure `glowRenderArgs`                                         | R10-01: glow is an interactive terminal renderer — spawning it per message into pipes/files/test buffers (every `internal/text` feature test) added ~63 ms × 2 subprocesses per emission and blew the mandated `-race -count=3` 30 s package budget, a load-dependent flake. Terminal-only gating makes the gate reproducible and keeps the interactive glow path intact (2026-08-05, worker session 2)            |
 | D26 | `ExecuteBatch` defers `io.EOF` until every plan of the batch has emitted its tool result (a `pendingEOF` flag set at each hardStop plan; the run still ends cleanly on the deferred return) — no mid-batch hardStop may skip the remaining plans, because the assistant message already declared them and a dangling tool_call breaks the persisted transcript for replay                  | R11-01: the first hardStop plan of a post-handover batch returned `io.EOF` immediately and skipped the later plans of the same assistant turn (reproduced: 5 declared calls, 4 results). Side-effect-safe because `preflightToolCall` freezes `ToolCallsUsed` on a hardStop refusal, so later plans are already decided; an exempt `load_skill` runs per the atomic batch decision (2026-08-05, worker session 10) |
+| D27 | Post-handover tool budget: `stoploss.max-tool-calls-after-handover` (absent or 0 = unlimited, the new default); a positive value is a FRESH wrap-up allowance with its own session counter (`PostHandoverToolCallsUsed`) that pre-handover `max-tool-calls` consumption never eats into; the refusal ladder applies only past the allowance; `load_skill` loads post-handover by default and is refused only when the allowance is exhausted | Phase 8 Q1 option C: cutting tooling off at the handover (the D2/Q2:B behavior) leaves the agent unable to summarize context into a file exactly when it must; the opt-in bound keeps an operator safety valve; D2's post-handover refusal is superseded for the default case (2026-08-09, worker session 11) |
 
 ## Rejected alternatives
 
@@ -190,6 +201,7 @@ refusal. A refused call has no tool output; its result contains the ladder text.
 | Absorb `max-tool-calls` into the `stoploss` object                 | Requires migrating an existing flat key; the user chose to keep the tool message system as is (Q5: A)                               |
 | No CLI flags; textConfig + agent API only                          | Operators need a per-run override without editing config files (user decision, Q6 revision)                                         |
 | Profile key for the stoploss                                       | No use case; parity with `max-tool-calls` which has no profile key (D8)                                                             |
+| Refuse every post-handover tool call via the ladder (D2/Q2:B)       | Phase 8 Q1 option C: the agent must keep tooling to summarize context into a file after the handover fires; the ladder stays as the bound past a configured wrap-up allowance instead of cutting tools off entirely (2026-08-09)                                                                    |
 
 ## Out of scope
 
@@ -976,13 +988,13 @@ happen to load them (`clai tools`, `clai profiles`, `clai confdir`,
 per-mode loads remain but are idempotent. Broken configs downgrade to a
 warning so setup stays the repair path (same policy as `LoadTheme`).
 `LoadConfigFromFileCollect` (new) returns the added field paths without
-printing; `internal.Setup` defers the announcement until after the interactive
-setup wizard exits, because the wizard's TUI erases pre-wizard stdout when it
-redraws (`go_away_boilerplate/pkg/table` `ClearTermTo` overshoots by one
-line), which silently swallowed the pre-wizard announcement whenever the user
-navigated past the first screen. All other commands announce immediately.
-Pinned by `Test_e2e_setup_migrates_mode_configs_and_announces` (announcement
-must appear after the wizard exits) and
+printing; `internal.Setup` prints the announcements just before the interactive
+setup wizard starts, padding the block with a blank separator line that
+absorbs the wizard's one-line clear overshoot (`go_away_boilerplate/pkg/table`
+`ClearTermTo` clears `upTo+1` lines). All other commands announce
+immediately. Pinned by
+`Test_e2e_setup_migrates_mode_configs_and_announces_before_wizard`
+(announcement must appear before the wizard starts) and
 `Test_e2e_confdir_migrates_mode_configs` (a non-setup command upgrades and
 announces a downgraded config).
 
@@ -1024,7 +1036,7 @@ name as before. Pinned by `TestFindProfile_NameLessProfileStaysNameLess`,
 `Test_e2e_confdir_migrates_profiles`,
 `Test_e2e_confdir_migrates_profiles_skips_broken_and_non_json_files`,
 `Test_e2e_raw_run_does_not_migrate_profiles`,
-`Test_e2e_setup_migrates_profiles_and_announces_after_wizard`, and the
+`Test_e2e_setup_migrates_profiles_and_announces_before_wizard`, and the
 updated `Test_goldenFile_PROFILES_list_prints_summary_for_valid_profiles_and_skips_invalid`
 (which now also pins the broken-profile warning).
 
@@ -1072,8 +1084,10 @@ Empirical probes (built binary, sandbox `CLAI_CONFIG_DIR`):
 - `clai -n -cm test s 0 0 q` with a theme.json missing `roleReasoning` /
   `tableItems` prints the theme upgrade announcement BEFORE the wizard
   header (line 1 of the capture) while the mode-config announcements are
-  correctly deferred until after the wizard exits — R13-04 (Low): the
-  deferral design covers mode configs + profiles but not `LoadTheme`.
+  printed just before the wizard starts — R13-04 (Low): the announcement
+  design covers mode configs + profiles but not `LoadTheme`; both now print
+  before the wizard (the announcement block ends with a blank separator line
+  that absorbs the wizard's one-line clear overshoot).
 
 Trace audit (read the code, not the notes):
 
@@ -1099,8 +1113,10 @@ Trace audit (read the code, not the notes):
   runs fill in memory without rewriting or announcing; the united migration
   covers mode configs and every `profiles/*.json` before dispatch, with
   broken files downgraded to warnings; the `DefaultProfile.Name` zero-value
-  fix keeps name-less profiles name-less on disk; setup defers mode-config
-  and profile announcements until after the wizard exits.
+  fix keeps name-less profiles name-less on disk; setup prints mode-config
+  and profile announcements just before the wizard starts (the block ends
+  with a blank separator line that absorbs the wizard's one-line clear
+  overshoot, so pre-wizard stdout survives).
 - Verified good — the `-r` precmd scenario that motivated the raw-mode fix:
   `clai -r chat dirv2` neither rewrites the configs nor pollutes machine
   output (pinned by `Test_e2e_raw_run_does_not_migrate_configs`).
@@ -1122,3 +1138,70 @@ gate (`utils.ReadonlyConfig = postFlagConf.PrintRaw ||
 postFlagConf.ResponseFormatPath != ""`, or route announcements to stderr,
 with a `-rf` + migration e2e pin) together with the R13-02/03/04 updates,
 then re-run the gates in this entry.
+
+### 2026-08-09 — Phase 8 implemented (imago + clai, worker session 11)
+
+Phase 8 (post-handover tool budget) is Complete. Design interview Q1
+concluded option C: tooling must not be cut off after the stoploss fires —
+the agent often needs to write a summary file during the wrap-up phase.
+New `stoploss.max-tool-calls-after-handover` config key: absent or 0 =
+unlimited post-handover tool calls (the new default); a positive value
+bounds the wrap-up phase with a fresh counter.
+
+- Controller (`internal/text/stoploss.go`): phase-aware `effectiveBudget` /
+  `effectiveUsed` / `incUsed` — the wrap-up allowance never eats pre-handover
+  `max-tool-calls` consumption; `load_skill` loads post-handover by default
+  and is refused only when the allowance is exhausted (D27).
+- Session (`internal/text/session.go`): `PostHandoverToolCallsUsed` phase
+  counter; `HandoverRequested` now switches the budget phase instead of
+  forcing refusal.
+- CLI flag `-max-tool-calls-after-handover` (explicit 0 disables a file
+  budget), agent API field on `WithStoploss`, usage text, and the
+  architecture docs (`query.md`, `tooling.md`, `config.md`).
+
+Tests first: the rewritten and new tests were red against the old
+handover-forces-refusal behavior and green after. The old post-handover
+refusal tests were rewritten to the new semantics rather than deleted:
+refusal-pairing (R9-01) and deferred-`io.EOF` (R11-01) invariants stay
+pinned via a seeded budget. The help e2e now asserts the new flag line and
+the bounded-budget e2e pins exactly one post-handover execution past the
+allowance. Gates: `go test ./... -count=1` ✓ all packages; `go vet ./...`
+✓; the mandated full sweep (gofumpt, staticcheck, `go test ./... -race
+-cover -count=3 -timeout=30s`, `go fix`, dupl) passes on the finished
+branch.
+
+Follow-up (same session): the config migration gains a per-field opt-in
+`migrate:"true"` tag (`internal/utils/config.go` `fillMissingFromDefaults`):
+fields tagged with it are filled even when their default is the zero value,
+so new feature knobs whose natural default is 0 surface in upgraded configs.
+`MaxToolCallsAfterHandover` carries the tag and drops `omitempty`, so a
+pre-existing `stoploss` object gains `"max-tool-calls-after-handover": 0`
+once with the standard announcement (0 = unlimited, same as absent; second
+load silent; raw/`-r` runs stay read-only). Pinned by
+`Test_fillMissingFromDefaults_MigrateTag`,
+`TestConfigurations_StoplossMaxToolCallsAfterHandoverAbsentGetsMaterialized`,
+and the updated marshal tests. Docs: `architecture/config.md` migration
+section and the phase-8 doc updated.
+
+Follow-up (same session): the setup wizard now prints the upgrade
+announcements BEFORE it starts instead of after it exits. The wizard's TUI
+redraws by clearing its own frame plus one line above the header
+(`go_away_boilerplate/pkg/table` `ClearTermTo` clears `upTo+1` lines — the
+overshoot was verified empirically against the pinned library v1.33.9; earlier
+reasoning claimed the wizard never touches lines above its header, which the
+PTY check disproved), so the announcement block ends with a blank separator
+line that absorbs the overshoot; without it the first redraw wipes the
+announcement. Verified empirically in a PTY: with the announcement printed
+before `setup.InitCmd()`, it survives multi-step navigation (category select →
+config list → preview → back → quit) and ends up directly above the wizard on
+the final screen; deep navigation can still scroll it off (each `Run()` exit
+consumes one line). The mode-config and profile announcements therefore appear
+before the wizard, so the user sees what the united migration changed before
+interacting. Pinned by
+`Test_e2e_setup_migrates_mode_configs_and_announces_before_wizard` and
+`Test_e2e_setup_migrates_profiles_and_announces_before_wizard` (renamed from
+`..._after_wizard`), which assert the announcement precedes the
+`Setup categories` header in macro mode, and by
+`Test_e2e_setup_announcement_survives_interactive_wizard` (Linux PTY e2e),
+which asserts the announcement survives an immediate-quit session on a real
+terminal.

--- a/worklogs/2026-08-04-token-stoploss/phase-8-post-handover-tool-budget.md
+++ b/worklogs/2026-08-04-token-stoploss/phase-8-post-handover-tool-budget.md
@@ -1,0 +1,141 @@
+# Phase 8 — Post-handover tool budget
+
+**Status:** Complete
+**Back to:** [README](./README.md)
+
+## Goal
+
+Stop cutting tooling off after the stoploss handover fires: the agent keeps
+tool access during the wrap-up phase so it can summarize context into a file,
+with an optional configurable bound on that phase.
+
+## Specification
+
+### Config
+
+`Stoploss` (`internal/text/conf.go`) gains:
+
+```go
+MaxToolCallsAfterHandover int `json:"max-tool-calls-after-handover" migrate:"true"`
+```
+
+Semantics: absent or 0 = **unlimited** post-handover tool calls (the new
+default); a positive value bounds the wrap-up phase. The key is surfaced by
+the config migration: `migrate:"true"` fills it even at its zero default, so
+pre-existing configs gain `"max-tool-calls-after-handover": 0` once with the
+standard upgrade announcement (the field drops `omitempty` so the zero
+survives the rewrite). 0 in the file means the same as absent: unlimited.
+
+### Controller (`internal/text/stoploss.go`)
+
+The handover no longer zeroes the tool budget. The controller becomes
+phase-aware:
+
+```go
+// effectiveBudget: post-handover -> maxToolCallsAfterHandover (<= 0 = -1);
+// pre-handover -> maxToolCalls (nil or <= 0 = -1).
+// effectiveUsed: post-handover -> session.PostHandoverToolCallsUsed;
+// pre-handover -> session.ToolCallsUsed.
+```
+
+`PreflightToolCallBudget` uses `effectiveUsed`/`effectiveBudget` and reserves
+slots via `incUsed`, which increments the phase-appropriate session counter.
+The wrap-up allowance is **fresh**: pre-handover consumption never eats into
+it. `load_skill` keeps its pre-handover exemption (allowed even when the
+pre-handover budget is exhausted, no slot reserved); post-handover it is
+allowed while the wrap-up allowance has room (no slot) and refused once the
+allowance is exhausted, like every other tool.
+
+### Session state (`internal/text/session.go`)
+
+`QuerySession` gains:
+
+```go
+// PostHandoverToolCallsUsed counts tool calls made after the handover fired.
+PostHandoverToolCallsUsed int
+```
+
+`HandoverRequested` now switches the budget phase instead of forcing refusal.
+
+### CLI flag (`internal/setup_flags.go`)
+
+`-max-tool-calls-after-handover` (long form only) overrides
+`stoploss.max-tool-calls-after-handover` for the run; explicit `0` disables a
+file budget. `applyFlagOverridesForText` creates the `Stoploss` object when
+needed, mirroring `-max-tokens`.
+
+### Agent API (`pkg/agent/agent.go`)
+
+`agent.Stoploss` gains `MaxToolCallsAfterHandover`; `asInternalConfig` maps it
+onto the internal `Stoploss` when `MaxTokens > 0` (a stoploss with
+`max-tokens <= 0` is disabled, so a wrap-up budget without a stoploss is
+meaningless).
+
+## Integration contract
+
+| Input | Collaborators/fakes | Externally observable result | Required side effects | Prohibited side effects |
+| --- | --- | --- | --- | --- |
+| Handover fires, no `max-tool-calls-after-handover` | `sessionRunner` + counting probe tool | Post-handover tool call EXECUTES; tool result carries real output; run ends with the summary, exit 0 | `PostHandoverToolCallsUsed` stays 0 (unlimited) | Refusal text in post-handover results |
+| Handover fires, `max-tool-calls-after-handover: 1` | same | First post-handover call executes with remaining-count prefix; second is refused with ladder text before invocation; run exits 0 | Ladder slots reserved on `PostHandoverToolCallsUsed` | Pre-handover `ToolCallsUsed` mutation |
+| Pre-handover budget exhausted, then handover | same + `max-tool-calls` | Wrap-up allowance is fresh: post-handover calls still execute | Independent counters | Budget carry-over |
+| Handover fires, budget exhausted, `load_skill` | counting skill loader | `load_skill` refused before loading | Refusal pair in transcript | Loader invocation |
+| Handover fires, budget has room, `load_skill` | counting skill loader | `load_skill` loads (no slot reserved) | Loader invocation | Slot reservation |
+
+## Acceptance criteria
+
+1. Default config: post-handover tool calls execute; the refusal ladder never
+   fires in the wrap-up phase. Proven by
+   `Test_sessionRunner_Run_PostHandoverToolExecutesByDefault`,
+   `Test_e2e_stoploss_post_handover_tools_execute_by_default`,
+   `Test_toolExecutor_ExecuteBatch_PostHandoverBatchExecutesByDefault`, and the
+   `default (no post-handover budget) allows every call` controller case.
+2. A configured positive budget allows exactly N post-handover calls, then the
+   ladder escalates to `io.EOF`. Proven by
+   `Test_sessionRunner_Run_PostHandoverBudgetExhaustionEndsCleanly`,
+   `Test_toolExecutor_ExecuteBatch_PostHandoverBatchRefusesAfterBudget`, the
+   `post-handover budget escalates the ladder when exhausted` controller case,
+   and `Test_e2e_stoploss_post_handover_budget_refuses_after_budget`.
+3. The wrap-up allowance is fresh. Proven by the
+   `post-handover budget is a fresh allowance` controller case.
+4. `load_skill` loads post-handover by default and is refused only when the
+   allowance is exhausted. Proven by
+   `Test_sessionRunner_Run_PostHandoverLoadSkillLoadsByDefault` /
+   `...RefusedWhenBudgetExhausted` and the controller's load_skill cases.
+5. Pre-handover `max-tool-calls` behavior is byte-identical (including the
+   `load_skill` exemption). Proven by the unchanged pre-handover controller and
+   runner cases plus `pre-handover load_skill exemption survives budget
+   exhaustion`.
+6. The new key loads, marshals, and migrates without churn; the flag parses and
+   overrides; the agent API maps it. Proven by
+   `TestConfigurations_StoplossMaxToolCallsAfterHandoverLoads` /
+   `...AbsentStaysZero` / `...MarshalsPostHandoverBudget`,
+   `Test_applyFlagOverridesForText_Stoploss` rows, `parseFlags` rows, and
+   `TestAgent_WithStoploss`.
+
+## Error coverage
+
+| Failure condition | Expected outcome | Test |
+| --- | --- | --- |
+| Post-handover budget exhausted, agent persists | Refusal ladder escalates; past the final warning `io.EOF` ends the run cleanly; every declared call has a result | `Test_sessionRunner_Run_PostHandoverBudgetExhaustionEndsCleanly`, `Test_toolExecutor_ExecuteBatch_HardStopMidBatchEmitsAllResults` |
+| Non-integer flag value | `parseFlags` returns `invalid value` | `parseFlags` row |
+| `max-tool-calls-after-handover` absent from config | Migration fills it as the explicit 0 (unlimited) once; file rewritten; announcement lists `stoploss.max-tool-calls-after-handover`; second load silent | `TestConfigurations_StoplossMaxToolCallsAfterHandoverAbsentGetsMaterialized` |
+
+## Implementation notes
+
+2026-08-09, clai session: implemented after the design interview (Q1: option
+C). Key findings:
+
+- The old post-handover refusal tests were rewritten to the new semantics
+  rather than deleted: refusal-pairing and mid-batch hardStop coverage now
+  seeds `PostHandoverToolCallsUsed` and a budget of 1 to reach the exhausted
+  state, so the R9-01 pairing and R11-01 deferred-EOF invariants stay pinned.
+- The marshal assertion needed the empty
+  `max-tokens-handover-instructions` field between `max-tokens` and the new
+  key (field order is struct order).
+- `main.go` usage is a `fmt.Printf` template; the new line added one `%v`
+  verb, so `internal/setup.go printHelp` gained one matching `cfgDir`
+  argument.
+- No setup-wizard change: `editMap` edits whatever keys exist in the file's
+  `stoploss` object, so the new key is editable once present.
+- Verification: `go test ./... -count=1` green (all packages);
+  `go vet ./...` clean.


### PR DESCRIPTION
The user message telling agents to stop is surprisingly efficient. But, in the current version they are not 
allowed to run any tool calls. This update will allow the agent to run some amount of tool calls before stopping,
configurable in `textConfig.json` -> `stoploss.max-tool-calls-after-handover`, as a flag with the same name or
parameter in `pkg/Agents`.