### PR TITLE
feat: Expose agent runtime stats on `pkg/agent`

### DIFF
--- a/internal/text/call_usage_recorder.go
+++ b/internal/text/call_usage_recorder.go
@@ -1,11 +1,23 @@
 package text
 
-import "context"
+import (
+	"context"
 
-type CallUsageRecorder interface {
-	Record(context.Context, CompletedModelCall) error
-}
+	pub_models "github.com/baalimago/clai/pkg/text/models"
+)
 
+// The recorder types are canonical in pkg/text/models (worklog
+// 26-08-11-clai-prometheus-metrics). The aliases keep internal references
+// unchanged while exposing the seam to embedded consumers through the
+// public package.
+type (
+	CallUsageRecorder  = pub_models.CallUsageRecorder
+	CompletedModelCall = pub_models.CompletedModelCall
+	ToolCallRecorder   = pub_models.ToolCallRecorder
+	ToolCall           = pub_models.ToolCall
+)
+
+// noopCallUsageRecorder keeps today's behavior when no recorder is configured.
 type noopCallUsageRecorder struct{}
 
 func (noopCallUsageRecorder) Record(context.Context, CompletedModelCall) error {

--- a/internal/text/conf.go
+++ b/internal/text/conf.go
@@ -72,6 +72,16 @@ type Configurations struct {
 	// MaxTokens <= 0 disables the stoploss (no handover injection).
 	Stoploss *Stoploss `json:"stoploss,omitempty"`
 
+	// UsageRecorder receives one CompletedModelCall per model step of a
+	// session (worklog 26-08-11-clai-prometheus-metrics). Nil keeps the
+	// noop path; a Record error is logged by the session runner and never
+	// aborts the run.
+	UsageRecorder pub_models.CallUsageRecorder `json:"-"`
+	// ToolCallRecorder receives one ToolCall per tool invocation. Nil
+	// keeps the noop path; a RecordToolCall error is logged and never
+	// aborts the run.
+	ToolCallRecorder pub_models.ToolCallRecorder `json:"-"`
+
 	// Out writer. Normally stdout, but may also be a file when invoked as a package
 	Out io.Writer `json:"-"`
 

--- a/internal/text/querier.go
+++ b/internal/text/querier.go
@@ -108,9 +108,12 @@ type Querier[C models.StreamCompleter] struct {
 	costMgrRdyChan    <-chan struct{}
 	costMgrErrChan    <-chan error
 	callUsageRecorder CallUsageRecorder
-	skillLoader       SkillLoader
-	baseTools         map[string]pub_models.LLMTool
-	registeredTools   map[string]struct{}
+	// toolCallRecorder receives one ToolCall per tool invocation of the
+	// session. Nil keeps the noop path (worklog 26-08-11-clai-prometheus-metrics).
+	toolCallRecorder ToolCallRecorder
+	skillLoader      SkillLoader
+	baseTools        map[string]pub_models.LLMTool
+	registeredTools  map[string]struct{}
 }
 
 func (q *Querier[C]) SuppressCompletionNotification() bool {

--- a/internal/text/querier_setup.go
+++ b/internal/text/querier_setup.go
@@ -212,6 +212,8 @@ func NewQuerier[C models.StreamCompleter](ctx context.Context, userConf Configur
 	querier.toolOutputRuneLimit = userConf.ToolOutputRuneLimit
 	querier.maxToolCalls = userConf.MaxToolCalls
 	querier.stoploss = userConf.Stoploss
+	querier.callUsageRecorder = userConf.UsageRecorder
+	querier.toolCallRecorder = userConf.ToolCallRecorder
 	querier.out = output
 	// MCP server stderr lines follow the same display policy as the session:
 	// rolling output buffers them into the window, raw/structured output keeps

--- a/internal/text/session.go
+++ b/internal/text/session.go
@@ -39,17 +39,6 @@ type QuerySession struct {
 	LineCount           int
 }
 
-type CompletedModelCall struct {
-	StepIndex      int
-	Model          string
-	StartedAt      time.Time
-	FinishedAt     time.Time
-	Usage          *pub_models.Usage
-	EndedWithTool  bool
-	EndedWithReply bool
-	EndedWithStop  bool
-}
-
 func (s *QuerySession) PendingTextString() string {
 	return s.PendingText.String()
 }

--- a/internal/text/tool_executor.go
+++ b/internal/text/tool_executor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/baalimago/clai/internal/debugflags"
@@ -143,9 +144,39 @@ func (e toolExecutor[C]) runPlannedCall(ctx context.Context, session *QuerySessi
 			out = res
 		}
 	} else {
+		startedAt := time.Now()
 		out = tools.Invoke(ctx, plan.call)
+		e.recordToolCall(ctx, plan.call.Name, startedAt, out)
 	}
 	return e.emitToolResult(session, plan.call, plan.prefix+out)
+}
+
+// recordToolCall reports one executed tool invocation to the configured
+// recorder. A nil recorder keeps the noop path; a recorder error is logged
+// and never propagated — telemetry must not break the agent loop.
+func (e toolExecutor[C]) recordToolCall(ctx context.Context, name string, startedAt time.Time, out string) {
+	rec := e.querier.toolCallRecorder
+	if rec == nil {
+		return
+	}
+	if err := rec.RecordToolCall(ctx, ToolCall{
+		Name:       name,
+		StartedAt:  startedAt,
+		FinishedAt: time.Now(),
+		Err:        toolCallError(out),
+	}); err != nil {
+		ancli.Warnf("failed to record tool call: %v", err)
+	}
+}
+
+// toolCallError derives a tool failure from its output string. tools.Invoke
+// folds errors into the output using the "ERROR: " convention, so the
+// recorder observes failures without changing Invoke's signature.
+func toolCallError(out string) error {
+	if strings.HasPrefix(out, "ERROR: ") {
+		return errors.New(out)
+	}
+	return nil
 }
 
 // emitAssistantToolCall prints the user-facing assistant tool-call turn and

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -29,6 +29,12 @@ type Agent struct {
 	stoploss       Stoploss
 	responseFormat *models.ResponseFormat
 
+	// usageRecorder receives one CompletedModelCall per model step of every
+	// query; toolCallRecorder receives one ToolCall per tool invocation. Nil
+	// keeps clai's noop paths (worklog 26-08-11-clai-prometheus-metrics).
+	usageRecorder    models.CallUsageRecorder
+	toolCallRecorder models.ToolCallRecorder
+
 	querierCreator func(ctx context.Context, conf text.Configurations) (priv_models.Querier, error)
 
 	out io.Writer
@@ -160,6 +166,26 @@ func WithCmdBanList(entries ...string) Option {
 	}
 }
 
+// WithUsageRecorder registers a CallUsageRecorder that receives one
+// CompletedModelCall per model step of every query. Nil (the default)
+// keeps clai's noop path: no recording, no behavior change. A Record error
+// is logged by the session runner and never aborts the run.
+func WithUsageRecorder(rec models.CallUsageRecorder) Option {
+	return func(a *Agent) {
+		a.usageRecorder = rec
+	}
+}
+
+// WithToolCallRecorder registers a ToolCallRecorder that receives one
+// ToolCall per tool invocation of every query. Nil (the default) keeps
+// the noop path. A RecordToolCall error is logged and never aborts the
+// run.
+func WithToolCallRecorder(rec models.ToolCallRecorder) Option {
+	return func(a *Agent) {
+		a.toolCallRecorder = rec
+	}
+}
+
 // WithResponseFormat configures structured output for the agent.
 // Supports "json_object" and "json_schema" types.
 func WithResponseFormat(rf models.ResponseFormat) Option {
@@ -181,6 +207,8 @@ func (a *Agent) asInternalConfig() text.Configurations {
 		RequestedToolGlobs: a.toolGlobs,
 		CmdBan:             a.cmdBan,
 		ResponseFormat:     a.responseFormat,
+		UsageRecorder:      a.usageRecorder,
+		ToolCallRecorder:   a.toolCallRecorder,
 		Out:                a.out,
 	}
 	// A zero-value Stoploss must not create a non-nil internal pointer: the

--- a/pkg/agent/recorder.go
+++ b/pkg/agent/recorder.go
@@ -1,0 +1,16 @@
+package agent
+
+import (
+	"github.com/baalimago/clai/pkg/text/models"
+)
+
+// The recorder types are canonical in pkg/text/models; these aliases let
+// embedded consumers (e.g. sakfraga) reference the whole recorder surface
+// through a single pkg/agent import (worklog
+// 26-08-11-clai-prometheus-metrics).
+type (
+	CallUsageRecorder  = models.CallUsageRecorder
+	CompletedModelCall = models.CompletedModelCall
+	ToolCallRecorder   = models.ToolCallRecorder
+	ToolCall           = models.ToolCall
+)

--- a/pkg/agent/recorder_test.go
+++ b/pkg/agent/recorder_test.go
@@ -1,0 +1,265 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/baalimago/clai/pkg/text/models"
+	pkgtools "github.com/baalimago/clai/pkg/tools"
+)
+
+// recordingUsageRecorder is a thread-safe fake CallUsageRecorder. err, when
+// set, is returned from every Record to exercise the error-absorption path.
+type recordingUsageRecorder struct {
+	mu    sync.Mutex
+	calls []models.CompletedModelCall
+	err   error
+}
+
+func (r *recordingUsageRecorder) Record(_ context.Context, call models.CompletedModelCall) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, call)
+	return r.err
+}
+
+func (r *recordingUsageRecorder) recorded() []models.CompletedModelCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]models.CompletedModelCall(nil), r.calls...)
+}
+
+// recordingToolRecorder is a thread-safe fake ToolCallRecorder. err, when
+// set, is returned from every RecordToolCall to exercise the
+// error-absorption path.
+type recordingToolRecorder struct {
+	mu    sync.Mutex
+	calls []models.ToolCall
+	err   error
+}
+
+func (r *recordingToolRecorder) RecordToolCall(_ context.Context, call models.ToolCall) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, call)
+	return r.err
+}
+
+func (r *recordingToolRecorder) recorded() []models.ToolCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]models.ToolCall(nil), r.calls...)
+}
+
+// The pkg/agent aliases must satisfy the canonical interfaces: the recorder
+// surface is usable through a single pkg/agent import (worklog
+// 26-08-11-clai-prometheus-metrics).
+var (
+	_ CallUsageRecorder = (*recordingUsageRecorder)(nil)
+	_ ToolCallRecorder  = (*recordingToolRecorder)(nil)
+)
+
+// TestAgent_WithUsageRecorder proves the usage-recorder seam end to end: a
+// fake recorder registered via WithUsageRecorder receives one
+// CompletedModelCall per model step of a real agent run (mock vendor), with
+// ordered timestamps, usage, and the EndedWith* flags populated. The mock
+// vendor does not implement ModelNamer, so the recorded model name is empty;
+// the recorder contract must not depend on it.
+func TestAgent_WithUsageRecorder(t *testing.T) {
+	t.Setenv("CLAI_DISABLE_COST_ERR_LOG_GOROUTINE", "1")
+
+	rec := &recordingUsageRecorder{}
+	a := newCmdBanAgent(t,
+		WithModel("mock_test"),
+		WithUsageRecorder(rec),
+		WithOutputTo(io.Discard),
+	)
+
+	queryCmdBanAgent(t, &a, "please reply")
+
+	calls := rec.recorded()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 recorded model call, got %d", len(calls))
+	}
+	call := calls[0]
+	if call.Usage == nil || call.Usage.TotalTokens == 0 {
+		t.Fatalf("expected non-zero usage, got %+v", call.Usage)
+	}
+	// The mock vendor terminates every step with a stop event, so the
+	// recorded step reports EndedWithStop (not EndedWithReply).
+	if !call.EndedWithStop {
+		t.Fatalf("expected EndedWithStop on the mock's reply step, got %+v", call)
+	}
+	if call.EndedWithTool || call.EndedWithReply {
+		t.Fatalf("expected EndedWithTool/EndedWithReply false on the mock's reply step, got %+v", call)
+	}
+	if call.StepIndex != 0 {
+		t.Fatalf("expected step index 0, got %d", call.StepIndex)
+	}
+	if call.StartedAt.IsZero() || call.FinishedAt.IsZero() || !call.StartedAt.Before(call.FinishedAt) {
+		t.Fatalf("expected ordered timestamps, got started=%v finished=%v", call.StartedAt, call.FinishedAt)
+	}
+	if call.Model != "" {
+		t.Fatalf("expected empty model name for the mock vendor, got %q", call.Model)
+	}
+}
+
+// TestAgent_WithToolCallRecorder proves the tool-call hook end to end: a
+// scripted run that invokes one registered tool records exactly one ToolCall
+// with name, ordered timestamps, positive duration, and nil error, while the
+// usage recorder observes both model steps (tool-call step + final reply
+// step).
+func TestAgent_WithToolCallRecorder(t *testing.T) {
+	t.Setenv("CLAI_DISABLE_COST_ERR_LOG_GOROUTINE", "1")
+
+	usageRec := &recordingUsageRecorder{}
+	toolRec := &recordingToolRecorder{}
+	a := newCmdBanAgent(t,
+		WithModel("mock_test"),
+		WithToolGlobs("ls"),
+		WithUsageRecorder(usageRec),
+		WithToolCallRecorder(toolRec),
+		WithOutputTo(io.Discard),
+	)
+
+	queryCmdBanAgent(t, &a, "please tool_ls")
+
+	calls := usageRec.recorded()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 recorded model calls (tool step + reply step), got %d", len(calls))
+	}
+	if !calls[0].EndedWithTool {
+		t.Fatalf("expected step 0 to end with a tool call, got %+v", calls[0])
+	}
+	// The mock vendor terminates the final step with a stop event.
+	if !calls[1].EndedWithStop {
+		t.Fatalf("expected step 1 to end with a stop event, got %+v", calls[1])
+	}
+
+	toolCalls := toolRec.recorded()
+	if len(toolCalls) != 1 {
+		t.Fatalf("expected exactly 1 recorded tool call, got %d", len(toolCalls))
+	}
+	tc := toolCalls[0]
+	if tc.Name != "ls" {
+		t.Fatalf("expected tool name ls, got %q", tc.Name)
+	}
+	if tc.Err != nil {
+		t.Fatalf("expected nil error for a successful ls, got %v", tc.Err)
+	}
+	if tc.StartedAt.IsZero() || tc.FinishedAt.IsZero() || tc.StartedAt.After(tc.FinishedAt) {
+		t.Fatalf("expected ordered timestamps, got started=%v finished=%v", tc.StartedAt, tc.FinishedAt)
+	}
+	if d := tc.FinishedAt.Sub(tc.StartedAt); d <= 0 {
+		t.Fatalf("expected positive duration, got %v", d)
+	}
+}
+
+// TestAgent_WithToolCallRecorder_Error proves the recorder observes tool
+// failures: a banned command is refused by the cmd tool, the ToolCall
+// carries the derived error, and the run still completes normally.
+func TestAgent_WithToolCallRecorder_Error(t *testing.T) {
+	t.Setenv("CLAI_DISABLE_COST_ERR_LOG_GOROUTINE", "1")
+	t.Cleanup(pkgtools.ResetCmdBanListForTests)
+
+	marker := filepath.Join(t.TempDir(), "banned-marker")
+	t.Setenv("CLAI_MOCK_CMD_COMMAND", "touch "+marker)
+
+	toolRec := &recordingToolRecorder{}
+	a := newCmdBanAgent(t,
+		WithModel("mock_test"),
+		WithToolGlobs("cmd"),
+		WithCmdBanList("touch"),
+		WithToolCallRecorder(toolRec),
+		WithOutputTo(io.Discard),
+	)
+
+	chat := queryCmdBanAgent(t, &a, "please tool_cmd")
+	assertCmdBanRefusal(t, chat, "touch")
+
+	toolCalls := toolRec.recorded()
+	if len(toolCalls) != 1 {
+		t.Fatalf("expected exactly 1 recorded tool call, got %d", len(toolCalls))
+	}
+	tc := toolCalls[0]
+	if tc.Name != "cmd" {
+		t.Fatalf("expected tool name cmd, got %q", tc.Name)
+	}
+	if tc.Err == nil {
+		t.Fatal("expected a derived error for the refused command")
+	}
+	if !strings.Contains(tc.Err.Error(), "banned by policy") {
+		t.Fatalf("expected refusal text in the derived error, got %v", tc.Err)
+	}
+	if d := tc.FinishedAt.Sub(tc.StartedAt); d <= 0 {
+		t.Fatalf("expected positive duration, got %v", d)
+	}
+	assertMarkerAbsent(t, marker)
+}
+
+// TestAgent_RecorderErrorAbsorption proves recorder errors never break the
+// agent loop: both Record and RecordToolCall return errors, and the run
+// still completes (the errors are logged and swallowed).
+func TestAgent_RecorderErrorAbsorption(t *testing.T) {
+	t.Setenv("CLAI_DISABLE_COST_ERR_LOG_GOROUTINE", "1")
+
+	usageRec := &recordingUsageRecorder{err: errors.New("usage record failed")}
+	toolRec := &recordingToolRecorder{err: errors.New("tool record failed")}
+	a := newCmdBanAgent(t,
+		WithModel("mock_test"),
+		WithToolGlobs("ls"),
+		WithUsageRecorder(usageRec),
+		WithToolCallRecorder(toolRec),
+		WithOutputTo(io.Discard),
+	)
+
+	// A recorder error must not surface from Setup or Query.
+	queryCmdBanAgent(t, &a, "please tool_ls")
+
+	if len(usageRec.recorded()) != 2 {
+		t.Fatalf("expected 2 recorded model calls, got %d", len(usageRec.recorded()))
+	}
+	if len(toolRec.recorded()) != 1 {
+		t.Fatalf("expected 1 recorded tool call, got %d", len(toolRec.recorded()))
+	}
+}
+
+// TestAgent_NoRecorder_Noop proves an agent built without recorder options
+// behaves exactly as before: the run completes and no recorder state exists.
+func TestAgent_NoRecorder_Noop(t *testing.T) {
+	t.Setenv("CLAI_DISABLE_COST_ERR_LOG_GOROUTINE", "1")
+
+	a := newCmdBanAgent(t,
+		WithModel("mock_test"),
+		WithToolGlobs("ls"),
+		WithOutputTo(io.Discard),
+	)
+
+	queryCmdBanAgent(t, &a, "please tool_ls")
+}
+
+// TestAgent_RecorderOptions_PropagateToInternalConfig proves both recorder
+// options reach text.Configurations via asInternalConfig, and that the
+// defaults stay nil.
+func TestAgent_RecorderOptions_PropagateToInternalConfig(t *testing.T) {
+	usageRec := &recordingUsageRecorder{}
+	toolRec := &recordingToolRecorder{}
+	a := New(WithUsageRecorder(usageRec), WithToolCallRecorder(toolRec))
+	conf := a.asInternalConfig()
+	if conf.UsageRecorder != usageRec {
+		t.Fatalf("expected UsageRecorder to propagate, got %v", conf.UsageRecorder)
+	}
+	if conf.ToolCallRecorder != toolRec {
+		t.Fatalf("expected ToolCallRecorder to propagate, got %v", conf.ToolCallRecorder)
+	}
+
+	plain := New()
+	if plain.asInternalConfig().UsageRecorder != nil || plain.asInternalConfig().ToolCallRecorder != nil {
+		t.Fatal("expected nil recorders in the internal config by default")
+	}
+}

--- a/pkg/text/models/doc.go
+++ b/pkg/text/models/doc.go
@@ -15,6 +15,9 @@
 //     with Model Context Protocol (MCP) style schemas.
 //   - McpServer: describes an MCP server that can be registered and
 //     used by the underlying text engine.
+//   - CallUsageRecorder, CompletedModelCall, ToolCallRecorder, ToolCall:
+//     telemetry seams observed by the session runner per model step and
+//     per tool invocation (worklog 26-08-11-clai-prometheus-metrics).
 //
 // These types are designed to be serializable (where appropriate) and
 // safe to pass across package boundaries without leaking internal

--- a/pkg/text/models/recorder.go
+++ b/pkg/text/models/recorder.go
@@ -1,0 +1,47 @@
+package models
+
+import (
+	"context"
+	"time"
+)
+
+// CompletedModelCall is a record of one finished model step in a session.
+// The session runner invokes CallUsageRecorder.Record once per model
+// round-trip, before any tool execution the step requested. Embedded
+// consumers (e.g. sakfraga) implement CallUsageRecorder to emit per-step
+// telemetry.
+type CompletedModelCall struct {
+	StepIndex      int
+	Model          string
+	StartedAt      time.Time
+	FinishedAt     time.Time
+	Usage          *Usage
+	EndedWithTool  bool
+	EndedWithReply bool
+	EndedWithStop  bool
+}
+
+// CallUsageRecorder observes completed model calls. A nil recorder keeps
+// clai's noop path. A Record error is logged by the session runner and
+// never aborts the agent loop: telemetry must never break the run.
+type CallUsageRecorder interface {
+	Record(context.Context, CompletedModelCall) error
+}
+
+// ToolCall is a record of one tool invocation executed by a session.
+// Err is nil for a successful invocation; tools.Invoke folds failures
+// into its output using the "ERROR: " convention, which the tool executor
+// surfaces on this field.
+type ToolCall struct {
+	Name       string
+	StartedAt  time.Time
+	FinishedAt time.Time
+	Err        error
+}
+
+// ToolCallRecorder observes tool invocations. A nil recorder keeps the
+// noop path. A RecordToolCall error is logged and never aborts the agent
+// loop.
+type ToolCallRecorder interface {
+	RecordToolCall(context.Context, ToolCall) error
+}


### PR DESCRIPTION
I'll use this for prometheus dashboards in sakfraga, which runs up to 50 parallel agents