### PR TITLE
feat: Expose pkg/agent output via slog

### DIFF
--- a/internal/text/conf.go
+++ b/internal/text/conf.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -72,15 +73,11 @@ type Configurations struct {
 	// MaxTokens <= 0 disables the stoploss (no handover injection).
 	Stoploss *Stoploss `json:"stoploss,omitempty"`
 
-	// UsageRecorder receives one CompletedModelCall per model step of a
-	// session (worklog 26-08-11-clai-prometheus-metrics). Nil keeps the
-	// noop path; a Record error is logged by the session runner and never
-	// aborts the run.
-	UsageRecorder pub_models.CallUsageRecorder `json:"-"`
-	// ToolCallRecorder receives one ToolCall per tool invocation. Nil
-	// keeps the noop path; a RecordToolCall error is logged and never
-	// aborts the run.
-	ToolCallRecorder pub_models.ToolCallRecorder `json:"-"`
+	// AgentSettings carries agent-only runtime settings (slog logger, level,
+	// rune cap, recorder hooks) from pkg/agent into the querier. json:"-"
+	// keeps it out of textConfig.json and the presence-based config merge
+	// (worklog 2026-08-15-agent-slog-output, D7).
+	AgentSettings *AgentSettings `json:"-"`
 
 	// Out writer. Normally stdout, but may also be a file when invoked as a package
 	Out io.Writer `json:"-"`
@@ -102,6 +99,17 @@ type Configurations struct {
 	// LookbackCWD is the canonical session working directory captured at setup,
 	// used as the default search anchor for search_conversations.
 	LookbackCWD string `json:"-"`
+}
+
+// AgentSettings carries agent-only runtime settings into the querier. It is
+// never serialized to textConfig.json; a nil Logger or recorder disables that
+// channel (worklog 2026-08-15-agent-slog-output, D7).
+type AgentSettings struct {
+	Logger           *slog.Logger
+	Level            slog.Level
+	RuneLimit        int
+	UsageRecorder    pub_models.CallUsageRecorder
+	ToolCallRecorder pub_models.ToolCallRecorder
 }
 
 // Stoploss is the token stoploss policy. MaxTokens <= 0 disables the

--- a/internal/text/conf_agent_settings_test.go
+++ b/internal/text/conf_agent_settings_test.go
@@ -1,0 +1,75 @@
+package text
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// TestConfigurations_AgentSettings proves Configurations carries the full
+// AgentSettings group: the slog logger, its level, the rune cap, and both
+// recorder hooks (worklog 2026-08-15-agent-slog-output, D7).
+func TestConfigurations_AgentSettings(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	usageRec := &recordingCallUsageRecorder{}
+	toolRec := &recordingToolCallRecorder{}
+	conf := Configurations{
+		AgentSettings: &AgentSettings{
+			Logger:           logger,
+			Level:            slog.LevelWarn,
+			RuneLimit:        42,
+			UsageRecorder:    usageRec,
+			ToolCallRecorder: toolRec,
+		},
+	}
+	as := conf.AgentSettings
+	if as == nil {
+		t.Fatal("expected AgentSettings")
+	}
+	if as.Logger != logger {
+		t.Errorf("Logger: got %v, want the attached logger", as.Logger)
+	}
+	if as.Level != slog.LevelWarn {
+		t.Errorf("Level: got %v, want Warn", as.Level)
+	}
+	if as.RuneLimit != 42 {
+		t.Errorf("RuneLimit: got %d, want 42", as.RuneLimit)
+	}
+	if as.UsageRecorder != usageRec {
+		t.Errorf("UsageRecorder: got %v, want the attached recorder", as.UsageRecorder)
+	}
+	if as.ToolCallRecorder != toolRec {
+		t.Errorf("ToolCallRecorder: got %v, want the attached recorder", as.ToolCallRecorder)
+	}
+}
+
+// TestConfigurations_AgentSettings_jsonOmitted proves AgentSettings never
+// serializes into textConfig.json or the presence-based config merge
+// (json:"-", D7): a marshal/unmarshal round-trip must not leak the group and
+// must leave the receiving side with a nil pointer.
+func TestConfigurations_AgentSettings_jsonOmitted(t *testing.T) {
+	conf := Configurations{
+		Model: "mock",
+		AgentSettings: &AgentSettings{
+			Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+			Level:     slog.LevelDebug,
+			RuneLimit: 200,
+		},
+	}
+	data, err := json.Marshal(conf)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if bytes.Contains(data, []byte("AgentSettings")) || bytes.Contains(data, []byte("agentSettings")) {
+		t.Fatalf("AgentSettings leaked into JSON: %s", data)
+	}
+	var decoded Configurations
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if decoded.AgentSettings != nil {
+		t.Fatal("expected nil AgentSettings after round-trip")
+	}
+}

--- a/internal/text/emit_hooks_test.go
+++ b/internal/text/emit_hooks_test.go
@@ -1,0 +1,203 @@
+package text
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	pub_models "github.com/baalimago/clai/pkg/text/models"
+	"github.com/baalimago/go_away_boilerplate/pkg/dimensions"
+)
+
+// TestQuerier_CloseReasoningIfOpen_logsOnce proves the reasoning hook emits one
+// record per completed reasoning block — not per streamed token — and that a
+// spurious close of an empty buffer emits no record (worklog 2026-08-15-agent-slog-output, Phase 3).
+func TestQuerier_CloseReasoningIfOpen_logsOnce(t *testing.T) {
+	t.Run("one record per block", func(t *testing.T) {
+		h := &captureHandler{}
+		q := &Querier[*MockQuerier]{
+			out:           &strings.Builder{},
+			agentSettings: &AgentSettings{Logger: slog.New(h)},
+		}
+		session := &QuerySession{}
+		q.appendReasoning("token one ")
+		q.appendReasoning("token two")
+		q.reasoningActive = true
+
+		q.closeReasoningIfOpen(context.Background(), session)
+
+		if len(h.records) != 1 {
+			t.Fatalf("expected exactly one reasoning record, got %d", len(h.records))
+		}
+		attrs := recordAttrs(h.records[0])
+		if attrs["kind"] != "reasoning" {
+			t.Fatalf("kind = %v, want reasoning", attrs["kind"])
+		}
+		if attrs["text"] != "token one token two" {
+			t.Fatalf("text = %v, want the full block", attrs["text"])
+		}
+	})
+
+	t.Run("empty buffer emits nothing", func(t *testing.T) {
+		h := &captureHandler{}
+		q := &Querier[*MockQuerier]{
+			out:           &strings.Builder{},
+			agentSettings: &AgentSettings{Logger: slog.New(h)},
+		}
+		q.reasoningActive = true
+
+		q.closeReasoningIfOpen(context.Background(), &QuerySession{})
+
+		if len(h.records) != 0 {
+			t.Fatalf("expected no record for an empty reasoning buffer, got %d", len(h.records))
+		}
+	})
+}
+
+// TestFinalizeAssistantText_Logs proves the assistant hook fires only for
+// finalized, non-empty prose: echoed tool-call text and empty pending text
+// emit no record (worklog 2026-08-15-agent-slog-output, Phase 3).
+func TestFinalizeAssistantText_Logs(t *testing.T) {
+	call := pub_models.Call{ID: "call-1", Name: "pwd"}
+
+	newQuerier := func(h *captureHandler) *Querier[*MockQuerier] {
+		return &Querier[*MockQuerier]{
+			out:           &strings.Builder{},
+			dims:          dimensions.Dimensions{Width: 80, Height: 24},
+			agentSettings: &AgentSettings{Logger: slog.New(h)},
+		}
+	}
+
+	t.Run("non-empty prose logs assistant", func(t *testing.T) {
+		h := &captureHandler{}
+		q := newQuerier(h)
+		session := &QuerySession{}
+		session.AppendPendingText("I will check that for you.")
+
+		if err := (toolExecutor[*MockQuerier]{querier: q}).finalizeAssistantTextBeforeToolCall(context.Background(), session, call); err != nil {
+			t.Fatalf("finalizeAssistantTextBeforeToolCall: %v", err)
+		}
+		if len(h.records) != 1 {
+			t.Fatalf("expected one assistant record, got %d", len(h.records))
+		}
+		attrs := recordAttrs(h.records[0])
+		if attrs["kind"] != "assistant" || attrs["text"] != "I will check that for you." {
+			t.Fatalf("record = %v, want kind=assistant with the pending prose", attrs)
+		}
+	})
+
+	t.Run("non-rolling prose logs assistant", func(t *testing.T) {
+		// The plain (non-rolling) finalize path is a hook site of its own; a
+		// raw session forces it while the log must still fire.
+		h := &captureHandler{}
+		q := newQuerier(h)
+		q.Raw = true
+		session := &QuerySession{}
+		session.AppendPendingText("plain path prose")
+
+		if err := (toolExecutor[*MockQuerier]{querier: q}).finalizeAssistantTextBeforeToolCall(context.Background(), session, call); err != nil {
+			t.Fatalf("finalizeAssistantTextBeforeToolCall: %v", err)
+		}
+		if len(h.records) != 1 {
+			t.Fatalf("expected one assistant record, got %d", len(h.records))
+		}
+		if attrs := recordAttrs(h.records[0]); attrs["kind"] != "assistant" || attrs["text"] != "plain path prose" {
+			t.Fatalf("record = %v, want kind=assistant with the pending prose", attrs)
+		}
+	})
+
+	t.Run("echoed tool-call text does not log", func(t *testing.T) {
+		h := &captureHandler{}
+		q := newQuerier(h)
+		session := &QuerySession{}
+		session.AppendPendingText("\n" + call.PrettyPrint() + "\n")
+
+		if err := (toolExecutor[*MockQuerier]{querier: q}).finalizeAssistantTextBeforeToolCall(context.Background(), session, call); err != nil {
+			t.Fatalf("finalizeAssistantTextBeforeToolCall: %v", err)
+		}
+		if len(h.records) != 0 {
+			t.Fatalf("echoed tool-call text must not log, got %d records", len(h.records))
+		}
+	})
+
+	t.Run("empty pending does not log", func(t *testing.T) {
+		h := &captureHandler{}
+		q := newQuerier(h)
+
+		if err := (toolExecutor[*MockQuerier]{querier: q}).finalizeAssistantTextBeforeToolCall(context.Background(), &QuerySession{}, call); err != nil {
+			t.Fatalf("finalizeAssistantTextBeforeToolCall: %v", err)
+		}
+		if len(h.records) != 0 {
+			t.Fatalf("empty pending must not log, got %d records", len(h.records))
+		}
+	})
+}
+
+// TestPostProcessOutput_LogsFinalAnswer_unconditionally proves the final_answer
+// record fires before any display branch: a raw session that returns early
+// still logs its completed answer (worklog 2026-08-15-agent-slog-output, Phase 3).
+func TestPostProcessOutput_LogsFinalAnswer_unconditionally(t *testing.T) {
+	h := &captureHandler{}
+	q := &Querier[*MockQuerier]{
+		Raw:           true,
+		out:           &strings.Builder{},
+		agentSettings: &AgentSettings{Logger: slog.New(h)},
+	}
+	q.postProcessOutput(context.Background(), pub_models.Message{Role: "assistant", Content: "final answer"})
+
+	if len(h.records) != 1 {
+		t.Fatalf("expected one final_answer record even in raw display, got %d", len(h.records))
+	}
+	attrs := recordAttrs(h.records[0])
+	if attrs["kind"] != "final_answer" || attrs["text"] != "final answer" {
+		t.Fatalf("record = %v, want kind=final_answer with the answer text", attrs)
+	}
+}
+
+// TestExecuteLoadSkill_LogsToolResult proves the load_skill success path logs
+// one tool_result record whose text is the final user-visible body (warnings
+// folded in) and whose tool attribute is load_skill (worklog 2026-08-15-agent-slog-output, Phase 3).
+func TestExecuteLoadSkill_LogsToolResult(t *testing.T) {
+	h := &captureHandler{}
+	loaded := LoadedSkillRuntime{
+		Name:         "review",
+		SourceClass:  "project",
+		RenderedBody: "skill body",
+	}
+	q := Querier[*MockQuerier]{
+		out:           &strings.Builder{},
+		skillLoader:   fakeSkillLoader{loaded: loaded},
+		agentSettings: &AgentSettings{Logger: slog.New(h)},
+	}
+	session := &QuerySession{}
+	inputs := pub_models.Input{"skill": "review"}
+	call := pub_models.Call{ID: "call-1", Name: string(pub_models.LoadSkillTool), Inputs: &inputs}
+
+	if err := (toolExecutor[*MockQuerier]{querier: &q}).Execute(context.Background(), session, call); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	toolCalls, toolResults := 0, 0
+	for _, rec := range h.records {
+		attrs := recordAttrs(rec)
+		switch attrs["kind"] {
+		case "tool_call":
+			toolCalls++
+		case "tool_result":
+			toolResults++
+			if attrs["tool"] != string(pub_models.LoadSkillTool) {
+				t.Fatalf("tool = %v, want %q", attrs["tool"], string(pub_models.LoadSkillTool))
+			}
+			if want := formatSkillOutputForDisplay(loaded); attrs["text"] != want {
+				t.Fatalf("text = %v, want %q (the final user-visible body)", attrs["text"], want)
+			}
+		}
+	}
+	if toolCalls != 1 {
+		t.Fatalf("expected one tool_call record, got %d", toolCalls)
+	}
+	if toolResults != 1 {
+		t.Fatalf("expected one tool_result record, got %d", toolResults)
+	}
+}

--- a/internal/text/finalizer.go
+++ b/internal/text/finalizer.go
@@ -1,6 +1,7 @@
 package text
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -74,7 +75,7 @@ func mostRecentCompletedUsage(completed []CompletedModelCall, final *pub_models.
 	return final
 }
 
-func (f sessionFinalizer[C]) Finalize(session *QuerySession) {
+func (f sessionFinalizer[C]) Finalize(ctx context.Context, session *QuerySession) {
 	if session == nil || session.Finalized {
 		return
 	}
@@ -154,10 +155,17 @@ func (f sessionFinalizer[C]) Finalize(session *QuerySession) {
 		return
 	}
 	if q.structuredOutput {
+		// The final-answer record fires before the structured display too:
+		// postProcessOutput's display branches are skipped on this path, but
+		// the agent-logging contract is unconditional (worklog
+		// 2026-08-15-agent-slog-output, Phase 3). The typed-agent path is
+		// always structured, so a missing record here would leave every
+		// embedded log without the run's final answer.
+		q.logMessage(ctx, "final_answer", stripThinkingBlocks(session.FinalAssistantText), "")
 		fmt.Fprintln(q.out, stripThinkingBlocks(session.FinalAssistantText))
 		return
 	}
-	q.postProcessOutput(pub_models.Message{
+	q.postProcessOutput(ctx, pub_models.Message{
 		Role:    "assistant",
 		Content: session.FinalAssistantText,
 	})

--- a/internal/text/querier.go
+++ b/internal/text/querier.go
@@ -90,6 +90,11 @@ type Querier[C models.StreamCompleter] struct {
 	// Output of the querier. This is used mostly when Querier is invoked as an agent
 	out io.Writer
 
+	// agentSettings carries the agent-only runtime settings (slog logger,
+	// level, rune cap, recorder hooks) into the querier. nil (the CLI and
+	// pkg/text paths) keeps every channel disabled.
+	agentSettings *AgentSettings
+
 	// isLikelyGemini3Preview is set to true if it's likely that the current underlying model
 	// is the gemini 3 preview which suffers from an issue where it insists on crashing if there
 	// is no "though_signature" within extra content, while also sending requests which lack "though_signature"
@@ -137,7 +142,11 @@ type LoadedSkillRuntime struct {
 	RawArgs         string
 }
 
-func (q *Querier[C]) postProcessOutput(newSysMsg pub_models.Message) {
+func (q *Querier[C]) postProcessOutput(ctx context.Context, newSysMsg pub_models.Message) {
+	// Agent logging is unconditional: the final answer record fires before any
+	// display branch so raw, structured, rolling, and terminal paths all emit
+	// it (worklog 2026-08-15-agent-slog-output, Phase 3).
+	q.logMessage(ctx, "final_answer", newSysMsg.Content, "")
 	// The token should already have been printed while streamed
 	if q.rawDisplay() {
 		if q.debug {
@@ -206,7 +215,7 @@ func (q *Querier[C]) postProcess() {
 		Line:               q.line,
 		LineCount:          q.lineCount,
 	}
-	sessionFinalizer[C]{querier: q}.Finalize(session)
+	sessionFinalizer[C]{querier: q}.Finalize(context.Background(), session)
 	q.chat = session.Chat
 	q.fullMsg = session.FinalAssistantText
 	q.line = session.Line
@@ -385,11 +394,17 @@ func (q *Querier[C]) rawDisplay() bool {
 
 // closeReasoningIfOpen finishes the display viewport and persists the complete
 // source reasoning separately from assistant text.
-func (q *Querier[C]) closeReasoningIfOpen(session *QuerySession) {
+func (q *Querier[C]) closeReasoningIfOpen(ctx context.Context, session *QuerySession) {
 	if !q.reasoningActive {
 		return
 	}
 	q.reasoningActive = false
+	// One reasoning record per block, not per token: the complete buffer is
+	// captured before any branch resets it. An empty buffer (a spurious close)
+	// emits no record.
+	if reasoning := q.reasoningBuf.String(); reasoning != "" {
+		q.logMessage(ctx, "reasoning", reasoning, "")
+	}
 	if q.usesActivityViewport() {
 		session.PendingReasoning.WriteString(q.reasoningBuf.String())
 		q.fullMsg = session.PendingTextString()

--- a/internal/text/querier_setup.go
+++ b/internal/text/querier_setup.go
@@ -212,8 +212,15 @@ func NewQuerier[C models.StreamCompleter](ctx context.Context, userConf Configur
 	querier.toolOutputRuneLimit = userConf.ToolOutputRuneLimit
 	querier.maxToolCalls = userConf.MaxToolCalls
 	querier.stoploss = userConf.Stoploss
-	querier.callUsageRecorder = userConf.UsageRecorder
-	querier.toolCallRecorder = userConf.ToolCallRecorder
+	// Agent-only runtime settings (slog logger, level, rune cap, recorder
+	// hooks) ride one pointer (worklog 2026-08-15-agent-slog-output, D7). nil (the CLI and pkg/text paths) keeps
+	// every channel disabled; the loose Configurations recorder fields no
+	// longer exist.
+	if userConf.AgentSettings != nil {
+		querier.callUsageRecorder = userConf.AgentSettings.UsageRecorder
+		querier.toolCallRecorder = userConf.AgentSettings.ToolCallRecorder
+		querier.agentSettings = userConf.AgentSettings
+	}
 	querier.out = output
 	// MCP server stderr lines follow the same display policy as the session:
 	// rolling output buffers them into the window, raw/structured output keeps

--- a/internal/text/querier_setup_test.go
+++ b/internal/text/querier_setup_test.go
@@ -3,6 +3,8 @@ package text
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"log/slog"
 	"os"
 	"path"
 	"strings"
@@ -167,5 +169,89 @@ func Test_Querier_NewQuerier_dimsBoundToOutputWriter(t *testing.T) {
 	}
 	if q.out == nil {
 		t.Fatal("querier output writer must be set")
+	}
+}
+
+// recordingToolCallRecorder is a fake ToolCallRecorder that records every
+// invocation. It pairs with recordingCallUsageRecorder (session_runner_test.go)
+// for the AgentSettings plumbing tests.
+type recordingToolCallRecorder struct {
+	calls []ToolCall
+}
+
+func (r *recordingToolCallRecorder) RecordToolCall(_ context.Context, call ToolCall) error {
+	r.calls = append(r.calls, call)
+	return nil
+}
+
+// TestNewQuerier_AgentSettings proves NewQuerier copies the whole AgentSettings
+// pointer and sources both recorder hooks from it (worklog 2026-08-15-agent-slog-output, D7). A nil AgentSettings
+// (the CLI and pkg/text paths) keeps the querier recorders nil and logging
+// disabled.
+func TestNewQuerier_AgentSettings(t *testing.T) {
+	// Avoid races with the cost manager error logger goroutine in NewQuerier.
+	t.Setenv("CLAI_DISABLE_COST_ERR_LOG_GOROUTINE", "1")
+
+	model := "mock"
+	tmpDir := t.TempDir()
+	confDir := path.Join(tmpDir, ".clai")
+	if err := os.Mkdir(confDir, os.FileMode(0o755)); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	saved, err := json.Marshal(MockQuerier{Somefield: "somevalue"})
+	if err != nil {
+		t.Fatalf("marshal mock: %v", err)
+	}
+	if err := os.WriteFile(path.Join(confDir, "mock_mock_mock.json"), saved, os.FileMode(0o755)); err != nil {
+		t.Fatalf("write mock config: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	usageRec := &recordingCallUsageRecorder{}
+	toolRec := &recordingToolCallRecorder{}
+	agentSettings := &AgentSettings{
+		Logger:           logger,
+		Level:            slog.LevelWarn,
+		RuneLimit:        42,
+		UsageRecorder:    usageRec,
+		ToolCallRecorder: toolRec,
+	}
+	conf := Configurations{
+		Model:         model,
+		ConfigDir:     confDir,
+		Out:           &strings.Builder{},
+		AgentSettings: agentSettings,
+	}
+	q, err := NewQuerier(context.Background(), conf, &MockQuerier{})
+	if err != nil {
+		t.Fatalf("NewQuerier: %v", err)
+	}
+	if q.agentSettings != agentSettings {
+		t.Fatalf("agentSettings: got %v, want the configured pointer", q.agentSettings)
+	}
+	if q.callUsageRecorder != usageRec {
+		t.Fatalf("callUsageRecorder: got %v, want the AgentSettings recorder", q.callUsageRecorder)
+	}
+	if q.toolCallRecorder != toolRec {
+		t.Fatalf("toolCallRecorder: got %v, want the AgentSettings recorder", q.toolCallRecorder)
+	}
+
+	// A nil AgentSettings keeps every channel disabled.
+	plain, err := NewQuerier(context.Background(), Configurations{
+		Model:     model,
+		ConfigDir: confDir,
+		Out:       &strings.Builder{},
+	}, &MockQuerier{})
+	if err != nil {
+		t.Fatalf("NewQuerier (nil AgentSettings): %v", err)
+	}
+	if plain.agentSettings != nil {
+		t.Fatalf("expected nil agentSettings, got %v", plain.agentSettings)
+	}
+	if plain.callUsageRecorder != nil {
+		t.Fatalf("expected nil callUsageRecorder, got %v", plain.callUsageRecorder)
+	}
+	if plain.toolCallRecorder != nil {
+		t.Fatalf("expected nil toolCallRecorder, got %v", plain.toolCallRecorder)
 	}
 }

--- a/internal/text/querier_tool_test.go
+++ b/internal/text/querier_tool_test.go
@@ -213,7 +213,7 @@ func Test_toolExecutor_EmitToolResult_CompactsMCPOutputAndRetainsTranscript(t *t
 	out := "mcp_result\n" + strings.Repeat("a long result row\n", 20)
 	call := pub_models.Call{ID: "call-1", Name: "mcp_server_tool"}
 
-	if err := (toolExecutor[*MockQuerier]{querier: &q}).emitToolResult(session, call, out); err != nil {
+	if err := (toolExecutor[*MockQuerier]{querier: &q}).emitToolResult(context.Background(), session, call, out); err != nil {
 		t.Fatalf("emitToolResult() error = %v", err)
 	}
 	if got := printed.String(); !strings.Contains(got, "terminal rows omitted") {
@@ -231,7 +231,7 @@ func Test_toolExecutor_EmitToolResult_RawDisplayKeepsCompleteResult(t *testing.T
 	result := "complete tool result"
 	call := pub_models.Call{ID: "call-1", Name: "test"}
 
-	if err := (toolExecutor[*MockQuerier]{querier: &q}).emitToolResult(session, call, result); err != nil {
+	if err := (toolExecutor[*MockQuerier]{querier: &q}).emitToolResult(context.Background(), session, call, result); err != nil {
 		t.Fatalf("emitToolResult() error = %v", err)
 	}
 	if got := printed.String(); !strings.Contains(got, result) {

--- a/internal/text/session_runner.go
+++ b/internal/text/session_runner.go
@@ -40,7 +40,7 @@ type sessionRunner[C models.StreamCompleter] struct {
 }
 
 type sessionFinalizerer interface {
-	Finalize(*QuerySession)
+	Finalize(context.Context, *QuerySession)
 }
 
 func (r *sessionRunner[C]) Run(ctx context.Context, session *QuerySession) (runErr error) {
@@ -57,7 +57,7 @@ func (r *sessionRunner[C]) Run(ctx context.Context, session *QuerySession) (runE
 	defer func() {
 		session.FinishedAt = time.Now()
 		session.Failed = runErr != nil
-		r.finalizer.Finalize(session)
+		r.finalizer.Finalize(ctx, session)
 	}()
 	// Final MCP log flush before the finalizer prints the answer: deferred
 	// functions run LIFO, so buffered server errors elevate below the window
@@ -205,7 +205,7 @@ func (r *sessionRunner[C]) executeModelStep(ctx context.Context, session *QueryS
 		select {
 		case completion, ok := <-completionsChan:
 			if !ok {
-				q.closeReasoningIfOpen(session)
+				q.closeReasoningIfOpen(ctx, session)
 				if len(result.ToolCalls) == 0 {
 					q.prepareFinalAnswerPop()
 				}
@@ -227,16 +227,16 @@ func (r *sessionRunner[C]) executeModelStep(ctx context.Context, session *QueryS
 				if q.reasoningActive && cast.ReasoningContent == "" {
 					cast.ReasoningContent = q.reasoningBuf.String()
 				}
-				q.closeReasoningIfOpen(session)
+				q.closeReasoningIfOpen(ctx, session)
 				result.ToolCalls = append(result.ToolCalls, cast)
 			case string:
-				q.closeReasoningIfOpen(session)
+				q.closeReasoningIfOpen(ctx, session)
 				if err := q.handleTokenForSession(session, cast); err != nil {
 					return ModelStepResult{}, err
 				}
 			case error:
 				if errors.Is(cast, context.Canceled) || errors.Is(cast, io.EOF) {
-					q.closeReasoningIfOpen(session)
+					q.closeReasoningIfOpen(ctx, session)
 					result.EndedNormally = true
 					result.AssistantText = session.PendingTextString()
 					result.Usage = q.currentTokenUsage()
@@ -279,7 +279,7 @@ func (r *sessionRunner[C]) executeModelStep(ctx context.Context, session *QueryS
 				}
 				q.appendReasoning(cast.Content)
 			case models.StopEvent:
-				q.closeReasoningIfOpen(session)
+				q.closeReasoningIfOpen(ctx, session)
 				result.AssistantText = session.PendingTextString()
 				result.Usage = q.currentTokenUsage()
 				if len(result.ToolCalls) > 0 {
@@ -320,7 +320,7 @@ func (r *sessionRunner[C]) executeModelStep(ctx context.Context, session *QueryS
 				return ModelStepResult{}, fmt.Errorf("drain mcp logs: %w", err)
 			}
 		case <-ctx.Done():
-			q.closeReasoningIfOpen(session)
+			q.closeReasoningIfOpen(ctx, session)
 			result.StopRequested = true
 			result.AssistantText = session.PendingTextString()
 			result.Usage = q.currentTokenUsage()

--- a/internal/text/session_runner_test.go
+++ b/internal/text/session_runner_test.go
@@ -66,7 +66,7 @@ type countingFinalizer struct {
 	last  *QuerySession
 }
 
-func (f *countingFinalizer) Finalize(session *QuerySession) {
+func (f *countingFinalizer) Finalize(_ context.Context, session *QuerySession) {
 	f.count++
 	f.last = session
 	if session == nil || session.Finalized {
@@ -821,7 +821,7 @@ func Test_toolExecutor_FinalizeAssistantTextBeforeToolCall_PreservesAssistantPro
 	session := &QuerySession{}
 	session.AppendPendingText("I will check that for you.")
 
-	err := toolExecutor[*MockQuerier]{querier: q}.finalizeAssistantTextBeforeToolCall(session, call)
+	err := toolExecutor[*MockQuerier]{querier: q}.finalizeAssistantTextBeforeToolCall(context.Background(), session, call)
 	if err != nil {
 		t.Fatalf("finalizeAssistantTextBeforeToolCall returned err: %v", err)
 	}
@@ -863,7 +863,7 @@ func Test_toolExecutor_FinalizeAssistantTextBeforeToolCall_DropsWhitespaceEquiva
 	session := &QuerySession{}
 	session.AppendPendingText(echoed)
 
-	err := toolExecutor[*MockQuerier]{querier: q}.finalizeAssistantTextBeforeToolCall(session, call)
+	err := toolExecutor[*MockQuerier]{querier: q}.finalizeAssistantTextBeforeToolCall(context.Background(), session, call)
 	if err != nil {
 		t.Fatalf("finalizeAssistantTextBeforeToolCall returned err: %v", err)
 	}

--- a/internal/text/slog_output.go
+++ b/internal/text/slog_output.go
@@ -1,0 +1,77 @@
+package text
+
+import (
+	"context"
+	"unicode/utf8"
+)
+
+// slogTruncationMarker is the single rune (U+2026) inserted at the head/tail
+// split of a truncated message. One rune keeps tiny limits valid — a limit
+// of 1 yields exactly the marker — and avoids the sub-marker edge case a
+// longer "…[truncated]…" marker would create (worklog 2026-08-15-agent-slog-output, D2).
+const slogTruncationMarker = "…"
+
+// truncateMiddleRunes returns s unchanged when utf8.RuneCountInString(s) <= limit,
+// or when limit <= 0 (no cap, worklog 2026-08-15-agent-slog-output, D5). Otherwise it returns head + "…" + tail
+// totalling exactly limit runes and reports truncated=true. The split is
+// rune-safe: head is the first headLen runes, tail is the last tailLen runes,
+// headLen + tailLen == limit-1, balanced head/tail.
+func truncateMiddleRunes(s string, limit int) (string, bool) {
+	if limit <= 0 {
+		return s, false
+	}
+	n := utf8.RuneCountInString(s)
+	if n <= limit {
+		return s, false
+	}
+	headLen := limit / 2
+	tailLen := limit - 1 - headLen
+	return firstRunes(s, headLen) + slogTruncationMarker + lastRunes(s, tailLen), true
+}
+
+// firstRunes returns the first n runes of s. The caller guarantees n is
+// within the rune count of s.
+func firstRunes(s string, n int) string {
+	end := len(s)
+	i := 0
+	for j := range s {
+		if i == n {
+			end = j
+			break
+		}
+		i++
+	}
+	return s[:end]
+}
+
+// lastRunes returns the last n runes of s. The caller guarantees n is within
+// the rune count of s.
+func lastRunes(s string, n int) string {
+	i := len(s)
+	for range n {
+		_, size := utf8.DecodeLastRuneInString(s[:i])
+		i -= size
+	}
+	return s[i:]
+}
+
+// logMessage emits one truncated "clai message" record per completed message
+// at its semantic completion site (worklog 2026-08-15-agent-slog-output,
+// Phase 3). It is the sole gate for agent logging: nil agentSettings or a nil
+// Logger disables the channel, and the record is never gated by
+// structuredOutput, rawDisplay, debug, or the output writer. The caller-set
+// level is the record level; the kind attribute is how a caller filters finer
+// (worklog 2026-08-15-agent-slog-output, D3). ctx is the live query context, forwarded to the slog handler so a
+// ctx-aware external handler can enrich or correlate records (worklog 2026-08-15-agent-slog-output, D6).
+func (q *Querier[C]) logMessage(ctx context.Context, kind, text, tool string) {
+	s := q.agentSettings
+	if s == nil || s.Logger == nil {
+		return
+	}
+	truncated, was := truncateMiddleRunes(text, s.RuneLimit)
+	attrs := []any{"kind", kind, "text", truncated, "truncated", was}
+	if tool != "" {
+		attrs = append(attrs, "tool", tool)
+	}
+	s.Logger.Log(ctx, s.Level, "clai message", attrs...)
+}

--- a/internal/text/slog_output_test.go
+++ b/internal/text/slog_output_test.go
@@ -1,0 +1,395 @@
+package text
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/baalimago/clai/internal/models"
+	inttools "github.com/baalimago/clai/internal/tools"
+	pub_models "github.com/baalimago/clai/pkg/text/models"
+	"github.com/baalimago/go_away_boilerplate/pkg/dimensions"
+)
+
+func TestTruncateMiddleRunes(t *testing.T) {
+	t.Run("within_limit", func(t *testing.T) {
+		s := "hello world"
+		got, truncated := truncateMiddleRunes(s, 20)
+		if truncated || got != s {
+			t.Fatalf("within limit: got %q truncated=%t, want %q truncated=false", got, truncated, s)
+		}
+	})
+
+	t.Run("at_limit", func(t *testing.T) {
+		s := "hello world" // 11 runes
+		got, truncated := truncateMiddleRunes(s, 11)
+		if truncated || got != s {
+			t.Fatalf("at limit: got %q truncated=%t, want %q truncated=false", got, truncated, s)
+		}
+	})
+
+	t.Run("over_limit", func(t *testing.T) {
+		got, truncated := truncateMiddleRunes("abcdefghij", 5)
+		if !truncated {
+			t.Fatal("expected truncated=true")
+		}
+		want := "ab" + slogTruncationMarker + "ij"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+		if n := utf8.RuneCountInString(got); n != 5 {
+			t.Fatalf("expected 5 runes, got %d (%q)", n, got)
+		}
+	})
+
+	t.Run("multibyte_rune", func(t *testing.T) {
+		// é (U+00E9) and ö (U+00F6) are multi-byte runes; the head/tail cut
+		// must never land inside one.
+		cases := []struct {
+			name  string
+			s     string
+			limit int
+			want  string
+		}{
+			{"head_cut_mid_rune", "ééé", 2, "é" + slogTruncationMarker},
+			{"tail_cut_mid_rune", "abcéé", 3, "a" + slogTruncationMarker + "é"},
+			{"mixed_unicode", "héllo wörld", 4, "hé" + slogTruncationMarker + "d"},
+			{"ascii_balanced", "abcdefghij", 5, "ab" + slogTruncationMarker + "ij"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				got, truncated := truncateMiddleRunes(tc.s, tc.limit)
+				if !truncated {
+					t.Fatalf("expected truncated=true")
+				}
+				if got != tc.want {
+					t.Fatalf("got %q, want %q", got, tc.want)
+				}
+				if !utf8.ValidString(got) {
+					t.Fatalf("output is invalid UTF-8: %q", got)
+				}
+				if n := utf8.RuneCountInString(got); n != tc.limit {
+					t.Fatalf("expected %d runes, got %d", tc.limit, n)
+				}
+			})
+		}
+	})
+
+	t.Run("nonpositive_limit", func(t *testing.T) {
+		for _, limit := range []int{0, -1, -42} {
+			got, truncated := truncateMiddleRunes("any text", limit)
+			if truncated || got != "any text" {
+				t.Fatalf("limit %d: got %q truncated=%t, want input unchanged", limit, got, truncated)
+			}
+		}
+	})
+
+	t.Run("single_rune_limit", func(t *testing.T) {
+		got, truncated := truncateMiddleRunes("hello", 1)
+		if !truncated {
+			t.Fatal("expected truncated=true")
+		}
+		if got != slogTruncationMarker {
+			t.Fatalf("got %q, want %q", got, slogTruncationMarker)
+		}
+	})
+
+	t.Run("empty_input", func(t *testing.T) {
+		got, truncated := truncateMiddleRunes("", 5)
+		if truncated || got != "" {
+			t.Fatalf("empty input: got %q truncated=%t, want unchanged", got, truncated)
+		}
+		got, truncated = truncateMiddleRunes("", 0)
+		if truncated || got != "" {
+			t.Fatalf("empty input, no cap: got %q truncated=%t, want unchanged", got, truncated)
+		}
+	})
+}
+
+// captureHandler records every slog record with the context passed to Handle.
+// Enabled always returns true, so the caller-set AgentSettings.Level never
+// filters a record away in tests.
+type captureHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+	ctxs    []context.Context
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(ctx context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.ctxs = append(h.ctxs, ctx)
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
+
+// recordAttrs flattens one record's attributes into a map for assertions.
+func recordAttrs(r slog.Record) map[string]any {
+	attrs := make(map[string]any, 6)
+	r.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.Any()
+		return true
+	})
+	return attrs
+}
+
+func TestQuerier_LogMessage_nilLogger(t *testing.T) {
+	h := &captureHandler{}
+	logger := slog.New(h)
+	q := &Querier[*MockQuerier]{}
+
+	q.logMessage(context.Background(), "assistant", "text", "")
+	q.agentSettings = &AgentSettings{}
+	q.logMessage(context.Background(), "assistant", "text", "")
+	if len(h.records) != 0 {
+		t.Fatalf("nil agentSettings or nil logger must not log, got %d records", len(h.records))
+	}
+
+	q.agentSettings = &AgentSettings{Logger: logger}
+	q.logMessage(context.Background(), "assistant", "text", "")
+	if len(h.records) != 1 {
+		t.Fatalf("expected one record with a live logger, got %d", len(h.records))
+	}
+}
+
+func TestQuerier_LogMessage_truncates(t *testing.T) {
+	h := &captureHandler{}
+	q := &Querier[*MockQuerier]{agentSettings: &AgentSettings{
+		Logger:    slog.New(h),
+		Level:     slog.LevelDebug,
+		RuneLimit: 5,
+	}}
+	q.logMessage(context.Background(), "assistant", "abcdefghij", "")
+
+	record := h.records[0]
+	attrs := recordAttrs(record)
+	if got, want := attrs["text"], "ab"+slogTruncationMarker+"ij"; got != want {
+		t.Fatalf("text = %v, want %q", got, want)
+	}
+	if attrs["truncated"] != true {
+		t.Fatalf("truncated = %v, want true", attrs["truncated"])
+	}
+	if attrs["kind"] != "assistant" {
+		t.Fatalf("kind = %v, want assistant", attrs["kind"])
+	}
+	if record.Message != "clai message" {
+		t.Fatalf("message = %q, want %q", record.Message, "clai message")
+	}
+	if record.Level != slog.LevelDebug {
+		t.Fatalf("level = %v, want %v", record.Level, slog.LevelDebug)
+	}
+}
+
+// logMessageCtxKey is a private context key proving logMessage forwards the
+// live query context to the handler (worklog 2026-08-15-agent-slog-output, D6).
+type logMessageCtxKey string
+
+func TestQuerier_LogMessage_ctx(t *testing.T) {
+	h := &captureHandler{}
+	q := &Querier[*MockQuerier]{agentSettings: &AgentSettings{Logger: slog.New(h)}}
+	ctx := context.WithValue(context.Background(), logMessageCtxKey("marker"), "value")
+	q.logMessage(ctx, "assistant", "text", "")
+
+	if len(h.ctxs) != 1 {
+		t.Fatalf("expected one handled record, got %d", len(h.ctxs))
+	}
+	if got := h.ctxs[0].Value(logMessageCtxKey("marker")); got != "value" {
+		t.Fatalf("handler context lost the value: got %v, want %q", got, "value")
+	}
+}
+
+func TestQuerier_LogMessage_kind(t *testing.T) {
+	for _, kind := range []string{"assistant", "reasoning", "tool_call", "tool_result", "final_answer"} {
+		t.Run(kind, func(t *testing.T) {
+			h := &captureHandler{}
+			q := &Querier[*MockQuerier]{agentSettings: &AgentSettings{Logger: slog.New(h)}}
+			q.logMessage(context.Background(), kind, "text", "")
+
+			if len(h.records) != 1 {
+				t.Fatalf("expected exactly one record, got %d", len(h.records))
+			}
+			attrs := recordAttrs(h.records[0])
+			if attrs["kind"] != kind {
+				t.Fatalf("kind = %v, want %q", attrs["kind"], kind)
+			}
+			if attrs["text"] != "text" {
+				t.Fatalf("text = %v, want %q", attrs["text"], "text")
+			}
+			if attrs["truncated"] != false {
+				t.Fatalf("truncated = %v, want false", attrs["truncated"])
+			}
+		})
+	}
+}
+
+// scriptedDisplayQuerier builds a querier whose mock model streams one fixed
+// script: reasoning, assistant prose, a tool call, then reasoning and a final
+// answer. The stream exercises every display site — reasoning open/close,
+// streamed tokens, tool-call echo, tool result, and final answer — so the
+// worklog 2026-08-15-agent-slog-output Phase 4 byte-identity proof covers all of them.
+func scriptedDisplayQuerier(out *strings.Builder, raw bool, agentSettings *AgentSettings) *Querier[*MockQuerier] {
+	var callCount int
+	model := &MockQuerier{}
+	model.streamFn = func(context.Context, pub_models.Chat) (chan models.CompletionEvent, error) {
+		callCount++
+		ch := make(chan models.CompletionEvent, 4)
+		if callCount == 1 {
+			ch <- models.ReasoningEvent{Content: "thinking through the steps"}
+			ch <- "I will look that up."
+			ch <- pub_models.Call{ID: "call-1", Name: "test", Inputs: &pub_models.Input{}}
+		} else {
+			ch <- models.ReasoningEvent{Content: "final reasoning"}
+			ch <- "final answer"
+		}
+		close(ch)
+		return ch, nil
+	}
+	return &Querier[*MockQuerier]{
+		Raw:   raw,
+		Model: model,
+		out:   out,
+		dims:  dimensions.Dimensions{Width: 80, Height: 24},
+		chat: pub_models.Chat{Messages: []pub_models.Message{
+			{Role: "user", Content: "look it up"},
+		}},
+		agentSettings: agentSettings,
+	}
+}
+
+// TestSlogLogger_DoesNotPerturbDisplay proves display invariance: the same
+// scripted stream writes byte-identical output to out with and without an
+// attached slog logger (worklog 2026-08-15-agent-slog-output, Phase 4). Both
+// the raw display path and the default rolling-window path run, so every
+// display site is covered. The capturing logger must receive one record per
+// completed message in stream order while the display bytes stay untouched.
+func TestSlogLogger_DoesNotPerturbDisplay(t *testing.T) {
+	inttools.WithTestRegistry(t, func() {
+		inttools.Registry.Set("test", stubTool{output: "tool output"})
+
+		for _, tc := range []struct {
+			name string
+			raw  bool
+		}{
+			{name: "raw", raw: true},
+			{name: "rolling", raw: false},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				if !tc.raw {
+					// The default theme enables the rolling activity window;
+					// pin it so the interactive CLI display path runs.
+					withRollingTheme(t)
+				}
+				runOnce := func(withLogger bool) (string, *captureHandler) {
+					t.Helper()
+					var out strings.Builder
+					h := &captureHandler{}
+					var settings *AgentSettings
+					if withLogger {
+						settings = &AgentSettings{Logger: slog.New(h)}
+					}
+					if err := scriptedDisplayQuerier(&out, tc.raw, settings).Query(context.Background()); err != nil {
+						t.Fatalf("Query() error = %v", err)
+					}
+					return out.String(), h
+				}
+
+				plainOut, plainHandler := runOnce(false)
+				loggedOut, loggedHandler := runOnce(true)
+				if plainOut != loggedOut {
+					t.Fatalf("display bytes differ with a logger attached\n--- without logger ---\n%q\n--- with logger ---\n%q", plainOut, loggedOut)
+				}
+				if len(plainHandler.records) != 0 {
+					t.Fatalf("nil agentSettings must produce no log records, got %d", len(plainHandler.records))
+				}
+				kinds := make([]string, 0, len(loggedHandler.records))
+				for _, rec := range loggedHandler.records {
+					attrs := recordAttrs(rec)
+					kind, _ := attrs["kind"].(string)
+					kinds = append(kinds, kind)
+					if (kind == "tool_call" || kind == "tool_result") && attrs["tool"] != "test" {
+						t.Fatalf("%v record tool = %v, want test", kind, attrs["tool"])
+					}
+				}
+				want := "reasoning,assistant,tool_call,tool_result,reasoning,final_answer"
+				if got := strings.Join(kinds, ","); got != want {
+					t.Fatalf("logged kinds = %q, want %q", got, want)
+				}
+			})
+		}
+	})
+}
+
+// TestQuerier_StructuredOutput_EmitsFinalAnswer proves the final-answer
+// record fires on the structured-output path too. The typed-agent path is
+// always structured (json_object), and the finalizer's structured branch
+// skips postProcessOutput's display sites — the record must be emitted
+// there, not lost (worklog 2026-08-15-agent-slog-output, Phase 3; gap found
+// by sakfråga worklog 26-08-15-agent-slog-wiring, Phase 2). The stream is
+// the same scriptedDisplayQuerier sequence as the raw/rolling invariance
+// test, so the kind sequence must match it exactly.
+func TestQuerier_StructuredOutput_EmitsFinalAnswer(t *testing.T) {
+	inttools.WithTestRegistry(t, func() {
+		inttools.Registry.Set("test", stubTool{output: "tool output"})
+
+		var out strings.Builder
+		h := &captureHandler{}
+		q := scriptedDisplayQuerier(&out, false, &AgentSettings{Logger: slog.New(h)})
+		q.structuredOutput = true
+		if err := q.Query(context.Background()); err != nil {
+			t.Fatalf("Query() error = %v", err)
+		}
+
+		kinds := make([]string, 0, len(h.records))
+		for _, rec := range h.records {
+			attrs := recordAttrs(rec)
+			kind, _ := attrs["kind"].(string)
+			kinds = append(kinds, kind)
+		}
+		want := "reasoning,assistant,tool_call,tool_result,reasoning,final_answer"
+		if got := strings.Join(kinds, ","); got != want {
+			t.Fatalf("logged kinds = %q, want %q", got, want)
+		}
+		if got := strings.TrimSpace(out.String()); got != "final answer" {
+			t.Fatalf("structured display = %q, want %q", got, "final answer")
+		}
+	})
+}
+
+func TestQuerier_LogMessage_toolAttr(t *testing.T) {
+	cases := []struct {
+		kind     string
+		tool     string
+		wantTool bool
+	}{
+		{"tool_call", "ls", true},
+		{"tool_result", "ls", true},
+		{"assistant", "", false},
+		{"reasoning", "", false},
+		{"final_answer", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			h := &captureHandler{}
+			q := &Querier[*MockQuerier]{agentSettings: &AgentSettings{Logger: slog.New(h)}}
+			q.logMessage(context.Background(), tc.kind, "text", tc.tool)
+
+			attrs := recordAttrs(h.records[0])
+			gotTool, ok := attrs["tool"]
+			if tc.wantTool {
+				if !ok || gotTool != tc.tool {
+					t.Fatalf("tool = %v (present %t), want %q", gotTool, ok, tc.tool)
+				}
+			} else if ok {
+				t.Fatalf("kind %q must not carry a tool attribute, got %q", tc.kind, gotTool)
+			}
+		})
+	}
+}

--- a/internal/text/tool_executor.go
+++ b/internal/text/tool_executor.go
@@ -63,7 +63,7 @@ func (e toolExecutor[C]) ExecuteBatch(ctx context.Context, session *QuerySession
 		return nil
 	}
 	plans := q.newStoploss().PreflightToolCallBudget(session, planned)
-	if err := e.finalizeAssistantTextBeforeToolCall(session, planned[0]); err != nil {
+	if err := e.finalizeAssistantTextBeforeToolCall(ctx, session, planned[0]); err != nil {
 		return fmt.Errorf("finalize assistant text before tool call: %w", err)
 	}
 	// load_skill self-emits its assistant tool-call at execution time (the
@@ -98,7 +98,7 @@ func (e toolExecutor[C]) ExecuteBatch(ctx context.Context, session *QuerySession
 		for _, plan := range plans[start:end] {
 			nonSkill = append(nonSkill, plan.call)
 		}
-		if err := e.emitAssistantToolCalls(session, nonSkill); err != nil {
+		if err := e.emitAssistantToolCalls(ctx, session, nonSkill); err != nil {
 			return err
 		}
 		for _, plan := range plans[start:end] {
@@ -124,11 +124,11 @@ func (e toolExecutor[C]) ExecuteBatch(ctx context.Context, session *QuerySession
 func (e toolExecutor[C]) runPlannedCall(ctx context.Context, session *QuerySession, plan toolCallBudgetPlan) error {
 	if !plan.allowed {
 		if plan.call.Name == string(pub_models.LoadSkillTool) {
-			if err := e.emitAssistantToolCall(session, plan.call); err != nil {
+			if err := e.emitAssistantToolCall(ctx, session, plan.call); err != nil {
 				return err
 			}
 		}
-		return e.emitToolResult(session, plan.call, plan.out)
+		return e.emitToolResult(ctx, session, plan.call, plan.out)
 	}
 	if plan.call.Name == string(pub_models.LoadSkillTool) {
 		return e.executeLoadSkill(ctx, session, plan.call)
@@ -148,7 +148,7 @@ func (e toolExecutor[C]) runPlannedCall(ctx context.Context, session *QuerySessi
 		out = tools.Invoke(ctx, plan.call)
 		e.recordToolCall(ctx, plan.call.Name, startedAt, out)
 	}
-	return e.emitToolResult(session, plan.call, plan.prefix+out)
+	return e.emitToolResult(ctx, session, plan.call, plan.prefix+out)
 }
 
 // recordToolCall reports one executed tool invocation to the configured
@@ -183,11 +183,11 @@ func toolCallError(out string) error {
 // appends the model-safe version to the chat history. The model-safe message
 // omits the PrettyPrint content so the model does not learn the "Call: ..."
 // text format, which causes hallucinations.
-func (e toolExecutor[C]) emitAssistantToolCall(session *QuerySession, call pub_models.Call) error {
-	return e.emitAssistantToolCalls(session, []pub_models.Call{call})
+func (e toolExecutor[C]) emitAssistantToolCall(ctx context.Context, session *QuerySession, call pub_models.Call) error {
+	return e.emitAssistantToolCalls(ctx, session, []pub_models.Call{call})
 }
 
-func (e toolExecutor[C]) emitAssistantToolCalls(session *QuerySession, calls []pub_models.Call) error {
+func (e toolExecutor[C]) emitAssistantToolCalls(ctx context.Context, session *QuerySession, calls []pub_models.Call) error {
 	q := e.querier
 	if len(calls) == 0 {
 		return nil
@@ -197,6 +197,10 @@ func (e toolExecutor[C]) emitAssistantToolCalls(session *QuerySession, calls []p
 		ToolCalls: calls,
 	}
 	for _, call := range calls {
+		// One tool_call record per declared call (worklog 2026-08-15-agent-slog-output, Phase 3). The model-safe
+		// message carries the raw call; the log carries the human-facing
+		// PrettyPrint text and the tool name.
+		q.logMessage(ctx, "tool_call", call.PrettyPrint(), call.Name)
 		if modelSafe.ReasoningContent == "" {
 			modelSafe.ReasoningContent = call.ReasoningContent
 		}
@@ -220,7 +224,7 @@ func (e toolExecutor[C]) emitAssistantToolCalls(session *QuerySession, calls []p
 
 // emitToolResult bounds the output, appends it as the tool-result turn, prints
 // it, and resets pending text — the shared tail of every tool-call exchange.
-func (e toolExecutor[C]) emitToolResult(session *QuerySession, call pub_models.Call, out string) error {
+func (e toolExecutor[C]) emitToolResult(ctx context.Context, session *QuerySession, call pub_models.Call, out string) error {
 	q := e.querier
 	displayOut := out
 	out = limitToolOutput(out, q.toolOutputRuneLimit)
@@ -228,6 +232,9 @@ func (e toolExecutor[C]) emitToolResult(session *QuerySession, call pub_models.C
 		out = fmt.Sprintf("<NO-OUTPUT> tool %s completed successfully but produced no stdout/stderr.", call.Name)
 		displayOut = out
 	}
+	// One tool_result record per emitted result; the display body (bounded,
+	// not the transcript copy) is what a human saw (worklog 2026-08-15-agent-slog-output, Phase 3).
+	q.logMessage(ctx, "tool_result", displayOut, call.Name)
 	outMsg := pub_models.Message{
 		Role:       "tool",
 		Content:    out,
@@ -270,10 +277,10 @@ func (e toolExecutor[C]) executeLoadSkill(ctx context.Context, session *QuerySes
 		return err
 	}
 	if loaded.ActivationErr != "" {
-		if err := e.emitAssistantToolCall(session, call); err != nil {
+		if err := e.emitAssistantToolCall(ctx, session, call); err != nil {
 			return err
 		}
-		return e.emitToolResult(session, call, "ERROR: "+loaded.ActivationErr)
+		return e.emitToolResult(ctx, session, call, "ERROR: "+loaded.ActivationErr)
 	}
 	if len(loaded.ActiveTools) > 0 {
 		q.baseTools = loaded.ActiveTools
@@ -314,7 +321,10 @@ func (e toolExecutor[C]) executeLoadSkill(ctx context.Context, session *QuerySes
 			userVisibleContent = body + "\n\n" + userVisibleContent
 		}
 	}
-	if err := e.emitAssistantToolCall(session, call); err != nil {
+	// The load_skill result record carries the final display body, after the
+	// warnings are folded in (worklog 2026-08-15-agent-slog-output, Phase 3).
+	q.logMessage(ctx, "tool_result", userVisibleContent, string(pub_models.LoadSkillTool))
+	if err := e.emitAssistantToolCall(ctx, session, call); err != nil {
 		return err
 	}
 	// Skill bodies are persisted and displayed in full (no output limit, no
@@ -366,7 +376,7 @@ func formatSkillOutputForDisplay(loaded LoadedSkillRuntime) string {
 	)
 }
 
-func (e toolExecutor[C]) finalizeAssistantTextBeforeToolCall(session *QuerySession, call pub_models.Call) error {
+func (e toolExecutor[C]) finalizeAssistantTextBeforeToolCall(ctx context.Context, session *QuerySession, call pub_models.Call) error {
 	if session == nil {
 		return errors.New("session is nil")
 	}
@@ -376,15 +386,15 @@ func (e toolExecutor[C]) finalizeAssistantTextBeforeToolCall(session *QuerySessi
 	}
 	q := e.querier
 	if q.usesActivityViewport() {
-		return e.finalizeAssistantTextRolling(session, pending, call)
+		return e.finalizeAssistantTextRolling(ctx, session, pending, call)
 	}
-	return e.finalizeAssistantTextPlain(session, pending, call)
+	return e.finalizeAssistantTextPlain(ctx, session, pending, call)
 }
 
 // finalizeAssistantTextPlain finalizes assistant prose for non-rolling
 // display: the streamed text is cleared and re-printed as one proper message
 // above the upcoming tool activity. Echoed tool-call text is dropped.
-func (e toolExecutor[C]) finalizeAssistantTextPlain(session *QuerySession, pending string, call pub_models.Call) error {
+func (e toolExecutor[C]) finalizeAssistantTextPlain(ctx context.Context, session *QuerySession, pending string, call pub_models.Call) error {
 	q := e.querier
 	if !q.rawDisplay() && !q.structuredOutput && q.dims.Width > 0 {
 		utils.UpdateMessageTerminalMetadata(pending, &session.Line, &session.LineCount, q.dims.Width)
@@ -403,6 +413,8 @@ func (e toolExecutor[C]) finalizeAssistantTextPlain(session *QuerySession, pendi
 		q.lineCount = 0
 		return nil
 	}
+	// Finalized, non-echoed prose is one completed assistant message (worklog 2026-08-15-agent-slog-output, Phase 3).
+	q.logMessage(ctx, "assistant", pending, "")
 	session.ResetPendingText()
 	session.FinalAssistantText = pending
 	q.fullMsg = pending
@@ -429,7 +441,7 @@ func (e toolExecutor[C]) finalizeAssistantTextPlain(session *QuerySession, pendi
 // window is active. The prose already lives inside the window (or is moved
 // into it), so nothing is re-printed outside the window. Echoed tool-call text
 // is dropped from the window and the transcript.
-func (e toolExecutor[C]) finalizeAssistantTextRolling(session *QuerySession, pending string, call pub_models.Call) error {
+func (e toolExecutor[C]) finalizeAssistantTextRolling(ctx context.Context, session *QuerySession, pending string, call pub_models.Call) error {
 	q := e.querier
 	q.ensureActivityViewport()
 	if isEchoedToolCallText(pending, call) {
@@ -452,6 +464,8 @@ func (e toolExecutor[C]) finalizeAssistantTextRolling(session *QuerySession, pen
 		q.lineCount = 0
 		return nil
 	}
+	// Finalized, non-echoed prose is one completed assistant message (worklog 2026-08-15-agent-slog-output, Phase 3).
+	q.logMessage(ctx, "assistant", pending, "")
 	if !q.activityViewport.TextBlockActive() {
 		// The prose was streamed before any activity created the window. Move
 		// it inside the window instead of leaving it outside it.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path"
 	"strings"
@@ -35,9 +36,22 @@ type Agent struct {
 	usageRecorder    models.CallUsageRecorder
 	toolCallRecorder models.ToolCallRecorder
 
-	querierCreator func(ctx context.Context, conf text.Configurations) (priv_models.Querier, error)
+	// logger receives one slog record per completed message (assistant,
+	// reasoning, tool_call, tool_result, final_answer), truncated to
+	// slogRuneLimit runes. Nil (the default) disables the channel. Library
+	// mode stays silent on stdout regardless: asInternalConfig hardcodes
+	// Out to io.Discard, so the logger is the sole embedded output channel
+	// (worklog 2026-08-15-agent-slog-output, D4).
+	logger *slog.Logger
+	// slogLevel is the single caller-set level for every logged message; the
+	// kind attribute is how a caller filters finer (worklog 2026-08-15-agent-slog-output, D3). Default Debug.
+	slogLevel slog.Level
+	// slogRuneLimit caps every logged text to this many runes via a rune-safe
+	// head/tail split around the single-rune marker "…"; <= 0 means no cap
+	// (worklog 2026-08-15-agent-slog-output, D2, D5). Default 200.
+	slogRuneLimit int
 
-	out io.Writer
+	querierCreator func(ctx context.Context, conf text.Configurations) (priv_models.Querier, error)
 
 	querier priv_models.ChatQuerier
 }
@@ -54,7 +68,8 @@ var defaultConf = Agent{
 	tools:          make([]models.LLMTool, 0),
 	mcpServers:     make([]models.McpServer, 0),
 	querierCreator: internal.CreateTextQuerier,
-	out:            os.Stdout,
+	slogLevel:      slog.LevelDebug,
+	slogRuneLimit:  200,
 }
 
 type Option func(*Agent)
@@ -137,9 +152,33 @@ func WithMcpServers(mcpServers []models.McpServer) Option {
 	}
 }
 
-func WithOutputTo(out io.Writer) Option {
+// WithLogger attaches a *slog.Logger to the agent. The logger receives one
+// record per completed message (assistant, reasoning, tool_call,
+// tool_result, final_answer), truncated to WithSlogRuneLimit runes. nil (the
+// default) disables the channel. Library mode stays silent on stdout
+// regardless of this option: the querier's terminal display is discarded and
+// the logger is the sole embedded output channel.
+func WithLogger(l *slog.Logger) Option {
 	return func(a *Agent) {
-		a.out = out
+		a.logger = l
+	}
+}
+
+// WithSlogLevel sets the single level used for every logged message. The
+// default is slog.LevelDebug; the message kind is carried as the "kind"
+// attribute so callers can filter finer without per-kind levels.
+func WithSlogLevel(level slog.Level) Option {
+	return func(a *Agent) {
+		a.slogLevel = level
+	}
+}
+
+// WithSlogRuneLimit caps every logged message text to n runes with a rune-safe
+// head/tail split around the single-rune marker "…". The default is 200; a
+// value <= 0 disables the cap (the full text is logged unchanged).
+func WithSlogRuneLimit(n int) Option {
+	return func(a *Agent) {
+		a.slogRuneLimit = n
 	}
 }
 
@@ -207,9 +246,20 @@ func (a *Agent) asInternalConfig() text.Configurations {
 		RequestedToolGlobs: a.toolGlobs,
 		CmdBan:             a.cmdBan,
 		ResponseFormat:     a.responseFormat,
-		UsageRecorder:      a.usageRecorder,
-		ToolCallRecorder:   a.toolCallRecorder,
-		Out:                a.out,
+		// Library mode is silent on stdout: embedded use never writes raw
+		// terminal output. The slog logger (AgentSettings) is the sole
+		// embedded output channel (worklog 2026-08-15-agent-slog-output, D4).
+		Out: io.Discard,
+	}
+	// Agent-only settings ride one pointer (worklog 2026-08-15-agent-slog-output, D7): the slog logger, its level,
+	// the rune cap, and both recorder hooks. NewQuerier reads the recorders
+	// from this pointer; Configurations carries no loose recorder fields.
+	conf.AgentSettings = &text.AgentSettings{
+		Logger:           a.logger,
+		Level:            a.slogLevel,
+		RuneLimit:        a.slogRuneLimit,
+		UsageRecorder:    a.usageRecorder,
+		ToolCallRecorder: a.toolCallRecorder,
 	}
 	// A zero-value Stoploss must not create a non-nil internal pointer: the
 	// agent default stays unlimited (MaxTokens <= 0 disables the stoploss).

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"os"
 	"path"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -81,6 +81,40 @@ func TestNew(t *testing.T) {
 		a := New()
 		if a.model == "changed" {
 			t.Errorf("global state was mutated, model is still 'changed'")
+		}
+	})
+
+	t.Run("it should default the slog channel", func(t *testing.T) {
+		// The slog channel is disabled by default (nil logger); the level
+		// and rune cap ship enabled so a caller attaching only a logger gets
+		// Debug-level, 200-rune records (worklog 2026-08-15-agent-slog-output, D2, D3).
+		a := New()
+		if a.logger != nil {
+			t.Errorf("expected nil logger by default, got %v", a.logger)
+		}
+		if a.slogLevel != slog.LevelDebug {
+			t.Errorf("expected default slog level Debug, got %v", a.slogLevel)
+		}
+		if a.slogRuneLimit != 200 {
+			t.Errorf("expected default slog rune limit 200, got %d", a.slogRuneLimit)
+		}
+	})
+
+	t.Run("it should apply the slog options", func(t *testing.T) {
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		a := New(
+			WithLogger(logger),
+			WithSlogLevel(slog.LevelWarn),
+			WithSlogRuneLimit(5),
+		)
+		if a.logger != logger {
+			t.Errorf("expected logger to be applied, got %v", a.logger)
+		}
+		if a.slogLevel != slog.LevelWarn {
+			t.Errorf("expected slog level Warn, got %v", a.slogLevel)
+		}
+		if a.slogRuneLimit != 5 {
+			t.Errorf("expected slog rune limit 5, got %d", a.slogRuneLimit)
 		}
 	})
 }
@@ -157,33 +191,10 @@ func TestAgent_Setup(t *testing.T) {
 	})
 }
 
-func TestAgent_Setup_receives_Out_in_config(t *testing.T) {
-	// When WithOutputTo is used, the custom writer must reach
-	// the querierCreator via Configurations.Out.
-	custom := new(stringsBuilderWriter)
-	var capturedOut io.Writer
-
-	a := New(WithOutputTo(custom))
-	a.cfgDir = t.TempDir()
-	a.querierCreator = func(ctx context.Context, conf text.Configurations) (priv_models.Querier, error) {
-		capturedOut = conf.Out
-		return &mockChatQuerier{}, nil
-	}
-
-	err := a.Setup(context.Background())
-	if err != nil {
-		t.Fatalf("Setup failed: %v", err)
-	}
-
-	if capturedOut != custom {
-		t.Errorf("expected Configurations.Out to be the custom writer, got %v", capturedOut)
-	}
-}
-
-func TestAgent_Setup_receives_stdout_when_no_WithOutputTo(t *testing.T) {
-	// The defaultConf sets out: os.Stdout. Verify that when no
-	// WithOutputTo is passed, the querierCreator receives os.Stdout
-	// (not nil), preserving backward compatibility.
+func TestAgent_Setup_receives_io_Discard(t *testing.T) {
+	// Library mode is silent on stdout (worklog 2026-08-15-agent-slog-output, D4): regardless of options, the
+	// querierCreator must receive Configurations.Out == io.Discard so
+	// embedded use never writes raw terminal output.
 	var capturedOut io.Writer
 
 	a := New()
@@ -198,8 +209,8 @@ func TestAgent_Setup_receives_stdout_when_no_WithOutputTo(t *testing.T) {
 		t.Fatalf("Setup failed: %v", err)
 	}
 
-	if capturedOut != os.Stdout {
-		t.Errorf("expected Configurations.Out to be os.Stdout by default, got %v", capturedOut)
+	if capturedOut != io.Discard {
+		t.Errorf("expected Configurations.Out to be io.Discard, got %v", capturedOut)
 	}
 }
 
@@ -242,22 +253,73 @@ func TestAgent_asInternalConfig(t *testing.T) {
 	if !conf.SaveReplyAsConv {
 		t.Error("expected SaveReplyAsConv to be true")
 	}
-	// Verify Out is os.Stdout by default (the Agent's defaultConf sets out: os.Stdout).
-	// This preserves backward-compatible behavior: with no WithOutputTo,
-	// output goes to stdout.
-	if conf.Out != os.Stdout {
-		t.Errorf("expected Out to be os.Stdout by default, got %v", conf.Out)
+	// Verify Out is io.Discard: library mode is silent on stdout and the
+	// slog logger is the sole embedded output channel (worklog 2026-08-15-agent-slog-output, D4).
+	if conf.Out != io.Discard {
+		t.Errorf("expected Out to be io.Discard, got %v", conf.Out)
 	}
 }
 
-func TestAgent_WithOutputTo_propagates(t *testing.T) {
-	// Verify that WithOutputTo propagates the custom writer to
-	// the internal Configurations so the querier can use it.
-	custom := new(stringsBuilderWriter)
-	a := New(WithOutputTo(custom))
+func TestAgent_WithLogger_propagates(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(WithLogger(logger))
 	conf := a.asInternalConfig()
-	if conf.Out != custom {
-		t.Errorf("expected Out to be the custom writer, got %v", conf.Out)
+	if conf.AgentSettings == nil {
+		t.Fatal("expected AgentSettings in internal config")
+	}
+	if conf.AgentSettings.Logger != logger {
+		t.Errorf("expected AgentSettings.Logger to be the attached logger, got %v", conf.AgentSettings.Logger)
+	}
+}
+
+func TestAgent_WithSlogLevel_propagates(t *testing.T) {
+	a := New(WithSlogLevel(slog.LevelWarn))
+	conf := a.asInternalConfig()
+	if conf.AgentSettings == nil {
+		t.Fatal("expected AgentSettings in internal config")
+	}
+	if conf.AgentSettings.Level != slog.LevelWarn {
+		t.Errorf("expected AgentSettings.Level Warn, got %v", conf.AgentSettings.Level)
+	}
+}
+
+func TestAgent_WithSlogRuneLimit_propagates(t *testing.T) {
+	a := New(WithSlogRuneLimit(42))
+	conf := a.asInternalConfig()
+	if conf.AgentSettings == nil {
+		t.Fatal("expected AgentSettings in internal config")
+	}
+	if conf.AgentSettings.RuneLimit != 42 {
+		t.Errorf("expected AgentSettings.RuneLimit 42, got %d", conf.AgentSettings.RuneLimit)
+	}
+}
+
+func TestAgent_WithLogger_nil_disables(t *testing.T) {
+	// WithLogger(nil) must leave the channel disabled: the grouped pointer
+	// still exists, but Logger stays nil (the error coverage contract).
+	a := New(WithLogger(nil))
+	conf := a.asInternalConfig()
+	if conf.AgentSettings == nil {
+		t.Fatal("expected AgentSettings in internal config")
+	}
+	if conf.AgentSettings.Logger != nil {
+		t.Errorf("expected nil AgentSettings.Logger, got %v", conf.AgentSettings.Logger)
+	}
+}
+
+func TestAgent_WithSlogRuneLimit_nonpositive_carried(t *testing.T) {
+	// WithSlogRuneLimit(0) and negative values are carried verbatim;
+	// worklog 2026-08-15-agent-slog-output D5 makes truncation treat <= 0 as
+	// no cap (the querier side, Phase 2).
+	for _, n := range []int{0, -7} {
+		a := New(WithSlogRuneLimit(n))
+		conf := a.asInternalConfig()
+		if conf.AgentSettings == nil {
+			t.Fatal("expected AgentSettings in internal config")
+		}
+		if conf.AgentSettings.RuneLimit != n {
+			t.Errorf("expected AgentSettings.RuneLimit %d, got %d", n, conf.AgentSettings.RuneLimit)
+		}
 	}
 }
 
@@ -324,28 +386,6 @@ func TestAgent_WithCmdBanList_PropagatesToInternalConfig(t *testing.T) {
 	plain := New()
 	if plain.asInternalConfig().CmdBan != nil {
 		t.Fatalf("expected nil CmdBan in internal config by default")
-	}
-}
-
-// stringsBuilderWriter is a minimal io.Writer backed by a strings.Builder for tests.
-type stringsBuilderWriter struct{ strings.Builder }
-
-func (w *stringsBuilderWriter) Write(p []byte) (int, error) {
-	return w.Builder.Write(p)
-}
-
-func (w *stringsBuilderWriter) String() string { return w.Builder.String() }
-
-func TestTypedQuerier_WithOutputTo_suppresses_stdout(t *testing.T) {
-	// A TypedQuerier with WithOutputTo(customWriter) must route its
-	// agent's output to that writer, never to os.Stdout.
-	custom := new(stringsBuilderWriter)
-	tq := NewTyped[struct{}](
-		WithOutputTo(custom),
-	).agent
-	conf := tq.asInternalConfig()
-	if conf.Out != custom {
-		t.Errorf("TypedQuerier did not propagate Out to internal config: got %v", conf.Out)
 	}
 }
 

--- a/pkg/agent/cmd_ban_e2e_test.go
+++ b/pkg/agent/cmd_ban_e2e_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -168,7 +167,6 @@ func TestAgentCmdBan_SingleAgentRefusal(t *testing.T) {
 		WithModel("mock_test"),
 		WithToolGlobs("cmd"),
 		WithCmdBanList("touch"),
-		WithOutputTo(io.Discard),
 	)
 
 	chat := queryCmdBanAgent(t, &a, "please tool_cmd")
@@ -191,12 +189,10 @@ func TestAgentCmdBan_SequentialPerRunIsolation(t *testing.T) {
 		WithModel("mock_test"),
 		WithToolGlobs("cmd"),
 		WithCmdBanList("touch"),
-		WithOutputTo(io.Discard),
 	)
 	permissive := newCmdBanAgent(t,
 		WithModel("mock_test"),
 		WithToolGlobs("cmd"),
-		WithOutputTo(io.Discard),
 	)
 
 	// Run 1: the banned agent refuses `touch <marker1>`.
@@ -260,13 +256,11 @@ func TestAgentCmdBan_ConcurrentDistinctLists(t *testing.T) {
 		WithModel("mock_test"),
 		WithToolGlobs("cmd"),
 		WithCmdBanList("touch"),
-		WithOutputTo(io.Discard),
 	)
 	rmAgent := newCmdBanAgent(t,
 		WithModel("mock_test"),
 		WithToolGlobs("async_cmd"),
 		WithCmdBanList("rm"),
-		WithOutputTo(io.Discard),
 	)
 
 	const iterations = 3
@@ -350,13 +344,11 @@ func TestAgentCmdBan_ConcurrentPermissiveAndBanned(t *testing.T) {
 	permissive := newCmdBanAgent(t,
 		WithModel("mock_test"),
 		WithToolGlobs("cmd"),
-		WithOutputTo(io.Discard),
 	)
 	banned := newCmdBanAgent(t,
 		WithModel("mock_test"),
 		WithToolGlobs("async_cmd"),
 		WithCmdBanList("touch"),
-		WithOutputTo(io.Discard),
 	)
 
 	ctx := context.Background()

--- a/pkg/agent/recorder_test.go
+++ b/pkg/agent/recorder_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"errors"
-	"io"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -77,7 +76,6 @@ func TestAgent_WithUsageRecorder(t *testing.T) {
 	a := newCmdBanAgent(t,
 		WithModel("mock_test"),
 		WithUsageRecorder(rec),
-		WithOutputTo(io.Discard),
 	)
 
 	queryCmdBanAgent(t, &a, "please reply")
@@ -124,7 +122,6 @@ func TestAgent_WithToolCallRecorder(t *testing.T) {
 		WithToolGlobs("ls"),
 		WithUsageRecorder(usageRec),
 		WithToolCallRecorder(toolRec),
-		WithOutputTo(io.Discard),
 	)
 
 	queryCmdBanAgent(t, &a, "please tool_ls")
@@ -176,7 +173,6 @@ func TestAgent_WithToolCallRecorder_Error(t *testing.T) {
 		WithToolGlobs("cmd"),
 		WithCmdBanList("touch"),
 		WithToolCallRecorder(toolRec),
-		WithOutputTo(io.Discard),
 	)
 
 	chat := queryCmdBanAgent(t, &a, "please tool_cmd")
@@ -215,7 +211,6 @@ func TestAgent_RecorderErrorAbsorption(t *testing.T) {
 		WithToolGlobs("ls"),
 		WithUsageRecorder(usageRec),
 		WithToolCallRecorder(toolRec),
-		WithOutputTo(io.Discard),
 	)
 
 	// A recorder error must not surface from Setup or Query.
@@ -237,29 +232,31 @@ func TestAgent_NoRecorder_Noop(t *testing.T) {
 	a := newCmdBanAgent(t,
 		WithModel("mock_test"),
 		WithToolGlobs("ls"),
-		WithOutputTo(io.Discard),
 	)
 
 	queryCmdBanAgent(t, &a, "please tool_ls")
 }
 
 // TestAgent_RecorderOptions_PropagateToInternalConfig proves both recorder
-// options reach text.Configurations via asInternalConfig, and that the
+// options reach text.Configurations via AgentSettings (worklog 2026-08-15-agent-slog-output, D7), and that the
 // defaults stay nil.
 func TestAgent_RecorderOptions_PropagateToInternalConfig(t *testing.T) {
 	usageRec := &recordingUsageRecorder{}
 	toolRec := &recordingToolRecorder{}
 	a := New(WithUsageRecorder(usageRec), WithToolCallRecorder(toolRec))
 	conf := a.asInternalConfig()
-	if conf.UsageRecorder != usageRec {
-		t.Fatalf("expected UsageRecorder to propagate, got %v", conf.UsageRecorder)
+	if conf.AgentSettings == nil {
+		t.Fatal("expected AgentSettings in internal config")
 	}
-	if conf.ToolCallRecorder != toolRec {
-		t.Fatalf("expected ToolCallRecorder to propagate, got %v", conf.ToolCallRecorder)
+	if conf.AgentSettings.UsageRecorder != usageRec {
+		t.Fatalf("expected AgentSettings.UsageRecorder to propagate, got %v", conf.AgentSettings.UsageRecorder)
+	}
+	if conf.AgentSettings.ToolCallRecorder != toolRec {
+		t.Fatalf("expected AgentSettings.ToolCallRecorder to propagate, got %v", conf.AgentSettings.ToolCallRecorder)
 	}
 
 	plain := New()
-	if plain.asInternalConfig().UsageRecorder != nil || plain.asInternalConfig().ToolCallRecorder != nil {
+	if plain.asInternalConfig().AgentSettings.UsageRecorder != nil || plain.asInternalConfig().AgentSettings.ToolCallRecorder != nil {
 		t.Fatal("expected nil recorders in the internal config by default")
 	}
 }

--- a/pkg/agent/typed_test.go
+++ b/pkg/agent/typed_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"context"
 	"fmt"
+	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/baalimago/clai/pkg/text/models"
@@ -452,6 +454,51 @@ func TestTypedMetadataQuerier_Query(t *testing.T) {
 			t.Errorf("expected CostUSD=0.002, got %f", meta.CostUSD)
 		}
 	})
+}
+
+// TestTypedQuerier_WithLogger_propagates proves NewTyped and NewTypedMetadata
+// forward the three slog options into the wrapped agent's internal config:
+// the logger itself, the level, and the rune cap ride AgentSettings (worklog 2026-08-15-agent-slog-output, D7).
+func TestTypedQuerier_WithLogger_propagates(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	tq := NewTyped[struct{}](
+		WithLogger(logger),
+		WithSlogLevel(slog.LevelWarn),
+		WithSlogRuneLimit(7),
+	)
+	conf := tq.agent.asInternalConfig()
+	if conf.AgentSettings == nil {
+		t.Fatal("expected AgentSettings in internal config")
+	}
+	if conf.AgentSettings.Logger != logger {
+		t.Errorf("NewTyped did not forward the logger, got %v", conf.AgentSettings.Logger)
+	}
+	if conf.AgentSettings.Level != slog.LevelWarn {
+		t.Errorf("NewTyped did not forward the level, got %v", conf.AgentSettings.Level)
+	}
+	if conf.AgentSettings.RuneLimit != 7 {
+		t.Errorf("NewTyped did not forward the rune limit, got %d", conf.AgentSettings.RuneLimit)
+	}
+
+	tmq := NewTypedMetadata[struct{}](
+		WithLogger(logger),
+		WithSlogLevel(slog.LevelError),
+		WithSlogRuneLimit(9),
+	)
+	conf = tmq.agent.asInternalConfig()
+	if conf.AgentSettings == nil {
+		t.Fatal("expected AgentSettings in internal config")
+	}
+	if conf.AgentSettings.Logger != logger {
+		t.Errorf("NewTypedMetadata did not forward the logger, got %v", conf.AgentSettings.Logger)
+	}
+	if conf.AgentSettings.Level != slog.LevelError {
+		t.Errorf("NewTypedMetadata did not forward the level, got %v", conf.AgentSettings.Level)
+	}
+	if conf.AgentSettings.RuneLimit != 9 {
+		t.Errorf("NewTypedMetadata did not forward the rune limit, got %d", conf.AgentSettings.RuneLimit)
+	}
 }
 
 // stubChatQuerier returns a predefined chat, or an error if err is set.

--- a/worklogs/2026-08-15-agent-slog-output/README.md
+++ b/worklogs/2026-08-15-agent-slog-output/README.md
@@ -1,0 +1,210 @@
+# Agent slog output
+
+Replace the broken `WithOutputTo` writer injection on `pkg/agent` with an
+optional `log/slog` logger. Embedded (library) use becomes logger-only and
+never writes raw terminal output. The interactive CLI display path is
+untouched.
+
+## Status board
+
+| Phase | Deliverable                                                                                                                       | Status      |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| 1     | [Agent API](./phase-1-agent-api.md) — remove `WithOutputTo`, add `WithLogger`/`WithSlogLevel`/`WithSlogRuneLimit`                 | Complete (2026-08-15) |
+| 2     | [Config + querier plumbing](./phase-2-config-plumbing.md) — `AgentSettings` struct, `Querier` field, rune middle-truncation helper | Complete (2026-08-15) |
+| 3     | [Emit hooks](./phase-3-emit-hooks.md) — log each completed message at its semantic completion site                                | Complete (2026-08-15) |
+| 4     | [CLI-invariance + gates](./phase-4-cli-invariance-gates.md) — prove display unchanged, full gate sweep                            | Complete (2026-08-15) |
+
+## Feedback index
+
+| ID  | Severity | Phase | Summary |
+| --- | -------- | ----- | ------- |
+| —   | —        | —     | —       |
+
+## Strategy
+
+The public library API today offers `agent.WithOutputTo(io.Writer)` to choose
+where the querier's terminal-style display goes. For embedded consumers that
+knob is broken: with structured output (`WithResponseFormat`) the streamed
+tokens, reasoning, and tool rendering are suppressed, and with a non-terminal
+`out` the final answer is also suppressed. So the writer is set but nothing
+useful is written.
+
+The fix removes the writer knob from `pkg/agent` and replaces it with three
+options that feed a structured, per-message logging channel:
+
+```go
+agent.WithLogger(l *slog.Logger)      // nil = disabled (default)
+agent.WithSlogLevel(level slog.Level) // default slog.LevelDebug
+agent.WithSlogRuneLimit(n int)        // default 200
+```
+
+Those three values, plus the existing recorder hooks, are carried into the
+querier through one agent-only `text.AgentSettings` pointer (D7), not as loose
+`Configurations` fields.
+
+Load-bearing invariants (every phase must preserve them):
+
+1. **CLI output must not change.** The CLI does not use `pkg/agent`; it builds
+   `internal/text.Configurations` directly and sets `Out` to stdout/file. We
+   do not modify any existing write to `Querier.out`. The new logger hooks are
+   additive only.
+2. **Library output is logger-only.** `pkg/agent` stops exposing `Out` and
+   hardcodes `Out: io.Discard` in `asInternalConfig`, so embedded use never
+   writes raw terminal output. This reproduces exactly what sakfråga did by
+   hand with `WithOutputTo(io.Discard)`.
+3. **The logger is unconditional.** It fires on every completed message and is
+   not gated by `structuredOutput`, `rawDisplay`, `debug`, or terminal
+   detection. Those gates remain display-only.
+4. **No streaming.** The logger fires once per _completed_ message, never per
+   streamed token.
+5. **Rune-safe middle truncation.** Every logged text is capped to
+   `AgentSettings.RuneLimit` runes by a head/tail split around the single-rune
+   marker `…`; a multi-byte rune is never cut in half.
+
+Completed-message kinds (the `kind` attribute): `assistant`, `reasoning`,
+`tool_call`, `tool_result`, `final_answer`.
+
+Log line shape:
+
+```go
+logger.Log(ctx, level, "clai message",
+    "kind", kind,
+    "text", truncatedText,
+    "truncated", wasTruncated,
+    // tool_call / tool_result only:
+    "tool", toolName,
+)
+```
+
+`ctx` is the live query context, threaded through the hooks (D6). `level` is
+the single caller-set `SlogLevel` (D3). The caller controls the level; the
+`kind` attribute is how the caller filters if it needs finer control.
+
+## Decisions log
+
+- **D1 (Q1):** inject `*slog.Logger` directly (`WithLogger`), not a narrow
+  interface and not a content event sink. `log/slog` is stdlib, and sakfråga
+  already logs with `slog` + `slogcolor` and a `corrID` attr, so a per-job
+  `slog.With("corrID", ...)` propagates for free.
+- **D2 (Q2):** per-completed-message logging with rune-based middle
+  truncation. Runes, not tokens: clai's token count is a whitespace heuristic,
+  while `utf8.RuneCountInString` is exact. 50 tokens ≈ 200 runes. The marker is
+  the single rune `…`: the `truncated` bool is the machine signal, `…` is the
+  human signal.
+- **D3 (Q3):** single caller-set level via `WithSlogLevel`; no per-kind level
+  table inside clai. Default Debug.
+- **D4 (Q4/Q5):** remove `WithOutputTo` entirely. Library mode is silent on
+  stdout; the logger is the sole embedded output channel. The CLI's internal
+  display (`Configurations.Out` → `Querier.out`) stays and must not change.
+- **D5:** `RuneLimit <= 0` means no cap: `truncateMiddleRunes` returns the input
+  unchanged with `truncated=false`.
+- **D6:** the slog hooks receive the live query `context.Context`, threaded
+  through the session runner, finalizer, and tool executor. `log/slog` forwards
+  ctx to the handler, so a ctx-aware external handler (e.g. OpenTelemetry) can
+  enrich or correlate records. No `context.Background()` at the hook sites.
+- **D7:** batch agent-only runtime settings into `text.AgentSettings`, carried
+  on `Configurations` as `AgentSettings *AgentSettings` with `json:"-"`. It
+  holds `Logger`, `Level`, `RuneLimit`, `UsageRecorder`, and `ToolCallRecorder`.
+  `RequestedToolGlobs` stays on `Configurations`: the CLI (`-use-tools`),
+  profiles, and the `pkg/text` full querier also populate it, so it is not
+  agent-only.
+- **D8 (Phase 1, 2026-08-15):** the phase landed as a partial working tree:
+  `pkg/agent/agent.go` and `internal/text/conf.go` already carried the
+  production changes (the `AgentSettings` struct + field and the three slog
+  options), but no test compiled (`WithOutputTo` references remained). This
+  session finished the phase by updating the `pkg/agent` tests and docs.
+  `text.AgentSettings` and the `Configurations.AgentSettings` field are a
+  Phase 1 dependency (the spec's `asInternalConfig` snippet requires them);
+  the loose `UsageRecorder`/`ToolCallRecorder` fields stay on
+  `Configurations` and stay populated by `asInternalConfig` until Phase 2
+  moves `NewQuerier`'s recorder source onto `AgentSettings` — the recorder
+  e2e tests (Phase 1 AC) run through the current `NewQuerier`, which still
+  reads the loose fields.
+- **D9 (Phase 2, 2026-08-15, clai worker session 2026-08-15-02):** the loose
+  `UsageRecorder`/`ToolCallRecorder` fields are removed from
+  `Configurations`; `NewQuerier` now sources both recorders (and the whole
+  `agentSettings` pointer) from `Configurations.AgentSettings` when it is
+  non-nil, and leaves them nil otherwise. `Querier` gains the
+  `agentSettings *AgentSettings` field that Phase 3's `logMessage` reads.
+  The rune middle-truncation helper landed as `truncateMiddleRunes` +
+  `slogTruncationMarker` in `internal/text/slog_output.go` with a
+  range-based head/tail split that never allocates a full `[]rune` copy (the
+  reasoning buffer can reach 1 MiB).
+- **D10 (Phase 3, 2026-08-15, clai worker session 2026-08-15-03):** the
+  semantic-empty gates live at the hook sites, not inside `logMessage`:
+  `logMessage` stays the pure nil-settings/nil-logger gate, while
+  `closeReasoningIfOpen` guards an empty reasoning buffer and the
+  `finalizeAssistantText*` pair guards echoed/empty prose. The `tool_result`
+  hook in `emitToolResult` fires after the `<NO-OUTPUT>` substitution, so
+  `displayOut` is the final display body. The `load_skill` success path logs
+  its own `tool_result` (it never calls `emitToolResult`), carrying the
+  warning-folded `userVisibleContent`. `ctx` threading follows D6: the
+  session runner, finalizer, and tool executor all forward the live query
+  context; the legacy test-only `Querier.postProcess` passes
+  `context.Background()`.
+- **D11 (Phase 4, 2026-08-15, clai worker session 2026-08-15-04):**
+  `TestSlogLogger_DoesNotPerturbDisplay` in `slog_output_test.go` is the
+  CLI-invariance proof: one scripted stream (reasoning, assistant prose, one
+  tool call, reasoning, final answer) runs twice — `agentSettings == nil`
+  vs a capturing `*slog.Logger` — and asserts byte-identical `out` in both
+  the raw display path and the default rolling-window path. The logger run
+  must additionally emit the five kinds in stream order with the `tool`
+  attribute on `tool_call`/`tool_result`; the nil run emits nothing. No
+  production write to `out` was modified, reordered, or gated; the full
+  pre-existing suite (including CLI e2e) passes unchanged.
+
+## Test doctrine
+
+No event bus. Phases are unit-test-only except Phase 4, whose contract is a
+CLI-invariance test: with a scripted stream, the bytes written to `out` are
+byte-identical with and without a logger attached, and the existing CLI/e2e
+test suite passes unchanged.
+
+## Session journal
+
+- 2026-08-15 — design Q&A (D1–D4) and worklog authored. No code yet.
+- 2026-08-15 — validation review: pinned D5 (limit ≤ 0 → no cap), D6 (thread
+  live ctx through slog hooks), D7 (`AgentSettings` grouping); corrected the
+  Phase 4 gates and the Phase 3 `load_skill`/marker contracts.
+- 2026-08-15 — Phase 1 implemented (worker session 2026-08-15-01): production
+  changes were already in the working tree; this session completed the phase
+  with the `pkg/agent` test sweep (`WithOutputTo` removed everywhere, the
+  three slog propagation tests, nil-logger and non-positive rune-limit
+  coverage, typed-forwarding test, recorder assertions moved onto
+  `AgentSettings`) and the documentation updates (D8). Full strict QA gate
+  (`go test ./... -race -cover -count=3 -timeout=30s`) passes.
+- 2026-08-15 — Phase 2 implemented (worker session 2026-08-15-02): removed
+  the loose `UsageRecorder`/`ToolCallRecorder` fields from `Configurations`
+  (D9), switched `NewQuerier`'s recorder source onto the `AgentSettings`
+  pointer, added the `Querier.agentSettings` field, and landed
+  `truncateMiddleRunes` + `slogTruncationMarker` in
+  `internal/text/slog_output.go` (100% statement coverage on all three
+  functions). The pre-written `slog_output_test.go` plus the new
+  `TestConfigurations_AgentSettings`, `TestConfigurations_AgentSettings_jsonOmitted`,
+  and `TestNewQuerier_AgentSettings` (with its nil-settings sub-case) cover
+  every Phase 2 AC. Full strict QA gate passes unedited.
+- 2026-08-15 — Phase 3 implemented (worker session 2026-08-15-03): added
+  `Querier.logMessage` to `internal/text/slog_output.go` and wired the five
+  hook sites (reasoning, assistant, tool_call, tool_result, final_answer),
+  threading the live query `ctx` through `closeReasoningIfOpen`,
+  `finalizeAssistantTextBeforeToolCall` (+ plain/rolling pair),
+  `emitAssistantToolCall(s)`, `emitToolResult`, `sessionFinalizerer`/
+  `sessionFinalizer`, and `postProcessOutput` (D6). The legacy test-only
+  `Querier.postProcess` passes `context.Background()`. Every Phase 3 AC is
+  covered: `logMessage` unit tests (nil gate, truncation, ctx forwarding,
+  kind table, tool attribute) in `slog_output_test.go` and the four hook-site
+  tests in the new `emit_hooks_test.go`. The `captureHandler` + `recordAttrs`
+  helpers back both files. Full strict QA gate passes unedited; the dupl
+  clone groups are all pre-existing and none touch the phase's files.
+- 2026-08-15 — Phase 4 implemented (worker session 2026-08-15-04): added
+  `TestSlogLogger_DoesNotPerturbDisplay` to `internal/text/slog_output_test.go`
+  (D11). The test runs one scripted stream twice per display mode (raw and
+  the default rolling-window path) — `agentSettings == nil` vs a capturing
+  `*slog.Logger` — and asserts the `out` bytes are byte-identical, that the
+  nil run emits no records, and that the logger run emits the five completed-
+  message kinds in stream order with the `tool` attribute on
+  `tool_call`/`tool_result`. A mutation check (logger writing to `out`)
+  confirms the test detects display perturbation. No production code changed
+  in this phase; the full strict QA gate (`go test ./... -race -cover
+  -count=3 -timeout=30s`), gofumpt, staticcheck, `go vet`, `go fix`, `go
+  build`, and dupl all pass unedited.

--- a/worklogs/2026-08-15-agent-slog-output/phase-1-agent-api.md
+++ b/worklogs/2026-08-15-agent-slog-output/phase-1-agent-api.md
@@ -1,0 +1,140 @@
+# Phase 1 — Agent API
+
+**Status:** Complete (2026-08-15)
+
+[← README](./README.md)
+
+## Goal
+
+Remove `WithOutputTo` from `pkg/agent` and add the three slog options.
+
+## Specification
+
+`pkg/agent/agent.go`:
+
+- Delete `WithOutputTo` and the `out io.Writer` field on `Agent`.
+- Add fields: `logger *slog.Logger`, `slogLevel slog.Level`, `slogRuneLimit int`.
+- Add options:
+  - `WithLogger(l *slog.Logger)`
+  - `WithSlogLevel(level slog.Level)`
+  - `WithSlogRuneLimit(n int)`
+- Defaults (in `defaultConf`): `slogLevel: slog.LevelDebug`,
+  `slogRuneLimit: 200`; `logger` stays nil (disabled).
+- In `asInternalConfig()`, replace the removed `Out: a.out` with `Out: io.Discard`
+  and set one `AgentSettings` pointer carrying all agent-only settings:
+
+```go
+conf.AgentSettings = &text.AgentSettings{
+    Logger:           a.logger,
+    Level:            a.slogLevel,
+    RuneLimit:        a.slogRuneLimit,
+    UsageRecorder:    a.usageRecorder,
+    ToolCallRecorder: a.toolCallRecorder,
+}
+```
+
+`pkg/agent/typed.go`:
+
+- `NewTyped` / `NewTypedMetadata` already forward `Option`s through `New`; they
+  hold no per-option fields. Keep that forwarding and add a propagation test.
+
+`pkg/agent` tests:
+
+- Remove/replace every `WithOutputTo` reference in `pkg/agent`, including
+  `agent_test.go`, `typed_test.go`, `cmd_ban_e2e_test.go`, and
+  `recorder_test.go`. With the agent now silent by default, the
+  `WithOutputTo(io.Discard)` calls simply get dropped.
+- Update recorder-propagation assertions to read `conf.AgentSettings.UsageRecorder`
+  and `conf.AgentSettings.ToolCallRecorder`.
+- Add propagation tests for the three slog options and the nil-logger case.
+
+## Integration contract
+
+`unit-test-only`.
+
+## Acceptance criteria
+
+- [x] `WithOutputTo` is gone from `pkg/agent` — `go test ./pkg/agent/` compiles with no reference
+- [x] `asInternalConfig()` sets `Out: io.Discard` regardless of options — `TestAgent_asInternalConfig`
+- [x] `asInternalConfig()` propagates `Logger`/`Level`/`RuneLimit` via `AgentSettings` — `TestAgent_WithLogger_propagates`, `TestAgent_WithSlogLevel_propagates`, `TestAgent_WithSlogRuneLimit_propagates`
+- [x] `asInternalConfig()` propagates `UsageRecorder`/`ToolCallRecorder` via `AgentSettings` — `TestAgent_WithUsageRecorder`, `TestAgent_WithToolCallRecorder`
+- [x] `asInternalConfig()` with a nil logger leaves `AgentSettings.Logger` nil — `TestAgent_WithLogger_nil_disables`
+- [x] defaults: level `slog.LevelDebug`, rune limit 200, logger nil — `TestNew`
+- [x] `NewTyped`/`NewTypedMetadata` forward the three options — `TestTypedQuerier_WithLogger_propagates`
+
+## Error coverage
+
+| Failure | Expected outcome |
+| ------- | ---------------- |
+| `WithLogger(nil)` | Logger disabled; `Configurations.AgentSettings.Logger == nil` |
+| `WithSlogLevel` omitted | Defaults to `slog.LevelDebug` |
+| `WithSlogRuneLimit(0)` or negative | Carried into `AgentSettings.RuneLimit` verbatim; D5 makes truncation treat `<= 0` as no cap |
+| Recorders omitted | `AgentSettings.UsageRecorder`/`ToolCallRecorder` stay nil |
+
+## Implementation notes
+
+Executing agent: clai (worker session 2026-08-15-01).
+
+- The phase landed as a partial working tree: `pkg/agent/agent.go` and
+  `internal/text/conf.go` already carried the production changes (the
+  `AgentSettings` struct + field and the three slog options), but no test
+  compiled — every `WithOutputTo` reference in `pkg/agent` remained. This
+  session completed the phase with the test sweep and docs (D8).
+- `asInternalConfig` keeps setting the loose `UsageRecorder`/
+  `ToolCallRecorder` fields alongside the grouped `AgentSettings` pointer.
+  Phase 2 removes the loose fields from `Configurations` and moves
+  `NewQuerier`'s recorder source onto `AgentSettings`; until then the loose
+  assignments keep the recorder e2e tests (this phase's AC) green, because
+  the current `NewQuerier` still reads them. *(Phase 2, 2026-08-15:
+  completed — see D9 and the phase-2 doc.)*
+- The `WithOutputTo(io.Discard)` calls in the e2e/recorder tests were simply
+  dropped: with `Out` hardcoded to `io.Discard`, the agent is silent on
+  stdout by construction.
+- The old `TestAgent_Setup_receives_Out_in_config` and
+  `TestAgent_Setup_receives_stdout_when_no_WithOutputTo` tests were replaced
+  by one `TestAgent_Setup_receives_io_Discard`, which proves the querier
+  creator receives `io.Discard` through the real `Setup` path.
+- `stringsBuilderWriter` became dead after the `WithOutputTo` tests were
+  removed and was deleted.
+
+Verification (all run from the repo root):
+
+```bash
+go test ./pkg/agent/ -race -count=1 -timeout=120s   # ok 1.084s
+```
+
+```bash
+go test ./pkg/agent/ -cover   # ok 0.193s, coverage: 94.2% of statements
+```
+
+```bash
+go test ./... -race -cover -count=3 -timeout=30s   # all ok, pkg/agent 94.2%
+```
+
+```bash
+go build ./...   # clean
+```
+
+```bash
+go vet ./...   # clean
+```
+
+```bash
+go run mvdan.cc/gofumpt@latest -w -l .   # no output (already formatted)
+```
+
+```bash
+go run honnef.co/go/tools/cmd/staticcheck@latest ./...   # clean
+```
+
+```bash
+go fix ./...   # no output
+```
+
+```bash
+go run github.com/mibk/dupl@latest -t 80 .   # 10 clone groups, all pre-existing, none in pkg/agent
+```
+
+## Review findings
+
+_(empty — no review findings raised for this phase.)_

--- a/worklogs/2026-08-15-agent-slog-output/phase-2-config-plumbing.md
+++ b/worklogs/2026-08-15-agent-slog-output/phase-2-config-plumbing.md
@@ -1,0 +1,156 @@
+# Phase 2 — Config + querier plumbing
+
+**Status:** Complete (2026-08-15)
+
+[← README](./README.md)
+
+## Goal
+
+Carry the agent-only slog settings and recorder hooks from `Configurations`
+into the querier via one `AgentSettings` pointer, and add the rune
+middle-truncation helper.
+
+## Specification
+
+`internal/text/conf.go` (add `log/slog` import):
+
+```go
+// AgentSettings carries agent-only runtime settings into the querier. It is
+// never serialized to textConfig.json; a nil Logger or recorder disables that
+// channel.
+type AgentSettings struct {
+    Logger           *slog.Logger
+    Level            slog.Level
+    RuneLimit        int
+    UsageRecorder    pub_models.CallUsageRecorder
+    ToolCallRecorder pub_models.ToolCallRecorder
+}
+```
+
+- Add `AgentSettings *AgentSettings` to `Configurations`, tagged `json:"-"`.
+  The tag keeps it out of `textConfig.json` and the presence-based config merge
+  (`internal/utils/config.go` `jsonConfigKey`).
+- Remove `UsageRecorder` and `ToolCallRecorder` from `Configurations`; they move
+  into `AgentSettings`.
+- Keep `RequestedToolGlobs` and `Out io.Writer` untouched — the CLI, profiles,
+  and `pkg/text` full querier set those, so they are not agent-only.
+
+`internal/text/querier_setup.go` (`NewQuerier`):
+
+- When `userConf.AgentSettings != nil`, copy
+  `querier.callUsageRecorder = userConf.AgentSettings.UsageRecorder` and
+  `querier.toolCallRecorder = userConf.AgentSettings.ToolCallRecorder`, and set
+  `querier.agentSettings = userConf.AgentSettings`.
+- The existing `querier.callUsageRecorder` / `querier.toolCallRecorder` fields
+  stay; only their source changes.
+
+`internal/text/querier.go` (the `Querier` struct):
+
+- Add `agentSettings *AgentSettings` alongside `out`.
+
+New `internal/text/slog_output.go`:
+
+```go
+// truncateMiddleRunes returns s unchanged when utf8.RuneCountInString(s) <= limit,
+// or when limit <= 0 (no cap, D5). Otherwise it returns head + "…" + tail
+// totalling exactly limit runes and reports truncated=true. The split is
+// rune-safe: head is the first headLen runes, tail is the last tailLen runes,
+// headLen + tailLen == limit-1, balanced head/tail.
+func truncateMiddleRunes(s string, limit int) (string, bool)
+```
+
+The marker is the single rune `…` (U+2026). It avoids the sub-marker edge case
+a longer `…[truncated]…` marker would create for tiny limits (see D2).
+
+## Integration contract
+
+`unit-test-only`.
+
+## Acceptance criteria
+
+- [x] `Configurations` carries `AgentSettings` with all five fields — `TestConfigurations_AgentSettings`
+- [x] `Configurations` no longer exposes `UsageRecorder`/`ToolCallRecorder` — `go test ./internal/... ./pkg/...` compiles
+- [x] `Configurations` JSON round-trip omits `AgentSettings` — `TestConfigurations_AgentSettings_jsonOmitted`
+- [x] `NewQuerier` copies `AgentSettings` and both recorders — `TestNewQuerier_AgentSettings`
+- [x] `truncateMiddleRunes` unchanged within limit — `TestTruncateMiddleRunes/within_limit`
+- [x] `truncateMiddleRunes` `(out, false)` at exactly limit — `TestTruncateMiddleRunes/at_limit`
+- [x] `truncateMiddleRunes` `(out, true)` over limit, `runes(out) == limit` — `TestTruncateMiddleRunes/over_limit`
+- [x] `truncateMiddleRunes` never splits a multi-byte rune — `TestTruncateMiddleRunes/multibyte_rune`
+- [x] `truncateMiddleRunes` with `limit <= 0` returns `(s, false)` — `TestTruncateMiddleRunes/nonpositive_limit`
+- [x] `truncateMiddleRunes` with `limit == 1` returns `("…", true)` — `TestTruncateMiddleRunes/single_rune_limit`
+
+## Error coverage
+
+| Failure | Expected outcome |
+| ------- | ---------------- |
+| Empty input | `("", false)` |
+| Input exactly at limit | unchanged, not truncated |
+| Input over limit | `head + "…" + tail`, truncated |
+| `limit <= 0` | unchanged, no cap (D5) |
+| `limit == 1` | `("…", true)` |
+| Multi-byte rune straddles the cut | cut moves to a rune boundary |
+| `AgentSettings` set on `Configurations` | not serialized (`json:"-"`) |
+| `AgentSettings == nil` | querier recorders stay nil, logging disabled |
+
+## Implementation notes
+
+Executing agent: clai (worker session 2026-08-15-02).
+
+- The `AgentSettings` struct and the `Configurations.AgentSettings` field
+  already existed from Phase 1 (D8); this phase removed the now-redundant
+  loose `UsageRecorder`/`ToolCallRecorder` fields from `Configurations` and
+  moved `NewQuerier`'s recorder source onto the grouped pointer (D9).
+  `pkg/agent/asInternalConfig` dropped its loose assignments — the grouped
+  pointer is now the only carrier.
+- `NewQuerier` copies the whole `agentSettings` pointer when non-nil and
+  leaves the querier recorders nil otherwise, so the CLI and `pkg/text`
+  paths (which never set `AgentSettings`) are behavior-identical: the
+  session runner's existing nil-recorder noop path absorbs the nil.
+- `truncateMiddleRunes` lives in the new `internal/text/slog_output.go`
+  next to `slogTruncationMarker` (the single rune `…`, U+2026). The
+  head/tail split is range-based (`firstRunes`/`lastRunes`) and never
+  allocates a full `[]rune` copy: the reasoning buffer is capped at 1 MiB,
+  and a full conversion would transiently cost up to 4× that. The split is
+  head-biased for even limits (limit 4 → 2 head + 1 tail), balanced for odd
+  limits (limit 5 → 2 + 2). All three functions reach 100% statement
+  coverage.
+- The pre-written `slog_output_test.go` (untracked before this phase)
+  compiled and passed unchanged against the implementation.
+
+Verification (all run from the repo root):
+
+```bash
+go vet ./...   # clean
+```
+
+```bash
+go test ./internal/text/ -run 'TestTruncateMiddleRunes|TestConfigurations_AgentSettings|TestNewQuerier_AgentSettings' -v -count=1 -timeout=60s   # all pass
+```
+
+```bash
+go test ./... -race -cover -count=3 -timeout=30s   # all ok; internal/text 75.4%, pkg/agent 94.2%
+```
+
+```bash
+go build ./...   # clean
+```
+
+```bash
+go run mvdan.cc/gofumpt@latest -w -l .   # no output (already formatted)
+```
+
+```bash
+go run honnef.co/go/tools/cmd/staticcheck@latest ./...   # clean
+```
+
+```bash
+go fix ./...   # no output
+```
+
+```bash
+go run github.com/mibk/dupl@latest -t 80 .   # clone groups all pre-existing; none in the files touched by this phase
+```
+
+## Review findings
+
+_(empty)_

--- a/worklogs/2026-08-15-agent-slog-output/phase-3-emit-hooks.md
+++ b/worklogs/2026-08-15-agent-slog-output/phase-3-emit-hooks.md
@@ -1,0 +1,180 @@
+# Phase 3 — Emit hooks
+
+**Status:** Complete (2026-08-15)
+
+[← README](./README.md)
+
+## Goal
+
+Emit one truncated log line per completed message, additively, at each
+semantic completion site.
+
+## Specification
+
+Add one helper on `Querier` (in `slog_output.go`):
+
+```go
+func (q *Querier[C]) logMessage(ctx context.Context, kind, text, tool string) {
+    s := q.agentSettings
+    if s == nil || s.Logger == nil {
+        return
+    }
+    truncated, was := truncateMiddleRunes(text, s.RuneLimit)
+    attrs := []any{"kind", kind, "text", truncated, "truncated", was}
+    if tool != "" {
+        attrs = append(attrs, "tool", tool)
+    }
+    s.Logger.Log(ctx, s.Level, "clai message", attrs...)
+}
+```
+
+### Context threading
+
+`logMessage` takes the live query `context.Context` (D6). Thread `ctx` through
+these signatures. Every production caller already holds the query ctx, except
+the legacy `Querier.postProcess` noted below.
+
+- `closeReasoningIfOpen(ctx, session)` — the six call sites in
+  `session_runner.go` (`executeModelStep`) all hold `ctx`.
+- `finalizeAssistantTextBeforeToolCall(ctx, session, call)` →
+  `finalizeAssistantTextPlain(ctx, session, pending, call)` /
+  `finalizeAssistantTextRolling(ctx, session, pending, call)`.
+- `emitAssistantToolCall(ctx, session, call)` /
+  `emitAssistantToolCalls(ctx, session, calls)`.
+- `emitToolResult(ctx, session, call, out)`.
+- `sessionFinalizerer.Finalize(ctx, session)` /
+  `sessionFinalizer.Finalize(ctx, session)` → `postProcessOutput(ctx, msg)`.
+  The `Run` defer already captures `ctx`.
+- legacy `Querier.postProcess()` (test-only) passes `context.Background()` to
+  `Finalize`.
+
+Update the direct test call sites to pass a ctx (usually `context.Background()`):
+`countingFinalizer.Finalize` in `session_runner_test.go`,
+`finalizeAssistantTextBeforeToolCall` in `session_runner_test.go`, and
+`emitToolResult` in `querier_tool_test.go`.
+
+### Hook sites
+
+Wire the hook at these sites, without removing or reordering any existing write
+to `q.out`:
+
+1. `reasoning` — `closeReasoningIfOpen` (`internal/text/querier.go`),
+   immediately after `q.reasoningActive = false`, once per block, using
+   `q.reasoningBuf.String()` before any branch resets the buffer:
+   `q.logMessage(ctx, "reasoning", q.reasoningBuf.String(), "")`.
+2. `assistant` — `finalizeAssistantTextPlain` and
+   `finalizeAssistantTextRolling` (`internal/text/tool_executor.go`), after the
+   echoed-tool-call check, when the finalized `pending` prose is non-empty:
+   `q.logMessage(ctx, "assistant", pending, "")`.
+3. `tool_call` — `emitAssistantToolCalls` (`internal/text/tool_executor.go`),
+   once per call in the loop: `q.logMessage(ctx, "tool_call", call.PrettyPrint(), call.Name)`.
+4. `tool_result` — `emitToolResult` (`internal/text/tool_executor.go`), after
+   `displayOut` is computed: `q.logMessage(ctx, "tool_result", displayOut, call.Name)`.
+   The `load_skill` success path in `executeLoadSkill` must also log a
+   `tool_result` with `text = userVisibleContent` (the final display body, after
+   warnings are folded in) and `tool = "load_skill"`.
+5. `final_answer` — `postProcessOutput` (`internal/text/querier.go`), at the
+   top, before any display branch: `q.logMessage(ctx, "final_answer", newSysMsg.Content, "")`.
+
+`logMessage` is the sole gate: it no-ops when `agentSettings` or its `Logger`
+is nil, and is never gated by `structuredOutput`, `rawDisplay`, `debug`, or
+`q.Raw`.
+
+## Integration contract
+
+`unit-test-only`. Display-invariance is asserted in Phase 4.
+
+## Acceptance criteria
+
+- [x] `logMessage` with nil settings or nil logger is a no-op — `TestQuerier_LogMessage_nilLogger`
+- [x] `logMessage` truncates over-budget text, sets `truncated=true` — `TestQuerier_LogMessage_truncates`
+- [x] `logMessage` forwards the passed ctx to the handler — `TestQuerier_LogMessage_ctx`
+- [x] one record per completed message with correct `kind` — `TestQuerier_LogMessage_kind` (table over five kinds)
+- [x] `tool_call`/`tool_result` carry `tool`; other kinds do not — `TestQuerier_LogMessage_toolAttr`
+- [x] reasoning emits once per block, not per token — `TestQuerier_CloseReasoningIfOpen_logsOnce`
+- [x] assistant prose emits only when finalized non-empty, not for echoed tool-call text — `TestFinalizeAssistantText_Logs`
+- [x] `postProcessOutput` logs `final_answer` even when display returns early (raw) — `TestPostProcessOutput_LogsFinalAnswer_unconditionally`
+- [x] `load_skill` success logs one `tool_result` with `tool=load_skill`, `text=userVisibleContent` — `TestExecuteLoadSkill_LogsToolResult`
+- [x] full `internal/text` suite passes unchanged — package gate
+
+## Error coverage
+
+| Failure                          | Expected outcome                                                       |
+| -------------------------------- | ---------------------------------------------------------------------- |
+| Logger nil                       | No-op                                                                  |
+| Text over rune limit             | Truncated + `truncated=true`                                           |
+| Empty reasoning buffer on close  | No `reasoning` record                                                  |
+| Empty pending prose on tool call | No `assistant` record                                                  |
+| Echoed tool-call text            | No `assistant` record                                                  |
+| `load_skill` success             | One `tool_result` record, `tool=load_skill`, `text=userVisibleContent` |
+| Ctx-aware handler                | Observes the ctx value passed to `logMessage`                          |
+
+## Implementation notes
+
+Executing agent: clai (worker session 2026-08-15-03).
+
+- `logMessage` landed at the bottom of `internal/text/slog_output.go` next to
+  the truncation helpers. It is the sole gate: nil `agentSettings` or nil
+  `Logger` returns before logging; nothing else gates it. The record level is
+  the single caller-set `AgentSettings.Level`, and the `kind` attribute is the
+  only per-message discriminator (D3).
+- Context threading follows D6: `closeReasoningIfOpen`, the
+  `finalizeAssistantTextBeforeToolCall` → plain/rolling pair,
+  `emitAssistantToolCall(s)`, `emitToolResult`, `sessionFinalizerer`/
+  `sessionFinalizer`, and `postProcessOutput` all gained a `ctx` parameter
+  carrying the live query context. The session runner passes its own `ctx`;
+  the legacy test-only `Querier.postProcess` passes `context.Background()`.
+- Semantic-empty gates live at the hook sites (D10): `closeReasoningIfOpen`
+  captures `q.reasoningBuf.String()` before any branch resets the buffer and
+  skips the record when it is empty; both `finalizeAssistantText*` variants
+  log only after the echoed-tool-call check, so echoed or empty prose emits
+  nothing.
+- `emitToolResult` logs after the `<NO-OUTPUT>` substitution, so `displayOut`
+  is the final display body. The `load_skill` success path never calls
+  `emitToolResult`; it logs its own `tool_result` with the warning-folded
+  `userVisibleContent` and `tool = "load_skill"` right before the assistant
+  tool-call echo.
+- No existing write to `q.out` was moved or reordered: the hooks are purely
+  additive, and display-invariance is asserted by Phase 4.
+- Test helpers: `captureHandler` (a slog handler that records every record
+  with its context) and `recordAttrs` (flattens a record's attributes) live in
+  `slog_output_test.go`; `emit_hooks_test.go` holds the four hook-site tests.
+  `logMessage` reaches 100% statement coverage.
+
+Verification (all run from the repo root):
+
+```bash
+go build ./...   # clean
+```
+
+```bash
+go vet ./...   # clean
+```
+
+```bash
+go test ./internal/text/ -run 'TestQuerier_LogMessage|TestQuerier_CloseReasoningIfOpen|TestFinalizeAssistantText_Logs|TestPostProcessOutput_LogsFinalAnswer|TestExecuteLoadSkill_LogsToolResult' -v -count=1 -timeout=60s   # all pass
+```
+
+```bash
+go test ./... -race -cover -count=3 -timeout=30s   # all ok; internal/text 75.6%, pkg/agent 94.2%
+```
+
+```bash
+go run mvdan.cc/gofumpt@latest -w -l .   # no output (already formatted)
+```
+
+```bash
+go run honnef.co/go/tools/cmd/staticcheck@latest ./...   # clean
+```
+
+```bash
+go fix ./...   # no output
+```
+
+```bash
+go run github.com/mibk/dupl@latest -t 80 .   # 32 clone groups, all pre-existing, none in this phase's files
+```
+
+## Review findings
+
+_(empty)_

--- a/worklogs/2026-08-15-agent-slog-output/phase-4-cli-invariance-gates.md
+++ b/worklogs/2026-08-15-agent-slog-output/phase-4-cli-invariance-gates.md
@@ -1,0 +1,122 @@
+# Phase 4 — CLI-invariance + gates
+
+**Status:** Complete (2026-08-15)
+
+[← README](./README.md)
+
+## Goal
+
+Prove the interactive CLI display is byte-identical and run the full quality
+gates.
+
+## Specification
+
+Add `internal/text/slog_output_test.go` (or extend the suite):
+
+```go
+// TestSlogLogger_DoesNotPerturbDisplay runs the same scripted stream twice,
+// once with agentSettings == nil and once with a capturing slog logger, and
+// asserts the bytes written to out are byte-identical.
+```
+
+The scripted stream uses the existing mock completer and exercises at least one
+tool call plus a final answer, so all display paths run.
+
+Do not modify any production write to `out`. Proof of CLI-invariance: (1) the
+byte-identity test, and (2) the full pre-existing suite (including CLI e2e)
+passing unchanged.
+
+## Integration contract
+
+- **Trigger:** run the same scripted stream twice — `agentSettings == nil` vs a
+  capturing `*slog.Logger`.
+- **Observable result:** the bytes written to `out` are byte-identical; the
+  capturing logger receives the expected completed-message records.
+- **Required side effects:** none on the display path.
+- **Prohibited side effects:** no production write to `out` is modified,
+  reordered, or newly gated; no display-only flag (`structuredOutput`,
+  `rawDisplay`, `debug`, `q.Raw`) changes behavior.
+
+## Acceptance criteria
+
+- [x] `out` bytes identical with and without a logger — `TestSlogLogger_DoesNotPerturbDisplay`
+- [x] `go test ./... -race -cover -count=3 -timeout=30s` passes with no pre-existing expectation edits
+- [x] CLI e2e tests pass unchanged
+- [x] `go build ./...` clean
+- [x] `go vet ./...` clean
+- [x] `go run mvdan.cc/gofumpt@latest -w -l .` clean
+- [x] `go run honnef.co/go/tools/cmd/staticcheck@latest ./...` clean
+- [x] `go fix ./...` clean
+- [x] `go run github.com/mibk/dupl@latest -t 80 .` clean
+
+## Error coverage
+
+| Failure | Expected outcome |
+| ------- | ---------------- |
+| Logger attached | Display bytes unchanged |
+| Logger nil | Display bytes unchanged, no log records |
+
+## Implementation notes
+
+Executing agent: clai (worker session 2026-08-15-04).
+
+- `TestSlogLogger_DoesNotPerturbDisplay` landed in `internal/text/slog_output_test.go`
+  next to the `logMessage` unit tests, reusing the existing `captureHandler` +
+  `recordAttrs` helpers and the `MockQuerier.streamFn` scripted-stream pattern.
+- The scripted stream emits reasoning, assistant prose, one `test` tool call,
+  a second reasoning block, and a final answer — so reasoning open/close,
+  streamed tokens, the tool-call echo, the tool result, and the final answer
+  all run. The tool is registered via `inttools.WithTestRegistry` +
+  `inttools.Registry.Set("test", stubTool{...})`, the same pattern as the
+  existing tool-flow tests.
+- The test runs the script once per display mode: the raw path (`Raw: true`)
+  and the default interactive path (rolling activity window pinned via the
+  existing `withRollingTheme` helper). For each mode it runs the stream twice
+  — `agentSettings == nil` vs `&AgentSettings{Logger: slog.New(captureHandler)}`
+  — and asserts the `out` bytes are byte-identical, that the nil run captured
+  zero records, and that the logger run captured the five completed-message
+  kinds in stream order (`reasoning,assistant,tool_call,tool_result,
+  reasoning,final_answer`) with `tool=test` on the tool records.
+- No production code changed in this phase. A temporary mutation (the logger
+  writing to `out`) made the test fail with a byte diff, proving it detects
+  display perturbation; the mutation was reverted.
+- The full pre-existing suite — including the CLI e2e tests — passes
+  unchanged.
+
+Verification (all run from the repo root):
+
+```bash
+go test ./internal/text/ -run 'TestSlogLogger_DoesNotPerturbDisplay' -race -v -count=1 -timeout=60s   # both modes pass
+```
+
+```bash
+go build ./...   # clean
+```
+
+```bash
+go vet ./...   # clean
+```
+
+```bash
+go test ./... -race -cover -count=3 -timeout=30s   # all ok, no pre-existing expectation edits
+```
+
+```bash
+go run mvdan.cc/gofumpt@latest -w -l .   # no output (already formatted)
+```
+
+```bash
+go run honnef.co/go/tools/cmd/staticcheck@latest ./...   # clean
+```
+
+```bash
+go fix ./...   # no output
+```
+
+```bash
+go run github.com/mibk/dupl@latest -t 80 .   # clone groups all pre-existing, none in this phase's files
+```
+
+## Review findings
+
+_(empty)_


### PR DESCRIPTION
The recent rolling output update silently broke the agent WithOutputTo option as it ONLY outputs the structurd output and no streaming when using structured output.

Instead of fixing it, I decided to upgrade it and add slog injection so that the package is a bit more solid. With it comes two tweaks to truncate the message length, and also set slog level which its output to.