### PR TITLE
fix: Move MCP server setup into unique rolling windows

### DIFF
--- a/internal/text/conf_profile_test.go
+++ b/internal/text/conf_profile_test.go
@@ -196,3 +196,19 @@ func TestFindProfile_CmdBanPersistsViaJSON(t *testing.T) {
 		t.Fatalf("expected CmdBan %v, got %v", want, prof.CmdBan)
 	}
 }
+
+func Test_findProfileByPath_LoadsProfileFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "reviewer.json")
+	if err := os.WriteFile(p, []byte(`{"name":"reviewer","model":"gpt-x","use_tools":true}`), 0o644); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+
+	got, err := findProfileByPath(p)
+	if err != nil {
+		t.Fatalf("findProfileByPath: %v", err)
+	}
+	if got.Name != "reviewer" || got.Model != "gpt-x" || !got.UseTools {
+		t.Errorf("loaded profile = %+v, want reviewer/gpt-x/tools-on", got)
+	}
+}

--- a/internal/text/conf_test.go
+++ b/internal/text/conf_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/baalimago/clai/internal/text/generic"
 	"github.com/baalimago/clai/internal/utils"
+	pub_models "github.com/baalimago/clai/pkg/text/models"
 )
 
 func TestResponseFormatFromGeneric_Nil(t *testing.T) {
@@ -189,5 +190,80 @@ func TestConfigurations_CmdBanPersistsViaTextConfigJSON(t *testing.T) {
 	want := []string{"rm", "sudo"}
 	if !slices.Equal(conf.CmdBan, want) {
 		t.Fatalf("expected CmdBan %v, got %v", want, conf.CmdBan)
+	}
+}
+
+func Test_UsingProfile(t *testing.T) {
+	tests := []struct {
+		name string
+		conf Configurations
+		want bool
+	}{
+		{name: "no profile", conf: Configurations{}, want: false},
+		{name: "profile by name", conf: Configurations{UseProfile: "dev"}, want: true},
+		{name: "profile by path", conf: Configurations{ProfilePath: "/tmp/p.json"}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.conf.UsingProfile(); got != tt.want {
+				t.Errorf("UsingProfile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_setupSystemPrompt_ConcatenatesDescriptors(t *testing.T) {
+	c := &Configurations{
+		SystemPrompt:       "base prompt",
+		SkillsDescriptor:   "skills available",
+		LookbackDescriptor: "lookback available",
+	}
+	c.setupSystemPrompt()
+
+	if len(c.InitialChat.Messages) != 1 {
+		t.Fatalf("InitialChat holds %d messages, want 1", len(c.InitialChat.Messages))
+	}
+	msg := c.InitialChat.Messages[0]
+	if msg.Role != "system" {
+		t.Errorf("role = %q, want system", msg.Role)
+	}
+	for _, want := range []string{"base prompt", "skills available", "lookback available"} {
+		if !strings.Contains(msg.Content, want) {
+			t.Errorf("system prompt missing %q; got: %q", want, msg.Content)
+		}
+	}
+}
+
+func Test_setupSystemPrompt_BlankDescriptorsAddNothing(t *testing.T) {
+	c := &Configurations{SystemPrompt: "base prompt", SkillsDescriptor: "  "}
+	c.setupSystemPrompt()
+	if got := c.InitialChat.Messages[0].Content; got != "base prompt" {
+		t.Errorf("system prompt = %q, want bare base prompt", got)
+	}
+}
+
+func Test_toGenericResponseFormat(t *testing.T) {
+	if got := toGenericResponseFormat(nil); got != nil {
+		t.Errorf("nil input converted to %+v, want nil", got)
+	}
+	plain := toGenericResponseFormat(&pub_models.ResponseFormat{Type: "json_object"})
+	if plain.Type != "json_object" || plain.JSONSchema != nil {
+		t.Errorf("plain conversion = %+v, want type only", plain)
+	}
+	withSchema := toGenericResponseFormat(&pub_models.ResponseFormat{
+		Type: "json_schema",
+		Schema: &pub_models.JSONSchema{
+			Name:        "result",
+			Description: "the result",
+			Strict:      true,
+			Schema:      map[string]any{"type": "object"},
+		},
+	})
+	if withSchema.JSONSchema == nil {
+		t.Fatal("schema dropped in conversion")
+	}
+	if withSchema.JSONSchema.Name != "result" || !withSchema.JSONSchema.Strict ||
+		withSchema.JSONSchema.Description != "the result" || withSchema.JSONSchema.Schema["type"] != "object" {
+		t.Errorf("schema fields lost: %+v", withSchema.JSONSchema)
 	}
 }

--- a/internal/text/cost_enricher.go
+++ b/internal/text/cost_enricher.go
@@ -1,0 +1,52 @@
+package text
+
+import (
+	"time"
+
+	pub_models "github.com/baalimago/clai/pkg/text/models"
+	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
+)
+
+// costEnricher owns the cost-manager readiness handshake: it waits a bounded
+// time for the model price catalog and then enriches the chat with cost
+// estimates. The zero value (no manager) is a no-op.
+type costEnricher struct {
+	manager CostManager
+	ready   <-chan struct{}
+	// waitFor bounds the readiness wait: the finalizer must never stall the
+	// answer on a slow price fetch.
+	waitFor time.Duration
+	warnf   func(format string, a ...any)
+}
+
+func newCostEnricher(manager CostManager, ready <-chan struct{}) costEnricher {
+	return costEnricher{
+		manager: manager,
+		ready:   ready,
+		waitFor: 200 * time.Millisecond,
+		warnf:   ancli.Warnf,
+	}
+}
+
+// enrich returns chat with cost estimates, or unchanged when no manager is
+// configured, the catalog does not become ready within waitFor, or the
+// enrichment itself fails.
+func (c costEnricher) enrich(chat pub_models.Chat) pub_models.Chat {
+	if c.manager == nil {
+		return chat
+	}
+	timeout := time.NewTimer(c.waitFor)
+	defer timeout.Stop()
+	select {
+	case <-timeout.C:
+		c.warnf("skipping wait for cost manager model price fetch after: %v\n", c.waitFor)
+		return chat
+	case <-c.ready:
+	}
+	enriched, err := c.manager.Enrich(chat)
+	if err != nil {
+		c.warnf("failed to enrich chat with cost estimate: %v\n", err)
+		return chat
+	}
+	return enriched
+}

--- a/internal/text/cost_enricher_test.go
+++ b/internal/text/cost_enricher_test.go
@@ -1,0 +1,93 @@
+package text
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	pub_models "github.com/baalimago/clai/pkg/text/models"
+)
+
+// fakeCostManager implements CostManager with a stubbed Enrich.
+type fakeCostManager struct {
+	enrichFn func(pub_models.Chat) (pub_models.Chat, error)
+	calls    int
+}
+
+func (f *fakeCostManager) Start(context.Context) (<-chan struct{}, <-chan error) {
+	return nil, nil
+}
+
+func (f *fakeCostManager) Enrich(chat pub_models.Chat) (pub_models.Chat, error) {
+	f.calls++
+	return f.enrichFn(chat)
+}
+
+func Test_costEnricher_ZeroValueIsANoop(t *testing.T) {
+	var enricher costEnricher
+	chat := pub_models.Chat{ID: "unchanged"}
+	if got := enricher.enrich(chat); got.ID != "unchanged" {
+		t.Errorf("zero-value enricher mutated chat: %+v", got)
+	}
+}
+
+func Test_costEnricher_EnrichesWhenReady(t *testing.T) {
+	manager := &fakeCostManager{enrichFn: func(chat pub_models.Chat) (pub_models.Chat, error) {
+		chat.Queries = append(chat.Queries, pub_models.QueryCost{CostUSD: 0.42})
+		return chat, nil
+	}}
+	ready := make(chan struct{})
+	close(ready)
+	enricher := newCostEnricher(manager, ready)
+
+	got := enricher.enrich(pub_models.Chat{ID: "chat"})
+	if len(got.Queries) != 1 || got.Queries[0].CostUSD != 0.42 {
+		t.Errorf("chat not enriched: %+v", got.Queries)
+	}
+	if manager.calls != 1 {
+		t.Errorf("Enrich called %d times, want 1", manager.calls)
+	}
+}
+
+func Test_costEnricher_ReadinessTimeoutKeepsChat(t *testing.T) {
+	manager := &fakeCostManager{enrichFn: func(chat pub_models.Chat) (pub_models.Chat, error) {
+		return chat, nil
+	}}
+	enricher := newCostEnricher(manager, make(chan struct{}))
+	enricher.waitFor = time.Millisecond
+	var warned strings.Builder
+	enricher.warnf = func(format string, a ...any) { fmt.Fprintf(&warned, format, a...) }
+
+	got := enricher.enrich(pub_models.Chat{ID: "chat"})
+	if got.ID != "chat" || len(got.Queries) != 0 {
+		t.Errorf("chat changed although catalog never became ready: %+v", got)
+	}
+	if manager.calls != 0 {
+		t.Errorf("Enrich called %d times despite timeout, want 0", manager.calls)
+	}
+	if !strings.Contains(warned.String(), "skipping") {
+		t.Errorf("timeout not warned about; got: %q", warned.String())
+	}
+}
+
+func Test_costEnricher_EnrichErrorKeepsChat(t *testing.T) {
+	manager := &fakeCostManager{enrichFn: func(pub_models.Chat) (pub_models.Chat, error) {
+		return pub_models.Chat{}, errors.New("catalog is haunted")
+	}}
+	ready := make(chan struct{})
+	close(ready)
+	enricher := newCostEnricher(manager, ready)
+	var warned strings.Builder
+	enricher.warnf = func(format string, a ...any) { fmt.Fprintf(&warned, format, a...) }
+
+	got := enricher.enrich(pub_models.Chat{ID: "chat"})
+	if got.ID != "chat" {
+		t.Errorf("failed enrichment must return the original chat; got: %+v", got)
+	}
+	if !strings.Contains(warned.String(), "catalog is haunted") {
+		t.Errorf("enrich error not warned about; got: %q", warned.String())
+	}
+}

--- a/internal/text/finalizer.go
+++ b/internal/text/finalizer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/baalimago/clai/internal/chat"
 	"github.com/baalimago/clai/internal/models"
@@ -101,31 +100,7 @@ func (f sessionFinalizer[C]) Finalize(ctx context.Context, session *QuerySession
 	q.chat = session.Chat
 
 	if session.ShouldSaveReply {
-		if q.costManager != nil {
-			timeoutdur := 200 * time.Millisecond
-			timeout := time.NewTimer(timeoutdur)
-			defer func() {
-				if !timeout.Stop() {
-					select {
-					case <-timeout.C:
-					default:
-					}
-				}
-			}()
-			select {
-			case <-timeout.C:
-				ancli.Warnf("skippng wait for cost manager model price fetch after: %v", timeoutdur)
-				goto costMgrDone
-			case <-q.costMgrRdyChan:
-			}
-			enrichedChat, err := q.costManager.Enrich(session.Chat)
-			if err != nil {
-				ancli.PrintErr(fmt.Sprintf("failed to enrich chat with cost estimate: %v\n", err))
-			} else {
-				session.Chat = enrichedChat
-			}
-		}
-	costMgrDone:
+		session.Chat = q.costEnricher.enrich(session.Chat)
 		// Origin stamping is always-on and forward-only: stamp the canonical CWD on
 		// first persist, preserve it on every later write (including replies).
 		if originErr := chat.EnsureOriginDir(q.configDir, &session.Chat); originErr != nil {

--- a/internal/text/mcp_log_sink.go
+++ b/internal/text/mcp_log_sink.go
@@ -31,9 +31,14 @@ const mcpLogQueueCap = 256
 // elevated error block when a server terminates unexpectedly.
 const mcpLogExitTailLines = 10
 
-// mcpLogEntry is one buffered stderr line. An exit entry carries the flushed
-// tail of a terminated server and is always classified as an error so it
-// elevates out of the rolling window.
+// mcpLogAuthFollowLines is the number of lines elevated after an auth prompt,
+// so payloads like URLs and device codes on the following lines stay visible.
+const mcpLogAuthFollowLines = 3
+
+// mcpLogEntry is one buffered stderr line. isError marks entries that elevate
+// out of the rolling window: errors, auth prompts and their follow window. An
+// exit entry carries the flushed tail of a terminated server and always
+// elevates.
 type mcpLogEntry struct {
 	server  string
 	line    string
@@ -48,22 +53,35 @@ type mcpLogEntry struct {
 // session loop when an error entry is buffered, so elevated errors render
 // live instead of waiting for the next session event.
 type mcpLogSink struct {
-	mu     sync.Mutex
-	mode   mcpLogMode
-	notice func(server, line string)
-	errOut io.Writer
-	queue  []mcpLogEntry
-	tails  map[string][]string
-	notify chan struct{}
+	mu         sync.Mutex
+	mode       mcpLogMode
+	notice     func(server, line string)
+	errOut     io.Writer
+	termWidth  func() int
+	queue      []mcpLogEntry
+	tails      map[string][]string
+	authFollow map[string]int
+	notify     chan struct{}
+	// attached marks the serialized session loop as running. Before that (MCP
+	// setup may block on the very auth prompt a server just wrote), rolling
+	// mode renders every stderr line live into per-server startup windows
+	// instead of queueing it for a drain that would never come.
+	attached   bool
+	startup    *mcpStartupWindows
+	termHeight func() int
 }
 
 func newMcpLogSink(mode mcpLogMode) *mcpLogSink {
 	return &mcpLogSink{
-		mode:   mode,
-		notice: func(server, line string) { ancli.Noticef("mcp_%v: %v\n", server, line) },
-		errOut: os.Stderr,
-		tails:  make(map[string][]string),
-		notify: make(chan struct{}, 1),
+		mode:       mode,
+		notice:     func(server, line string) { ancli.Noticef("mcp_%v: %v\n", server, line) },
+		errOut:     os.Stderr,
+		termWidth:  func() int { return utils.SessionDimensions(os.Stderr).Width },
+		termHeight: func() int { return utils.SessionDimensions(os.Stderr).Height },
+		tails:      make(map[string][]string),
+		authFollow: make(map[string]int),
+		startup:    newMcpStartupWindows(),
+		notify:     make(chan struct{}, 1),
 	}
 }
 
@@ -85,30 +103,68 @@ func mcpLogModeFor(debug, outputIsTerminal, raw, structured, rollingEnabled bool
 }
 
 // AppendServerLog receives one non-empty stderr line from an MCP server
-// process. Rolling mode queues the line for the session loop; direct modes
-// print or drop it immediately. Every mode retains the bounded termination
-// tail so ServerExited can flush the crash reason.
+// process. During startup, rolling mode renders the line live into the
+// server's startup window; once the windows are cleared or the session loop
+// attaches, lines queue for the session loop instead. Direct modes print or
+// drop immediately. Queued error lines and auth prompts elevate; an auth
+// prompt also opens a short follow window elevating payload-shaped lines
+// (URLs, user codes), since the actionable payload often arrives on its own
+// line. Every mode retains the bounded termination tail so ServerExited can
+// flush the crash reason.
 func (s *mcpLogSink) AppendServerLog(server, line string) {
 	isErr := utils.IsMcpLogErrorLine(line)
+	isAuth := utils.IsMcpLogAuthLine(line)
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	followPayload := s.authFollow[server] > 0 && utils.IsMcpLogAuthPayloadLine(line)
+	elevate := isErr || isAuth || followPayload
+	if s.authFollow[server] > 0 {
+		s.authFollow[server]--
+	}
+	if isAuth {
+		s.authFollow[server] = mcpLogAuthFollowLines
+	}
 	switch s.mode {
 	case mcpLogPlainDirect:
 		s.notice(server, line)
 		return
 	case mcpLogRawStructured:
 		s.retainTailLocked(server, line)
-		if isErr {
+		if elevate {
 			fmt.Fprintf(s.errOut, "mcp_%v: %v\n", server, line)
 		}
 		return
 	}
 	s.retainTailLocked(server, line)
-	s.queue = append(s.queue, mcpLogEntry{server: server, line: line, isError: isErr})
+	if !s.attached && !s.startup.cleared {
+		s.startup.appendLine(server, line, isAuth || followPayload)
+		s.startup.render(s.errOut, s.termWidth(), s.termHeight())
+		return
+	}
+	s.queue = append(s.queue, mcpLogEntry{server: server, line: line, isError: elevate})
 	s.dropOldestNonErrorLocked()
-	if isErr {
+	if elevate {
 		s.signalLocked()
 	}
+}
+
+// attach marks the serialized session loop as running: from now on elevated
+// lines queue for live elevation out of the rolling window instead of
+// printing directly to stderr.
+func (s *mcpLogSink) attach() {
+	s.mu.Lock()
+	s.attached = true
+	s.mu.Unlock()
+}
+
+// setupSucceeded reports that every MCP server finished setup: any pending
+// auth flow completed, so the startup windows are cleared in place and later
+// lines queue for the session loop. Setup failures and hangs never reach
+// this, keeping each server's last lines visible.
+func (s *mcpLogSink) setupSucceeded() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.startup.clear(s.errOut)
 }
 
 // ServerExited reports an unexpected server termination. Rolling mode appends
@@ -126,6 +182,11 @@ func (s *mcpLogSink) ServerExited(server string) {
 	}
 	switch s.mode {
 	case mcpLogRolling:
+		if !s.attached && !s.startup.cleared {
+			// The startup window already shows this server's trailing lines;
+			// a failed setup leaves them visible as the crash reason.
+			return
+		}
 		s.queue = append(s.queue, mcpLogEntry{server: server, exit: true, lines: tail, isError: true})
 		s.dropOldestNonErrorLocked()
 		s.signalLocked()

--- a/internal/text/mcp_log_sink_test.go
+++ b/internal/text/mcp_log_sink_test.go
@@ -42,8 +42,273 @@ func TestMcpLogModeFor(t *testing.T) {
 	}
 }
 
+// lastStartupFrame returns the content of the most recent full-region redraw:
+// everything after the last clear sequence, or the whole output when no
+// clear happened yet.
+func lastStartupFrame(s string) string {
+	if i := strings.LastIndex(s, "\x1b[J"); i >= 0 {
+		return s[i+len("\x1b[J"):]
+	}
+	return s
+}
+
+func TestMcpLogSink_StartupWindowShowsAllServerLines(t *testing.T) {
+	var errOut bytes.Buffer
+	sink := newMcpLogSink(mcpLogRolling)
+	sink.errOut = &errOut
+	sink.termWidth = func() int { return 200 }
+	sink.termHeight = func() int { return 40 }
+
+	sink.AppendServerLog("notion", "started")
+	sink.AppendServerLog("notion", "Please authorize this client by visiting:")
+	sink.AppendServerLog("notion", "https://mcp.notion.com/authorize?response_type=code&client_id=abc")
+	sink.AppendServerLog("notion", "fatal: boom")
+
+	frame := lastStartupFrame(errOut.String())
+	for _, want := range []string{
+		"▸ mcp.notion log",
+		"started",
+		"» Please authorize this client by visiting:",
+		"https://mcp.notion.com/authorize?response_type=code&client_id=abc",
+		"✗ fatal: boom",
+	} {
+		if !strings.Contains(frame, want) {
+			t.Errorf("startup window missing %q; frame: %q", want, frame)
+		}
+	}
+	if count := strings.Count(frame, "▸ mcp.notion log"); count != 1 {
+		t.Errorf("server header appears %d times in one frame, want 1", count)
+	}
+	if entries := sink.Drain(); entries != nil {
+		t.Errorf("startup window lines also queued: %+v", entries)
+	}
+}
+
+func TestMcpLogSink_StartupWindowGroupsPerServer(t *testing.T) {
+	var errOut bytes.Buffer
+	sink := newMcpLogSink(mcpLogRolling)
+	sink.errOut = &errOut
+	sink.termWidth = func() int { return 120 }
+	sink.termHeight = func() int { return 40 }
+
+	sink.AppendServerLog("notion", "notion line one")
+	sink.AppendServerLog("linear", "linear line one")
+	sink.AppendServerLog("notion", "notion line two")
+
+	frame := lastStartupFrame(errOut.String())
+	if count := strings.Count(frame, "▸ mcp.notion log"); count != 1 {
+		t.Errorf("notion header appears %d times, want 1; frame: %q", count, frame)
+	}
+	if count := strings.Count(frame, "▸ mcp.linear log"); count != 1 {
+		t.Errorf("linear header appears %d times, want 1; frame: %q", count, frame)
+	}
+	// A late notion line lands inside the notion window, above the linear
+	// window: per-server grouping survives interleaved output.
+	if strings.Index(frame, "notion line two") > strings.Index(frame, "▸ mcp.linear log") {
+		t.Errorf("late notion line not grouped under its server window; frame: %q", frame)
+	}
+}
+
+// TestMcpLogSink_StartupWindowPinsAuthPrompt reproduces the OAuth flow where
+// the prompt and URL print first and the auth machinery then emits enough
+// chatter to fill the tail: the prompt must stay pinned in the window while
+// the chatter rolls.
+func TestMcpLogSink_StartupWindowPinsAuthPrompt(t *testing.T) {
+	var errOut bytes.Buffer
+	sink := newMcpLogSink(mcpLogRolling)
+	sink.errOut = &errOut
+	sink.termWidth = func() int { return 200 }
+	sink.termHeight = func() int { return 40 }
+
+	sink.AppendServerLog("notion", "Please authorize this client by visiting:")
+	sink.AppendServerLog("notion", "https://mcp.notion.com/authorize?client_id=abc")
+	for i := range 8 {
+		sink.AppendServerLog("notion", fmt.Sprintf("[109] chatter %d", i))
+	}
+
+	frame := lastStartupFrame(errOut.String())
+	for _, want := range []string{
+		"» Please authorize this client by visiting:",
+		"» https://mcp.notion.com/authorize?client_id=abc",
+		"chatter 7",
+	} {
+		if !strings.Contains(frame, want) {
+			t.Errorf("startup window missing %q; frame: %q", want, frame)
+		}
+	}
+	if strings.Contains(frame, "chatter 0") {
+		t.Errorf("oldest chatter not evicted from the tail; frame: %q", frame)
+	}
+	if strings.Index(frame, "» Please authorize") > strings.Index(frame, "chatter 7") {
+		t.Errorf("pinned auth lines not above the rolling tail; frame: %q", frame)
+	}
+}
+
+func TestMcpLogSink_StartupWindowBoundsServerTail(t *testing.T) {
+	var errOut bytes.Buffer
+	sink := newMcpLogSink(mcpLogRolling)
+	sink.errOut = &errOut
+	sink.termWidth = func() int { return 120 }
+	sink.termHeight = func() int { return 40 }
+
+	for i := range 10 {
+		sink.AppendServerLog("fs", fmt.Sprintf("line %d", i))
+	}
+
+	frame := lastStartupFrame(errOut.String())
+	if strings.Contains(frame, "line 0\n") || strings.Contains(frame, "line 3\n") {
+		t.Errorf("startup window shows lines past the tail bound; frame: %q", frame)
+	}
+	if !strings.Contains(frame, "line 9") {
+		t.Errorf("newest line missing from startup window; frame: %q", frame)
+	}
+}
+
+func TestMcpLogSink_StartupWindowCapsRegionToTerminalHeight(t *testing.T) {
+	var errOut bytes.Buffer
+	sink := newMcpLogSink(mcpLogRolling)
+	sink.errOut = &errOut
+	sink.termWidth = func() int { return 120 }
+	sink.termHeight = func() int { return 8 }
+
+	for _, server := range []string{"one", "two", "three", "four"} {
+		for i := range 6 {
+			sink.AppendServerLog(server, fmt.Sprintf("%s line %d", server, i))
+		}
+	}
+
+	frame := lastStartupFrame(errOut.String())
+	if rows := strings.Count(frame, "\n"); rows > 7 {
+		t.Errorf("startup region %d rows exceeds terminal height budget 7; frame: %q", rows, frame)
+	}
+}
+
+func TestMcpLogSink_StartupWindowShowsExitTail(t *testing.T) {
+	var errOut bytes.Buffer
+	sink := newMcpLogSink(mcpLogRolling)
+	sink.errOut = &errOut
+	sink.termWidth = func() int { return 120 }
+	sink.termHeight = func() int { return 40 }
+	sink.AppendServerLog("fs", "line one")
+	sink.ServerExited("fs")
+
+	frame := lastStartupFrame(errOut.String())
+	for _, want := range []string{"▸ mcp.fs log", "line one"} {
+		if !strings.Contains(frame, want) {
+			t.Errorf("startup window missing %q after exit; frame: %q", want, frame)
+		}
+	}
+	if entries := sink.Drain(); entries != nil {
+		t.Errorf("pre-attach exit queued entries: %+v", entries)
+	}
+}
+
+// TestMcpLogSink_SetupSucceededClearsStartupWindows pins the handoff
+// contract: once MCP setup completes, the startup log windows are cleared in
+// place, and later pre-attach lines queue for the session loop instead of
+// rendering.
+func TestMcpLogSink_SetupSucceededClearsStartupWindows(t *testing.T) {
+	var errOut bytes.Buffer
+	sink := newMcpLogSink(mcpLogRolling)
+	sink.errOut = &errOut
+	sink.termWidth = func() int { return 120 }
+	sink.termHeight = func() int { return 40 }
+
+	sink.AppendServerLog("notion", "Please authorize this client by visiting:")
+	sink.AppendServerLog("notion", "https://example.com/authorize?x=1")
+	if !strings.Contains(errOut.String(), "» Please authorize this client by visiting:") {
+		t.Fatalf("startup window never rendered: %q", errOut.String())
+	}
+	errOut.Reset()
+
+	sink.setupSucceeded()
+	got := errOut.String()
+	if !strings.Contains(got, "\x1b[") {
+		t.Errorf("expected ANSI clear of the startup windows; got: %q", got)
+	}
+	if strings.Contains(got, "authorize") {
+		t.Errorf("startup content re-rendered after clear: %q", got)
+	}
+	errOut.Reset()
+
+	sink.AppendServerLog("notion", "please sign in again")
+	if errOut.Len() != 0 {
+		t.Errorf("post-setup line rendered into cleared region: %q", errOut.String())
+	}
+	entries := sink.Drain()
+	if len(entries) != 1 || !entries[0].isError {
+		t.Fatalf("post-setup auth line not queued for session elevation: %+v", entries)
+	}
+}
+
+func TestMcpLogSink_SetupSucceededWithoutWindowIsNoop(t *testing.T) {
+	var errOut bytes.Buffer
+	sink := newMcpLogSink(mcpLogRolling)
+	sink.errOut = &errOut
+	sink.setupSucceeded()
+	if errOut.Len() != 0 {
+		t.Errorf("no-op clear wrote output: %q", errOut.String())
+	}
+}
+
+func Test_notifyMcpSetupSucceeded_NilSinkIsANoop(t *testing.T) {
+	notifyMcpSetupSucceeded(nil)
+}
+
+func TestMcpLogSink_AttachRestoresQueueing(t *testing.T) {
+	var errOut bytes.Buffer
+	sink := newMcpLogSink(mcpLogRolling)
+	sink.errOut = &errOut
+	sink.attach()
+
+	sink.AppendServerLog("github", "please sign in")
+	if errOut.Len() != 0 {
+		t.Errorf("post-attach line printed directly: %q", errOut.String())
+	}
+	entries := sink.Drain()
+	if len(entries) != 1 || !entries[0].isError {
+		t.Fatalf("post-attach auth entry not queued for elevation: %+v", entries)
+	}
+}
+
+// Test_McpSink_AuthPromptSurfacesDuringBlockedStartup pins the OAuth startup
+// case end to end: the server prints an auth prompt to stderr and then hangs
+// waiting for an authorization that never comes. No session loop exists to
+// drain the sink, yet the prompt must reach stderr while the server is alive.
+func Test_McpSink_AuthPromptSurfacesDuringBlockedStartup(t *testing.T) {
+	var errOut lockedBuffer
+	sink := newMcpLogSink(mcpLogRolling)
+	sink.errOut = &errOut
+	sink.termWidth = func() int { return 200 }
+	srv := pub_models.McpServer{
+		Name:    "oauth",
+		Command: "go",
+		Args:    []string{"run", "../tools/mcp/testserver"},
+		Env:     map[string]string{"TEST_SERVER_AUTH_HANG": "1"},
+	}
+	_, _, err := mcp.Client(t.Context(), srv, sink)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		got := errOut.String()
+		if strings.Contains(got, "▸ mcp.oauth log") &&
+			strings.Contains(got, "» Please authorize this client by visiting:") &&
+			strings.Contains(got, "https://example.com/authorize?client_id=test") {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("auth prompt never surfaced while startup blocked; got:\n%q", got)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func TestMcpLogSink_RollingModeQueuesLines(t *testing.T) {
 	sink := newMcpLogSink(mcpLogRolling)
+	sink.attach()
 	sink.AppendServerLog("fs", "started")
 	sink.AppendServerLog("fs", "error: boom")
 
@@ -97,8 +362,127 @@ func TestMcpLogSink_RawStructuredKeepsOnlyErrors(t *testing.T) {
 	}
 }
 
+func TestMcpLogSink_RollingModeElevatesAuthLines(t *testing.T) {
+	sink := newMcpLogSink(mcpLogRolling)
+	sink.attach()
+	sink.AppendServerLog("github", "started")
+	sink.AppendServerLog("github", "Please visit https://github.com/login/device")
+
+	entries := sink.Drain()
+	if len(entries) != 2 {
+		t.Fatalf("Drain() = %d entries, want 2", len(entries))
+	}
+	if entries[0].isError {
+		t.Errorf("entry %q classified for elevation, want normal", entries[0].line)
+	}
+	if !entries[1].isError {
+		t.Errorf("auth entry %q not classified for elevation", entries[1].line)
+	}
+}
+
+func TestMcpLogSink_AuthFollowWindowElevatesPayloadLines(t *testing.T) {
+	sink := newMcpLogSink(mcpLogRolling)
+	sink.attach()
+	sink.AppendServerLog("github", "To authenticate, visit:")
+	sink.AppendServerLog("github", "https://example.com/device-flow")
+	sink.AppendServerLog("github", "and enter your one-time code")
+	sink.AppendServerLog("github", "ABCD-1234")
+	sink.AppendServerLog("github", "plain line past the follow window")
+
+	entries := sink.Drain()
+	if len(entries) != 5 {
+		t.Fatalf("Drain() = %d entries, want 5", len(entries))
+	}
+	for i := range 4 {
+		if !entries[i].isError {
+			t.Errorf("entry %d %q not elevated, want elevated (auth prompt or payload)", i, entries[i].line)
+		}
+	}
+	if entries[4].isError {
+		t.Errorf("entry %q elevated past the follow window, want normal", entries[4].line)
+	}
+}
+
+func TestMcpLogSink_AuthFollowWindowSkipsChatter(t *testing.T) {
+	sink := newMcpLogSink(mcpLogRolling)
+	sink.attach()
+	sink.AppendServerLog("notion", "Please authorize this client by visiting:")
+	sink.AppendServerLog("notion", "Browser opened automatically.")
+	sink.AppendServerLog("notion", "Creating lockfile for server cb42 with process 115 on port 9553")
+
+	entries := sink.Drain()
+	if len(entries) != 3 {
+		t.Fatalf("Drain() = %d entries, want 3", len(entries))
+	}
+	if !entries[0].isError {
+		t.Errorf("auth prompt %q not elevated", entries[0].line)
+	}
+	for _, entry := range entries[1:] {
+		if entry.isError {
+			t.Errorf("chatter %q elevated by follow window, want normal", entry.line)
+		}
+	}
+}
+
+func TestMcpLogSink_AuthFollowWindowIsPerServer(t *testing.T) {
+	sink := newMcpLogSink(mcpLogRolling)
+	sink.attach()
+	sink.AppendServerLog("github", "please sign in")
+	sink.AppendServerLog("fs", "plain line from another server")
+
+	entries := sink.Drain()
+	if len(entries) != 2 {
+		t.Fatalf("Drain() = %d entries, want 2", len(entries))
+	}
+	if !entries[0].isError {
+		t.Errorf("auth entry %q not elevated", entries[0].line)
+	}
+	if entries[1].isError {
+		t.Errorf("entry %q from unrelated server elevated by follow window", entries[1].line)
+	}
+}
+
+func TestMcpLogSink_RawStructuredPrintsAuthLines(t *testing.T) {
+	var errOut bytes.Buffer
+	sink := newMcpLogSink(mcpLogRawStructured)
+	sink.errOut = &errOut
+
+	sink.AppendServerLog("github", "started")
+	sink.AppendServerLog("github", "Not authenticated. Run 'gh auth login'")
+	sink.AppendServerLog("github", "https://example.com/device-flow")
+	sink.AppendServerLog("github", "Browser opened automatically.")
+	sink.AppendServerLog("github", "plain line past the follow window")
+
+	got := errOut.String()
+	if strings.Contains(got, "started") {
+		t.Errorf("raw/structured mode printed normal line: %q", got)
+	}
+	for _, want := range []string{"Not authenticated", "https://example.com/device-flow"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("raw/structured mode dropped auth line %q; got: %q", want, got)
+		}
+	}
+	for _, absent := range []string{"Browser opened", "past the follow window"} {
+		if strings.Contains(got, absent) {
+			t.Errorf("raw/structured mode printed chatter %q: %q", absent, got)
+		}
+	}
+}
+
+func TestMcpLogSink_NotifySignalsOnAuth(t *testing.T) {
+	sink := newMcpLogSink(mcpLogRolling)
+	sink.attach()
+	sink.AppendServerLog("github", "please sign in at https://example.com")
+	select {
+	case <-sink.Notify():
+	default:
+		t.Fatal("auth line must signal the session loop")
+	}
+}
+
 func TestMcpLogSink_OverflowDropsOldestNonErrorFirst(t *testing.T) {
 	sink := newMcpLogSink(mcpLogRolling)
+	sink.attach()
 	sink.AppendServerLog("fs", "error: keep me")
 	for range mcpLogQueueCap + 10 {
 		sink.AppendServerLog("fs", "noise")
@@ -115,6 +499,7 @@ func TestMcpLogSink_OverflowDropsOldestNonErrorFirst(t *testing.T) {
 
 func TestMcpLogSink_ServerExitedFlushesTail(t *testing.T) {
 	sink := newMcpLogSink(mcpLogRolling)
+	sink.attach()
 	for i := range 5 {
 		sink.AppendServerLog("fs", fmt.Sprintf("line %d", i))
 	}
@@ -135,6 +520,7 @@ func TestMcpLogSink_ServerExitedFlushesTail(t *testing.T) {
 
 func TestMcpLogSink_ServerExitedTailCapped(t *testing.T) {
 	sink := newMcpLogSink(mcpLogRolling)
+	sink.attach()
 	for i := range 15 {
 		sink.AppendServerLog("fs", fmt.Sprintf("line %d", i))
 	}
@@ -194,6 +580,7 @@ func TestMcpLogSink_ServerExitedFlushesTailRawStructuredCapped(t *testing.T) {
 
 func TestMcpLogSink_NotifySignalsOnError(t *testing.T) {
 	sink := newMcpLogSink(mcpLogRolling)
+	sink.attach()
 	notify := sink.Notify()
 
 	// Normal lines stay quiet: they coalesce into the window at the next
@@ -261,6 +648,7 @@ func Test_sessionRunner_McpErrorRendersLiveWhileModelStreams(t *testing.T) {
 		dims:  dimensions.Dimensions{Width: 80, Height: 24},
 	}
 	q.mcpSink = newMcpLogSink(mcpLogRolling)
+	q.mcpSink.attach()
 	session := &QuerySession{Chat: pub_models.Chat{ID: "chat-live-mcp"}}
 	runner := sessionRunner[*MockQuerier]{
 		querier:      q,
@@ -358,6 +746,7 @@ func Test_drainMcpLogs_WindowAndElevation(t *testing.T) {
 		dims: dimensions.Dimensions{Width: 80, Height: 24},
 	}
 	q.mcpSink = newMcpLogSink(mcpLogRolling)
+	q.mcpSink.attach()
 	q.mcpSink.AppendServerLog("filesystem", "server started")
 	q.mcpSink.AppendServerLog("filesystem", "error: boom")
 
@@ -372,6 +761,28 @@ func Test_drainMcpLogs_WindowAndElevation(t *testing.T) {
 	}
 }
 
+func Test_drainMcpLogs_AuthPromptElevates(t *testing.T) {
+	var out strings.Builder
+	q := &Querier[*MockQuerier]{
+		out:  &out,
+		dims: dimensions.Dimensions{Width: 80, Height: 24},
+	}
+	q.mcpSink = newMcpLogSink(mcpLogRolling)
+	q.mcpSink.attach()
+	q.mcpSink.AppendServerLog("github", "To authenticate, visit:")
+	q.mcpSink.AppendServerLog("github", "https://example.com/device")
+
+	if err := q.drainMcpLogs(); err != nil {
+		t.Fatalf("drainMcpLogs: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"» To authenticate, visit:", "https://example.com/device"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("elevated auth block missing %q; got:\n%s", want, got)
+		}
+	}
+}
+
 func Test_drainMcpLogs_ElevationClearsWindowRegion(t *testing.T) {
 	var out strings.Builder
 	q := &Querier[*MockQuerier]{
@@ -379,6 +790,7 @@ func Test_drainMcpLogs_ElevationClearsWindowRegion(t *testing.T) {
 		dims: dimensions.Dimensions{Width: 80, Height: 24},
 	}
 	q.mcpSink = newMcpLogSink(mcpLogRolling)
+	q.mcpSink.attach()
 	q.mcpSink.AppendServerLog("fs", "started")
 	if err := q.drainMcpLogs(); err != nil {
 		t.Fatalf("first drain: %v", err)
@@ -405,6 +817,7 @@ func Test_drainMcpLogs_ExitFlushElevates(t *testing.T) {
 		dims: dimensions.Dimensions{Width: 80, Height: 24},
 	}
 	q.mcpSink = newMcpLogSink(mcpLogRolling)
+	q.mcpSink.attach()
 	q.mcpSink.AppendServerLog("fs", "line one")
 	q.mcpSink.AppendServerLog("fs", "line two")
 	q.mcpSink.ServerExited("fs")

--- a/internal/text/mcp_startup.go
+++ b/internal/text/mcp_startup.go
@@ -1,0 +1,106 @@
+package text
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/baalimago/clai/internal/utils"
+)
+
+// mcpStartupPinnedCap bounds the pinned auth lines per startup window: enough
+// for a prompt, its URL, and a user code.
+const mcpStartupPinnedCap = 4
+
+// mcpStartupWindows renders per-server MCP startup logs into one shared
+// terminal region: one window per server in first-seen order, each showing
+// its pinned auth lines over the bounded tail of its other stderr. Auth lines
+// pin so OAuth machinery chatter can never evict the prompt the user must act
+// on. The region redraws in place on every line and is cleared once MCP setup
+// succeeds; a failed or blocked setup keeps it visible. All methods run under
+// the owning sink's mutex.
+type mcpStartupWindows struct {
+	order     []string
+	pinned    map[string][]string
+	tail      map[string][]string
+	drawnRows int
+	cleared   bool
+}
+
+func newMcpStartupWindows() *mcpStartupWindows {
+	return &mcpStartupWindows{
+		pinned: make(map[string][]string),
+		tail:   make(map[string][]string),
+	}
+}
+
+// appendLine records one line in its server's window: pinned lines survive
+// above the rolling tail, and the bounded tail keeps a chatty server from
+// drowning out its neighbours.
+func (w *mcpStartupWindows) appendLine(server, line string, pin bool) {
+	if _, seen := w.tail[server]; !seen {
+		if _, seenPinned := w.pinned[server]; !seenPinned {
+			w.order = append(w.order, server)
+		}
+	}
+	if pin {
+		pinned := append(w.pinned[server], line)
+		if len(pinned) > mcpStartupPinnedCap {
+			pinned = pinned[len(pinned)-mcpStartupPinnedCap:]
+		}
+		w.pinned[server] = pinned
+		return
+	}
+	tail := append(w.tail[server], line)
+	if bound := utils.ToolOutputRows(); len(tail) > bound {
+		tail = tail[len(tail)-bound:]
+	}
+	w.tail[server] = tail
+}
+
+// render redraws the whole region in place. The frame is capped to the
+// terminal height so the in-place clear can never run past the top of the
+// screen.
+func (w *mcpStartupWindows) render(out io.Writer, width, height int) {
+	width = max(width, 1)
+	var frame bytes.Buffer
+	for _, server := range w.order {
+		if err := utils.PrintMcpLogHeader(&frame, server, width); err != nil {
+			return
+		}
+		for _, section := range [][]string{w.pinned[server], w.tail[server]} {
+			for _, line := range section {
+				if err := utils.PrintMcpLogLine(&frame, line, width); err != nil {
+					return
+				}
+			}
+		}
+	}
+	rows := strings.Split(strings.TrimSuffix(frame.String(), "\n"), "\n")
+	if maxRows := max(height-1, 1); len(rows) > maxRows {
+		rows = rows[len(rows)-maxRows:]
+	}
+	var buf bytes.Buffer
+	if w.drawnRows > 0 {
+		fmt.Fprintf(&buf, "\x1b[%dA\r\x1b[J", w.drawnRows)
+	}
+	for _, row := range rows {
+		fmt.Fprintln(&buf, row)
+	}
+	if _, err := out.Write(buf.Bytes()); err != nil {
+		return
+	}
+	w.drawnRows = len(rows)
+}
+
+// clear wipes the drawn region in place and retires the windows: appendLine
+// and render are never called again after clear.
+func (w *mcpStartupWindows) clear(out io.Writer) {
+	w.cleared = true
+	if w.drawnRows == 0 {
+		return
+	}
+	fmt.Fprintf(out, "\x1b[%dA\r\x1b[J", w.drawnRows)
+	w.drawnRows = 0
+}

--- a/internal/text/mcp_startup_test.go
+++ b/internal/text/mcp_startup_test.go
@@ -1,0 +1,176 @@
+package text
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func Test_mcpStartupWindows_AppendLineKeepsFirstSeenOrder(t *testing.T) {
+	w := newMcpStartupWindows()
+	w.appendLine("notion", "n1", false)
+	w.appendLine("linear", "l1", true)
+	w.appendLine("notion", "n2", true)
+	w.appendLine("intercom", "i1", false)
+
+	want := []string{"notion", "linear", "intercom"}
+	if len(w.order) != len(want) {
+		t.Fatalf("order = %v, want %v", w.order, want)
+	}
+	for i, server := range want {
+		if w.order[i] != server {
+			t.Errorf("order[%d] = %q, want %q", i, w.order[i], server)
+		}
+	}
+}
+
+func Test_mcpStartupWindows_AppendLineSeparatesPinnedFromTail(t *testing.T) {
+	w := newMcpStartupWindows()
+	w.appendLine("notion", "prompt", true)
+	w.appendLine("notion", "chatter", false)
+
+	if len(w.pinned["notion"]) != 1 || w.pinned["notion"][0] != "prompt" {
+		t.Errorf("pinned = %v, want [prompt]", w.pinned["notion"])
+	}
+	if len(w.tail["notion"]) != 1 || w.tail["notion"][0] != "chatter" {
+		t.Errorf("tail = %v, want [chatter]", w.tail["notion"])
+	}
+}
+
+func Test_mcpStartupWindows_AppendLineBoundsPinned(t *testing.T) {
+	w := newMcpStartupWindows()
+	for i := range mcpStartupPinnedCap + 3 {
+		w.appendLine("notion", fmt.Sprintf("pin %d", i), true)
+	}
+	pinned := w.pinned["notion"]
+	if len(pinned) != mcpStartupPinnedCap {
+		t.Fatalf("pinned holds %d lines, want cap %d", len(pinned), mcpStartupPinnedCap)
+	}
+	if pinned[0] != "pin 3" {
+		t.Errorf("oldest retained pin = %q, want %q", pinned[0], "pin 3")
+	}
+}
+
+func Test_mcpStartupWindows_AppendLineBoundsTail(t *testing.T) {
+	w := newMcpStartupWindows()
+	for i := range 10 {
+		w.appendLine("notion", fmt.Sprintf("line %d", i), false)
+	}
+	tail := w.tail["notion"]
+	if len(tail) == 10 {
+		t.Fatal("tail unbounded: all 10 lines retained")
+	}
+	if tail[len(tail)-1] != "line 9" {
+		t.Errorf("newest tail line = %q, want %q", tail[len(tail)-1], "line 9")
+	}
+}
+
+func Test_mcpStartupWindows_RenderDrawsSectionsInOrder(t *testing.T) {
+	w := newMcpStartupWindows()
+	w.appendLine("notion", "please sign in", true)
+	w.appendLine("notion", "chatter", false)
+	w.appendLine("linear", "linear line", false)
+
+	var out bytes.Buffer
+	w.render(&out, 80, 40)
+	got := out.String()
+	if strings.Contains(got, "\x1b[J") {
+		t.Errorf("first render must not clear a region: %q", got)
+	}
+	order := []string{"▸ mcp.notion log", "» please sign in", "chatter", "▸ mcp.linear log", "linear line"}
+	last := -1
+	for _, want := range order {
+		idx := strings.Index(got, want)
+		if idx < 0 {
+			t.Fatalf("render missing %q; got: %q", want, got)
+		}
+		if idx < last {
+			t.Errorf("%q rendered out of order; got: %q", want, got)
+		}
+		last = idx
+	}
+	if w.drawnRows == 0 {
+		t.Error("drawnRows not tracked after render")
+	}
+}
+
+func Test_mcpStartupWindows_RerenderClearsPreviousRegion(t *testing.T) {
+	w := newMcpStartupWindows()
+	w.appendLine("notion", "line one", false)
+	var out bytes.Buffer
+	w.render(&out, 80, 40)
+	rows := w.drawnRows
+	out.Reset()
+
+	w.appendLine("notion", "line two", false)
+	w.render(&out, 80, 40)
+	if want := fmt.Sprintf("\x1b[%dA\r\x1b[J", rows); !strings.Contains(out.String(), want) {
+		t.Errorf("redraw missing clear of %d previous rows; got: %q", rows, out.String())
+	}
+}
+
+func Test_mcpStartupWindows_RenderCapsFrameToTerminalHeight(t *testing.T) {
+	w := newMcpStartupWindows()
+	for _, server := range []string{"one", "two", "three"} {
+		for i := range 6 {
+			w.appendLine(server, fmt.Sprintf("%s line %d", server, i), false)
+		}
+	}
+	var out bytes.Buffer
+	w.render(&out, 80, 6)
+	if w.drawnRows > 5 {
+		t.Errorf("drawnRows = %d exceeds height budget 5", w.drawnRows)
+	}
+	if got := strings.Count(out.String(), "\n"); got > 5 {
+		t.Errorf("rendered %d rows, want at most 5", got)
+	}
+}
+
+func Test_mcpStartupWindows_RenderEmptyIsANoop(t *testing.T) {
+	w := newMcpStartupWindows()
+	var out bytes.Buffer
+	w.render(&out, 80, 40)
+	// An empty frame still renders one blank row; the point is it must not
+	// emit a clear sequence or panic.
+	if strings.Contains(out.String(), "\x1b[J") {
+		t.Errorf("empty render emitted a clear: %q", out.String())
+	}
+}
+
+func Test_mcpStartupWindows_ClearWipesRegionOnceAndRetires(t *testing.T) {
+	w := newMcpStartupWindows()
+	w.appendLine("notion", "line", false)
+	var out bytes.Buffer
+	w.render(&out, 80, 40)
+	rows := w.drawnRows
+	out.Reset()
+
+	w.clear(&out)
+	if want := fmt.Sprintf("\x1b[%dA\r\x1b[J", rows); out.String() != want {
+		t.Errorf("clear = %q, want %q", out.String(), want)
+	}
+	if !w.cleared {
+		t.Error("cleared flag not set")
+	}
+	if w.drawnRows != 0 {
+		t.Errorf("drawnRows = %d after clear, want 0", w.drawnRows)
+	}
+	out.Reset()
+	w.clear(&out)
+	if out.Len() != 0 {
+		t.Errorf("second clear wrote output: %q", out.String())
+	}
+}
+
+func Test_mcpStartupWindows_ClearWithoutRenderEmitsNothing(t *testing.T) {
+	w := newMcpStartupWindows()
+	var out bytes.Buffer
+	w.clear(&out)
+	if out.Len() != 0 {
+		t.Errorf("clear with nothing drawn wrote output: %q", out.String())
+	}
+	if !w.cleared {
+		t.Error("cleared flag not set")
+	}
+}

--- a/internal/text/querier.go
+++ b/internal/text/querier.go
@@ -106,9 +106,9 @@ type Querier[C models.StreamCompleter] struct {
 	// stoploss controller consumes it in the session runner (Phase 3).
 	stoploss *Stoploss
 
-	costManager       CostManager
-	costMgrRdyChan    <-chan struct{}
-	costMgrErrChan    <-chan error
+	// costEnricher waits for the model price catalog and stamps cost
+	// estimates onto the chat at finalization.
+	costEnricher      costEnricher
 	callUsageRecorder CallUsageRecorder
 }
 

--- a/internal/text/querier_setup.go
+++ b/internal/text/querier_setup.go
@@ -290,9 +290,7 @@ func NewQuerier[C models.StreamCompleter](ctx context.Context, userConf Configur
 		return modelVersion
 	})
 	rdyChan, errChan := costManager.Start(ctx)
-	querier.costMgrRdyChan = rdyChan
-	querier.costMgrErrChan = errChan
-	querier.costManager = costManager
+	querier.costEnricher = newCostEnricher(costManager, rdyChan)
 	// IMPORTANT: avoid spawning a goroutine that writes to stdout/stderr in tests.
 	// Some tests capture stdout by swapping the global os.Stdout which will race
 	// with concurrent writers under -race.

--- a/internal/text/querier_setup_tools.go
+++ b/internal/text/querier_setup_tools.go
@@ -162,36 +162,20 @@ func setupMcpManager(ctx context.Context, mcpServersDir string, userConf Configu
 	select {
 	case err := <-statusChan:
 		if err != nil {
-			flushMcpSetupErrors(sink)
 			return nil, fmt.Errorf("MCP client manager failed: %w", err)
 		}
+		notifyMcpSetupSucceeded(sink)
 		return runReg.All(), nil
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
 }
 
-// flushMcpSetupErrors prints buffered MCP server error lines to stderr when
-// MCP setup fails before the session loop exists to drain the rolling sink.
-func flushMcpSetupErrors(sink mcp.ServerLogSink) {
-	type drainingSink interface {
-		Drain() []mcpLogEntry
-	}
-	drainer, ok := sink.(drainingSink)
-	if !ok {
-		return
-	}
-	for _, entry := range drainer.Drain() {
-		if !entry.isError {
-			continue
-		}
-		if entry.exit {
-			for _, line := range entry.lines {
-				ancli.Errf("mcp_%v: %v\n", entry.server, line)
-			}
-			continue
-		}
-		ancli.Errf("mcp_%v: %v\n", entry.server, entry.line)
+// notifyMcpSetupSucceeded tells a draining sink that MCP setup completed, so
+// the pre-session auth window can be cleared in place.
+func notifyMcpSetupSucceeded(sink mcp.ServerLogSink) {
+	if s, ok := sink.(interface{ setupSucceeded() }); ok {
+		s.setupSucceeded()
 	}
 }
 

--- a/internal/text/querier_setup_tools_test.go
+++ b/internal/text/querier_setup_tools_test.go
@@ -1,8 +1,8 @@
 package text
 
 import (
+	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -103,27 +103,6 @@ func Test_uniqueToolsDeduplicatesAliasesBySpecificationName(t *testing.T) {
 	}
 }
 
-// captureStderr redirects os.Stderr for the duration of fn and returns
-// everything fn wrote to it. The package runs its tests sequentially, so the
-// global swap cannot race another test.
-func captureStderr(t *testing.T, fn func()) string {
-	t.Helper()
-	old := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("stderr pipe: %v", err)
-	}
-	os.Stderr = w
-	defer func() { os.Stderr = old }()
-	fn()
-	w.Close()
-	out, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("read stderr: %v", err)
-	}
-	return string(out)
-}
-
 func Test_findConfiguredMcpServers_ParsesTimeoutSeconds(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "playwright.json")
@@ -150,10 +129,16 @@ func Test_findConfiguredMcpServers_ParsesTimeoutSeconds(t *testing.T) {
 	}
 }
 
-func Test_flushMcpSetupErrors_PrintsOnlyErrorsAndExitTails(t *testing.T) {
+// Test_setupPhase_LogsRenderLiveInStartupWindow pins the pre-session
+// contract: the startup window shows each server's trailing log lines live,
+// so a setup failure (or a setup blocked on an auth flow) never hides the
+// reason.
+func Test_setupPhase_LogsRenderLiveInStartupWindow(t *testing.T) {
+	var errOut bytes.Buffer
 	sink := newMcpLogSink(mcpLogRolling)
-	// Eleven normal lines: the first four are evicted from the retained tail
-	// (cap 10), so they stay queued as plain entries and must be skipped.
+	sink.errOut = &errOut
+	sink.termWidth = func() int { return 80 }
+	sink.termHeight = func() int { return 40 }
 	for i := range 11 {
 		sink.AppendServerLog("fs", fmt.Sprintf("n%d", i))
 	}
@@ -162,25 +147,156 @@ func Test_flushMcpSetupErrors_PrintsOnlyErrorsAndExitTails(t *testing.T) {
 	sink.AppendServerLog("fs", "tail two")
 	sink.ServerExited("fs")
 
-	got := captureStderr(t, func() { flushMcpSetupErrors(sink) })
-
-	for _, want := range []string{"mcp_fs: fatal: boom", "mcp_fs: n4\n", "mcp_fs: tail one", "mcp_fs: tail two"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("flushMcpSetupErrors output missing %q; got: %q", want, got)
+	frame := errOut.String()
+	if i := strings.LastIndex(frame, "\x1b[J"); i >= 0 {
+		frame = frame[i+len("\x1b[J"):]
+	}
+	for _, want := range []string{"▸ mcp.fs log", "✗ fatal: boom", "tail one", "tail two"} {
+		if !strings.Contains(frame, want) {
+			t.Errorf("startup window missing %q; frame: %q", want, frame)
 		}
 	}
-	for _, absent := range []string{"mcp_fs: n0\n", "mcp_fs: n1\n", "mcp_fs: n2\n", "mcp_fs: n3\n"} {
-		if strings.Contains(got, absent) {
-			t.Errorf("plain queued line was flushed as an error: %q in %q", absent, got)
+	for _, absent := range []string{"n0\n", "n1\n", "n2\n", "n3\n"} {
+		if strings.Contains(frame, absent) {
+			t.Errorf("line past the window tail bound shown: %q in %q", absent, frame)
 		}
 	}
-	if rest := sink.Drain(); rest != nil {
-		t.Errorf("flushMcpSetupErrors left buffered entries behind: %v", rest)
+	if entries := sink.Drain(); entries != nil {
+		t.Errorf("startup window lines also queued: %+v", entries)
 	}
 }
 
-func Test_flushMcpSetupErrors_NonDrainingSinkIsANoop(t *testing.T) {
-	// A nil sink fails the drainer type assertion: the flush must stay silent
-	// instead of panicking.
-	flushMcpSetupErrors(nil)
+// recordingSuccessSink observes the setup-success notification without any
+// rendering machinery.
+type recordingSuccessSink struct{ succeeded bool }
+
+func (r *recordingSuccessSink) AppendServerLog(string, string) {}
+func (r *recordingSuccessSink) ServerExited(string)            {}
+func (r *recordingSuccessSink) setupSucceeded()                { r.succeeded = true }
+
+// Test_setupMcpManager_RegistersToolsAndNotifiesSuccess drives the full
+// startup path against the real testserver subprocess: tools register under
+// the mcp_<server>_<tool> prefix and the sink learns that setup succeeded.
+func Test_setupMcpManager_RegistersToolsAndNotifiesSuccess(t *testing.T) {
+	dir := t.TempDir()
+	conf := []byte(`{"command":"go","args":["run","../tools/mcp/testserver"]}`)
+	if err := os.WriteFile(filepath.Join(dir, "echo.json"), conf, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	sink := &recordingSuccessSink{}
+
+	got, err := setupMcpManager(t.Context(), dir, Configurations{}, sink)
+	if err != nil {
+		t.Fatalf("setupMcpManager: %v", err)
+	}
+	for _, want := range []string{"mcp_echo_echo", "mcp_echo_hang"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("registered tools missing %q; got: %v", want, got)
+		}
+	}
+	if !sink.succeeded {
+		t.Error("sink never notified of setup success")
+	}
+}
+
+func Test_setupMcpManager_SuccessClearsStartupWindows(t *testing.T) {
+	dir := t.TempDir()
+	conf := []byte(`{"command":"go","args":["run","../tools/mcp/testserver"],"env":{"TEST_SERVER_STDERR":"1"}}`)
+	if err := os.WriteFile(filepath.Join(dir, "echo.json"), conf, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	var errOut bytes.Buffer
+	sink := newMcpLogSink(mcpLogRolling)
+	sink.errOut = &errOut
+	sink.termWidth = func() int { return 120 }
+	sink.termHeight = func() int { return 40 }
+
+	if _, err := setupMcpManager(t.Context(), dir, Configurations{}, sink); err != nil {
+		t.Fatalf("setupMcpManager: %v", err)
+	}
+	if !sink.startup.cleared {
+		t.Error("startup windows not cleared after successful setup")
+	}
+}
+
+func Test_setupMcpManager_MissingDirErrors(t *testing.T) {
+	_, err := setupMcpManager(t.Context(), "/nonexistent/mcp/servers/dir", Configurations{}, &recordingSuccessSink{})
+	if err == nil || !strings.Contains(err.Error(), "MCP servers directory not found") {
+		t.Fatalf("err = %v, want missing-directory error", err)
+	}
+}
+
+func Test_setupMcpManager_EmptyDirIsANoop(t *testing.T) {
+	sink := &recordingSuccessSink{}
+	got, err := setupMcpManager(t.Context(), t.TempDir(), Configurations{}, sink)
+	if err != nil {
+		t.Fatalf("setupMcpManager: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("empty dir registered tools: %v", got)
+	}
+	if sink.succeeded {
+		t.Error("sink notified of success although no manager ran")
+	}
+}
+
+func Test_setupMcpManager_SpawnFailureSkipsServer(t *testing.T) {
+	dir := t.TempDir()
+	conf := []byte(`{"command":"/nonexistent-binary-xyz","args":[]}`)
+	if err := os.WriteFile(filepath.Join(dir, "broken.json"), conf, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	sink := &recordingSuccessSink{}
+
+	got, err := setupMcpManager(t.Context(), dir, Configurations{}, sink)
+	if err != nil {
+		t.Fatalf("setupMcpManager: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("broken server registered tools: %v", got)
+	}
+	if !sink.succeeded {
+		t.Error("setup with only skipped servers must still report success")
+	}
+}
+
+func Test_matchingTools(t *testing.T) {
+	available := map[string]pub_models.LLMTool{
+		"mcp_notion_search": setupToolsTestTool{name: "mcp_notion_search"},
+		"mcp_notion_fetch":  setupToolsTestTool{name: "mcp_notion_fetch"},
+		"cat":               setupToolsTestTool{name: "cat"},
+	}
+	if got := matchingTools(available, "mcp_notion_*"); len(got) != 2 {
+		t.Errorf("wildcard matched %d tools, want 2", len(got))
+	}
+	if got := matchingTools(available, "cat"); len(got) != 1 {
+		t.Errorf("exact match found %d tools, want 1", len(got))
+	}
+	if got := matchingTools(available, "mcp_linear_*"); got != nil {
+		t.Errorf("non-matching pattern returned %v, want none", got)
+	}
+}
+
+// recordingToolBox counts tool registrations.
+type recordingToolBox struct{ registered []string }
+
+func (r *recordingToolBox) RegisterTool(tool pub_models.LLMTool) {
+	r.registered = append(r.registered, tool.Specification().Name)
+}
+
+func Test_registerTool_DeduplicatesByName(t *testing.T) {
+	box := &recordingToolBox{}
+	conf := &Configurations{}
+	tool := setupToolsTestTool{name: "cat"}
+
+	registerTool(box, conf, tool)
+	registerTool(box, conf, tool)
+	registerTool(box, conf, setupToolsTestTool{name: "ls"})
+
+	if !slices.Equal(box.registered, []string{"cat", "ls"}) {
+		t.Errorf("registered = %v, want [cat ls]", box.registered)
+	}
+	if _, ok := conf.RegisteredTools["cat"]; !ok {
+		t.Error("registration not tracked in RegisteredTools")
+	}
 }

--- a/internal/text/querier_test.go
+++ b/internal/text/querier_test.go
@@ -826,8 +826,7 @@ func Test_Querier_postProcess_OnlyOuterCallEnrichesChat(t *testing.T) {
 		shouldSaveReply: true,
 		configDir:       tmpConfigDir,
 		callStackLevel:  2,
-		costManager:     costMgr,
-		costMgrRdyChan:  ready,
+		costEnricher:    newCostEnricher(costMgr, ready),
 		chat: pub_models.Chat{
 			ID: "globalScope",
 			Messages: []pub_models.Message{
@@ -882,8 +881,7 @@ func Test_Querier_postProcess_enriches_before_save_when_cost_manager_ready(t *te
 	q := Querier[*MockQuerier]{
 		configDir:       tmpConfigDir,
 		shouldSaveReply: true,
-		costManager:     costMgr,
-		costMgrRdyChan:  ready,
+		costEnricher:    newCostEnricher(costMgr, ready),
 		chat: pub_models.Chat{
 			ID: "globalScope",
 			Messages: []pub_models.Message{
@@ -949,8 +947,7 @@ func Test_Querier_postProcess_preserves_runtime_model_name_in_saved_query_cost(t
 	q := Querier[*MockQuerier]{
 		configDir:       tmpConfigDir,
 		shouldSaveReply: true,
-		costManager:     costMgr,
-		costMgrRdyChan:  ready,
+		costEnricher:    newCostEnricher(costMgr, ready),
 		Model: &MockQuerier{
 			modelName: "runtime-model-b",
 		},
@@ -1014,8 +1011,7 @@ func Test_Querier_postProcess_enriches_before_save_for_nested_tool_root_query(t 
 		configDir:       tmpConfigDir,
 		shouldSaveReply: true,
 		callStackLevel:  2,
-		costManager:     costMgr,
-		costMgrRdyChan:  ready,
+		costEnricher:    newCostEnricher(costMgr, ready),
 		chat: pub_models.Chat{
 			ID: "globalScope",
 			Messages: []pub_models.Message{
@@ -1078,8 +1074,7 @@ func Test_Querier_postProcess_SkipsCostEnrichIfManagerNotReady(t *testing.T) {
 		out:             &strings.Builder{},
 		shouldSaveReply: true,
 		configDir:       tmpConfigDir,
-		costManager:     costMgr,
-		costMgrRdyChan:  ready,
+		costEnricher:    newCostEnricher(costMgr, ready),
 		chat: pub_models.Chat{
 			ID: "globalScope",
 			Messages: []pub_models.Message{
@@ -1121,8 +1116,7 @@ func Test_Querier_postProcess_StillSavesWhenCostEnrichFails(t *testing.T) {
 		out:             &strings.Builder{},
 		shouldSaveReply: true,
 		configDir:       tmpConfigDir,
-		costManager:     costMgr,
-		costMgrRdyChan:  ready,
+		costEnricher:    newCostEnricher(costMgr, ready),
 		chat: pub_models.Chat{
 			ID: "globalScope",
 			Messages: []pub_models.Message{
@@ -1188,7 +1182,7 @@ func Test_Querier_Query_ToolCallRecursion_PreservesConversationMessages(t *testi
 		out:             &strings.Builder{},
 		shouldSaveReply: true,
 		configDir:       tmpConfigDir,
-		costMgrRdyChan:  makeClosedChan(),
+		costEnricher:    newCostEnricher(nil, makeClosedChan()),
 		chat: pub_models.Chat{
 			ID: "globalScope",
 			Messages: []pub_models.Message{
@@ -1290,8 +1284,7 @@ func Test_Querier_Query_ToolCallRecursion_UsesFinalAssistantTurnTokenUsageForCos
 		out:             &strings.Builder{},
 		shouldSaveReply: true,
 		configDir:       tmpConfigDir,
-		costManager:     costMgr,
-		costMgrRdyChan:  makeClosedChan(),
+		costEnricher:    newCostEnricher(costMgr, makeClosedChan()),
 		chat: pub_models.Chat{
 			ID: "globalScope",
 			Messages: []pub_models.Message{
@@ -1376,8 +1369,7 @@ func Test_Querier_Query_ToolCallRecursion_AccumulatesNestedTokenUsageForCostEnri
 		out:             &strings.Builder{},
 		shouldSaveReply: true,
 		configDir:       tmpConfigDir,
-		costManager:     costMgr,
-		costMgrRdyChan:  makeClosedChan(),
+		costEnricher:    newCostEnricher(costMgr, makeClosedChan()),
 		chat: pub_models.Chat{
 			ID: "globalScope",
 			Messages: []pub_models.Message{
@@ -1462,8 +1454,7 @@ func Test_Querier_Query_ToolCallRecursion_CostEnrichmentUsesFinalAssistantTurnTo
 		out:             &strings.Builder{},
 		shouldSaveReply: true,
 		configDir:       tmpConfigDir,
-		costManager:     costMgr,
-		costMgrRdyChan:  makeClosedChan(),
+		costEnricher:    newCostEnricher(costMgr, makeClosedChan()),
 		chat: pub_models.Chat{
 			ID: "globalScope",
 			Messages: []pub_models.Message{
@@ -1545,8 +1536,7 @@ func Test_Querier_Query_ToolCallSession_PreservesFinalReplyRoleAndFinalUsage(t *
 		out:             &strings.Builder{},
 		shouldSaveReply: true,
 		configDir:       tmpConfigDir,
-		costManager:     costMgr,
-		costMgrRdyChan:  makeClosedChan(),
+		costEnricher:    newCostEnricher(costMgr, makeClosedChan()),
 		chat: pub_models.Chat{
 			ID:       "globalScope",
 			Messages: []pub_models.Message{{Role: "user", Content: "hello there"}},
@@ -1660,4 +1650,12 @@ func Test_ChatQuerier(t *testing.T) {
 		},
 	}
 	models.ChatQuerier_Test(t, &q)
+}
+
+func Test_SetChatID(t *testing.T) {
+	q := &Querier[*MockQuerier]{}
+	q.SetChatID("chat-42")
+	if q.chat.ID != "chat-42" {
+		t.Errorf("chat ID = %q, want chat-42", q.chat.ID)
+	}
 }

--- a/internal/text/session_runner.go
+++ b/internal/text/session_runner.go
@@ -53,6 +53,11 @@ func (r *sessionRunner[C]) Run(ctx context.Context, session *QuerySession) (runE
 	if r.stoploss == nil {
 		r.stoploss = r.querier.newStoploss()
 	}
+	if r.querier.mcpSink != nil {
+		// The session loop drains the sink from here on; stop the pre-loop
+		// direct printing of elevated MCP lines.
+		r.querier.mcpSink.attach()
+	}
 	session.StartedAt = time.Now()
 	defer func() {
 		session.FinishedAt = time.Now()

--- a/internal/text/session_runner_test.go
+++ b/internal/text/session_runner_test.go
@@ -1028,3 +1028,45 @@ func Test_sessionRunner_Run_DrainsAndExecutesParallelToolCallsAsOneTurn(t *testi
 		t.Fatalf("expected the first result before the second call, got:\n%s", output)
 	}
 }
+
+func Test_sleepContext(t *testing.T) {
+	if err := sleepContext(t.Context(), 0); err != nil {
+		t.Errorf("zero duration errored: %v", err)
+	}
+	if err := sleepContext(t.Context(), -time.Second); err != nil {
+		t.Errorf("negative duration errored: %v", err)
+	}
+	if err := sleepContext(t.Context(), time.Millisecond); err != nil {
+		t.Errorf("short sleep errored: %v", err)
+	}
+	cancelled, cancel := context.WithCancel(t.Context())
+	cancel()
+	if err := sleepContext(cancelled, time.Minute); err == nil {
+		t.Error("cancelled context did not interrupt the sleep")
+	}
+}
+
+// Test_waitForRateLimitReset_FallbackPath covers models without an input
+// token counter: the runner sleeps until ResetAt plus slack, which is
+// immediate for a reset time in the past.
+func Test_waitForRateLimitReset_FallbackPath(t *testing.T) {
+	r := sessionRunner[*MockQuerier]{querier: &Querier[*MockQuerier]{Model: &MockQuerier{}}}
+	err := r.waitForRateLimitReset(t.Context(), pub_models.Chat{}, models.ErrRateLimit{
+		ResetAt: time.Now().Add(-time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("waitForRateLimitReset: %v", err)
+	}
+}
+
+func Test_waitForRateLimitReset_FallbackHonorsCancel(t *testing.T) {
+	cancelled, cancel := context.WithCancel(t.Context())
+	cancel()
+	r := sessionRunner[*MockQuerier]{querier: &Querier[*MockQuerier]{Model: &MockQuerier{}}}
+	err := r.waitForRateLimitReset(cancelled, pub_models.Chat{}, models.ErrRateLimit{
+		ResetAt: time.Now().Add(time.Hour),
+	})
+	if err == nil {
+		t.Fatal("cancelled context did not interrupt the rate limit wait")
+	}
+}

--- a/internal/text/tool_executor_lookback_test.go
+++ b/internal/text/tool_executor_lookback_test.go
@@ -1,0 +1,56 @@
+package text
+
+import (
+	"testing"
+
+	pub_models "github.com/baalimago/clai/pkg/text/models"
+)
+
+func Test_boolInput(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     pub_models.Input
+		dfault bool
+		want   bool
+	}{
+		{name: "nil input keeps default", in: nil, dfault: true, want: true},
+		{name: "missing key keeps default", in: pub_models.Input{}, dfault: true, want: true},
+		{name: "bool value", in: pub_models.Input{"k": false}, dfault: true, want: false},
+		{name: "string true", in: pub_models.Input{"k": " True "}, dfault: false, want: true},
+		{name: "string false", in: pub_models.Input{"k": "FALSE"}, dfault: true, want: false},
+		{name: "garbage string keeps default", in: pub_models.Input{"k": "yes"}, dfault: true, want: true},
+		{name: "wrong type keeps default", in: pub_models.Input{"k": 1}, dfault: false, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := boolInput(tt.in, "k", tt.dfault); got != tt.want {
+				t.Errorf("boolInput = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_intInput(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     pub_models.Input
+		dfault int
+		want   int
+	}{
+		{name: "nil input keeps default", in: nil, dfault: 7, want: 7},
+		{name: "missing key keeps default", in: pub_models.Input{}, dfault: 7, want: 7},
+		{name: "int value", in: pub_models.Input{"k": 3}, dfault: 7, want: 3},
+		{name: "int64 value", in: pub_models.Input{"k": int64(4)}, dfault: 7, want: 4},
+		{name: "json float value", in: pub_models.Input{"k": 5.0}, dfault: 7, want: 5},
+		{name: "numeric string", in: pub_models.Input{"k": " 42 "}, dfault: 7, want: 42},
+		{name: "garbage string keeps default", in: pub_models.Input{"k": "many"}, dfault: 7, want: 7},
+		{name: "wrong type keeps default", in: pub_models.Input{"k": true}, dfault: 7, want: 7},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := intInput(tt.in, "k", tt.dfault); got != tt.want {
+				t.Errorf("intInput = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/text/tool_executor_test.go
+++ b/internal/text/tool_executor_test.go
@@ -1,0 +1,79 @@
+package text
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/baalimago/go_away_boilerplate/pkg/dimensions"
+
+	pub_models "github.com/baalimago/clai/pkg/text/models"
+)
+
+func Test_toolCallError(t *testing.T) {
+	tests := []struct {
+		name    string
+		out     string
+		wantErr bool
+	}{
+		{name: "error convention output", out: "ERROR: command exploded", wantErr: true},
+		{name: "plain output", out: "42 files found", wantErr: false},
+		{name: "empty output", out: "", wantErr: false},
+		{name: "error marker mid-output", out: "the log said ERROR: nope", wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := toolCallError(tt.out)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("toolCallError(%q) = %v, wantErr %v", tt.out, err, tt.wantErr)
+			}
+			if err != nil && !strings.Contains(err.Error(), "command exploded") {
+				t.Errorf("error lost the tool output: %v", err)
+			}
+		})
+	}
+}
+
+func Test_finalizeAssistantTextPlain_EchoedToolCallDropped(t *testing.T) {
+	var out strings.Builder
+	q := &Querier[*MockQuerier]{
+		Raw:  true, // raw display: no terminal clearing, no pretty print
+		out:  &out,
+		dims: dimensions.Dimensions{Width: 80, Height: 24},
+	}
+	e := toolExecutor[*MockQuerier]{querier: q}
+	call := pub_models.Call{Name: "cat", Inputs: &pub_models.Input{}}
+	session := &QuerySession{}
+
+	if err := e.finalizeAssistantTextPlain(t.Context(), session, call.PrettyPrint(), call); err != nil {
+		t.Fatalf("finalizeAssistantTextPlain: %v", err)
+	}
+	if session.FinalAssistantText != "" {
+		t.Errorf("echoed tool-call text kept as assistant prose: %q", session.FinalAssistantText)
+	}
+	if q.fullMsg != "" {
+		t.Errorf("echoed tool-call text kept in querier state: %q", q.fullMsg)
+	}
+}
+
+func Test_finalizeAssistantTextPlain_ProseIsFinalized(t *testing.T) {
+	var out strings.Builder
+	q := &Querier[*MockQuerier]{
+		out:              &out,
+		outputModeKnown:  true,
+		outputIsTerminal: true,
+		dims:             dimensions.Dimensions{Width: 80, Height: 24},
+	}
+	e := toolExecutor[*MockQuerier]{querier: q}
+	call := pub_models.Call{Name: "cat", Inputs: &pub_models.Input{}}
+	session := &QuerySession{}
+
+	if err := e.finalizeAssistantTextPlain(t.Context(), session, "let me check the file", call); err != nil {
+		t.Fatalf("finalizeAssistantTextPlain: %v", err)
+	}
+	if session.FinalAssistantText != "let me check the file" {
+		t.Errorf("FinalAssistantText = %q, want the streamed prose", session.FinalAssistantText)
+	}
+	if !strings.Contains(out.String(), "let me check the file") {
+		t.Errorf("prose not re-printed as a proper message; out: %q", out.String())
+	}
+}

--- a/internal/tools/mcp/testserver/main.go
+++ b/internal/tools/mcp/testserver/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 )
 
@@ -14,6 +15,14 @@ type Request struct {
 }
 
 func main() {
+	if os.Getenv("TEST_SERVER_AUTH_HANG") != "" {
+		// Print an OAuth prompt, then wait for an authorization that never
+		// comes: stay alive without answering any request.
+		fmt.Fprintln(os.Stderr, "Please authorize this client by visiting:")
+		fmt.Fprintln(os.Stderr, "https://example.com/authorize?client_id=test")
+		io.Copy(io.Discard, os.Stdin)
+		return
+	}
 	if os.Getenv("TEST_SERVER_CRASH_TAIL") != "" {
 		fmt.Fprintln(os.Stderr, "worker stopped")
 		fmt.Fprintln(os.Stderr, "signal received")

--- a/internal/utils/print.go
+++ b/internal/utils/print.go
@@ -597,14 +597,7 @@ func (v *ActivityViewport) wrapBlock(block *activityBlock) []activityRow {
 		return append(rows, activityRow{})
 	case blockMcpLog:
 		rows := []activityRow{{content: truncateTerminalRow(mcpLogBlockHeader(block.server), v.width), color: TableTheme().Secondary}}
-		for _, row := range compactTerminalRows(block.content, max(v.width-2, 1), block.toolBodyRows) {
-			color := ""
-			if IsMcpLogErrorLine(row) {
-				row = truncateTerminalRow("✗ "+row, max(v.width-2, 1))
-				color = RoleColor("tool")
-			}
-			rows = append(rows, activityRow{content: "  " + row, color: color})
-		}
+		rows = append(rows, mcpLogBodyRows(block.content, max(v.width-2, 1), block.toolBodyRows)...)
 		return append(rows, activityRow{})
 	}
 	return nil
@@ -816,17 +809,116 @@ var mcpLogErrorKeywords = []string{
 	"refused", "unable", "cannot", "could not", "warn", "timeout", "unreachable",
 }
 
+// mcpLogAuthKeywords marks MCP server stderr lines that ask the user to act
+// on an auth flow. Auth prompts elevate like errors: a suppressed prompt
+// leaves the server waiting on an auth flow the user never sees. The set is
+// deliberately imperative ("please authorize", "not logged in") so OAuth
+// machinery status chatter ("Discovering OAuth server configuration",
+// "Initializing auth coordination") stays quiet.
+var mcpLogAuthKeywords = []string{
+	"please authorize", "please authenticate", "please visit",
+	"please sign in", "please log in", "please login",
+	"to authenticate", "to authorize",
+	"sign in to", "sign in at", "log in to", "log in at", "login required",
+	"not authenticated", "not logged in", "unauthenticated",
+	"no credentials", "credentials expired", "session expired",
+	"missing api key", "invalid api key",
+	"token expired", "token has expired",
+	"enter the code", "enter code", "one-time code",
+	"device code", "verification code",
+	"401", "403", "unauthorized", "forbidden",
+}
+
+// mcpLogAuthURLMarkers are URL path fragments that mark a line carrying an
+// auth flow URL the user must visit. Matched only on lines containing "://",
+// so prose mentioning oauth stays unmatched.
+var mcpLogAuthURLMarkers = []string{
+	"/auth", "/login", "/oauth", "/device", "/activate",
+	"/signin", "/sign-in", "/verify",
+}
+
 // IsMcpLogErrorLine reports whether an MCP server stderr line looks like an
 // error. The match is case-insensitive substring matching against
 // mcpLogErrorKeywords.
 func IsMcpLogErrorLine(line string) bool {
+	return matchesAnyKeyword(line, mcpLogErrorKeywords)
+}
+
+// IsMcpLogAuthLine reports whether an MCP server stderr line asks the user to
+// act on an auth flow: an imperative prompt, an auth failure, or a URL whose
+// path looks like an auth endpoint.
+func IsMcpLogAuthLine(line string) bool {
+	if matchesAnyKeyword(line, mcpLogAuthKeywords) {
+		return true
+	}
+	return strings.Contains(line, "://") && matchesAnyKeyword(line, mcpLogAuthURLMarkers)
+}
+
+// IsMcpLogAuthPayloadLine reports whether a line following an auth prompt
+// carries its actionable payload: any URL, or a short uppercase user code like
+// "ABCD-1234". Everything else after a prompt is machinery chatter.
+func IsMcpLogAuthPayloadLine(line string) bool {
+	if strings.Contains(line, "://") {
+		return true
+	}
+	line = strings.TrimSpace(line)
+	if len(line) < 4 || len(line) > 16 {
+		return false
+	}
+	digitOrUpper := false
+	for _, r := range line {
+		switch {
+		case r >= 'A' && r <= 'Z' || r >= '0' && r <= '9':
+			digitOrUpper = true
+		case r == '-':
+		default:
+			return false
+		}
+	}
+	return digitOrUpper
+}
+
+func matchesAnyKeyword(line string, keywords []string) bool {
 	lower := strings.ToLower(line)
-	for _, keyword := range mcpLogErrorKeywords {
+	for _, keyword := range keywords {
 		if strings.Contains(lower, keyword) {
 			return true
 		}
 	}
 	return false
+}
+
+// mcpLogBodyRows wraps MCP log content into styled body rows: auth
+// prompts get the » marker in the user-role color, errors the magenta ✗
+// marker, other lines stay plain. Markers are prepended before wrapping and
+// rows wrap instead of truncating, so payloads like OAuth URLs keep every
+// character. maxRows > 0 compacts the middle rows like compactTerminalRows.
+// Auth wins over error so lines like "401 Unauthorized" read as an action
+// prompt rather than a failure to ignore.
+func mcpLogBodyRows(content string, width, maxRows int) []activityRow {
+	var rows []activityRow
+	for line := range strings.SplitSeq(content, "\n") {
+		marker, color := "", ""
+		switch {
+		case IsMcpLogAuthLine(line):
+			marker, color = "» ", RoleColor("user")
+		case IsMcpLogErrorLine(line):
+			marker, color = "✗ ", RoleColor("tool")
+		}
+		for _, row := range terminalRows(marker+line, width) {
+			rows = append(rows, activityRow{content: "  " + row, color: color})
+		}
+	}
+	if maxRows <= 0 || len(rows) <= maxRows {
+		return rows
+	}
+	head := maxRows / 2
+	tail := maxRows - head - 1
+	marker := fmt.Sprintf("  ... [%d terminal rows omitted] ...", len(rows)-head-tail)
+	compacted := make([]activityRow, 0, maxRows)
+	compacted = append(compacted, rows[:head]...)
+	compacted = append(compacted, activityRow{content: marker})
+	return append(compacted, rows[len(rows)-tail:]...)
 }
 
 // mcpLogBlockHeader renders the rolling-window header for one MCP server log
@@ -835,31 +927,40 @@ func mcpLogBlockHeader(server string) string {
 	return "▸ mcp." + sanitizeTerminalRow(server) + " log"
 }
 
+// PrintMcpLogHeader prints the rolling-window style block header for one MCP
+// server's log lines.
+func PrintMcpLogHeader(w io.Writer, server string, termWidth int) error {
+	header := truncateTerminalRow(mcpLogBlockHeader(server), max(termWidth, 1))
+	if _, err := fmt.Fprintln(w, table.Colorize(TableTheme().Secondary, header)); err != nil {
+		return fmt.Errorf("write mcp log block header: %w", err)
+	}
+	return nil
+}
+
+// PrintMcpLogLine prints one styled MCP log line under a block header,
+// following the mcpLogBodyRows styling and wrapping rules.
+func PrintMcpLogLine(w io.Writer, line string, termWidth int) error {
+	for _, row := range mcpLogBodyRows(sanitizeTerminalRow(line), max(termWidth-2, 1), 0) {
+		if _, err := fmt.Fprintln(w, table.Colorize(row.color, row.content)); err != nil {
+			return fmt.Errorf("write mcp log block line: %w", err)
+		}
+	}
+	return nil
+}
+
 // PrintMcpErrorBlock prints one elevated MCP server error block below the
 // rolling window. The block is display-only: it never enters the chat history
-// or model context. Non-error lines keep their plain body style; error lines
-// get the magenta ✗ marker used for tool errors.
+// or model context.
 func PrintMcpErrorBlock(w io.Writer, server string, lines []string, termWidth int) error {
 	if w == nil {
 		w = os.Stdout
 	}
-	header := truncateTerminalRow(mcpLogBlockHeader(server), max(termWidth, 1))
-	if _, err := fmt.Fprintln(w, table.Colorize(TableTheme().Secondary, header)); err != nil {
-		return fmt.Errorf("write mcp error block header: %w", err)
+	if err := PrintMcpLogHeader(w, server, termWidth); err != nil {
+		return err
 	}
-	contentWidth := max(termWidth-2, 1)
 	for _, line := range lines {
-		line = sanitizeTerminalRow(line)
-		line = truncateTerminalRow(line, contentWidth)
-		if IsMcpLogErrorLine(line) {
-			line = "✗ " + line
-			if _, err := fmt.Fprintln(w, "  "+table.Colorize(RoleColor("tool"), line)); err != nil {
-				return fmt.Errorf("write mcp error block line: %w", err)
-			}
-			continue
-		}
-		if _, err := fmt.Fprintln(w, "  "+line); err != nil {
-			return fmt.Errorf("write mcp error block line: %w", err)
+		if err := PrintMcpLogLine(w, line, termWidth); err != nil {
+			return err
 		}
 	}
 	_, err := fmt.Fprintln(w)

--- a/internal/utils/print_test.go
+++ b/internal/utils/print_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -51,6 +52,124 @@ func TestIsMcpLogErrorLine(t *testing.T) {
 	}
 }
 
+func TestIsMcpLogAuthLine(t *testing.T) {
+	authLines := []string{
+		"Please visit https://github.com/login/device and enter code ABCD-1234",
+		"[115] Please authorize this client by visiting:",
+		"https://mcp.notion.com/authorize?response_type=code&client_id=abc",
+		"Not authenticated. Run 'wrangler login' first",
+		"Your OAuth token has expired",
+		"401 Unauthorized",
+		"HTTP 403 Forbidden",
+		"missing API key",
+		"no credentials found",
+		"Sign in to continue",
+		"enter the verification code shown in your browser",
+	}
+	for _, line := range authLines {
+		if !IsMcpLogAuthLine(line) {
+			t.Errorf("IsMcpLogAuthLine(%q) = false, want true", line)
+		}
+	}
+	// OAuth machinery status chatter must stay quiet: only prompts that need
+	// the user's action elevate.
+	nonAuthLines := []string{
+		"server started",
+		"listening on :8080",
+		"request handled in 12ms",
+		"INFO: ready",
+		"error: boom",
+		"timeout exceeded",
+		"[108] Discovering OAuth server configuration...",
+		"[115] Discovered authorization server: https://mcp.notion.com",
+		"[115] Connecting to remote server: https://mcp.notion.com/mcp",
+		"[115] Using transport strategy: http-first",
+		"[115] Authentication required. Initializing auth...",
+		"[115] Initializing auth coordination on-demand",
+		"[115] OAuth callback server running at http://127.0.0.1:9553",
+		"[115] Creating lockfile for server cb42d1a06ae8 with process 115 on port 9553",
+		"[115] Authentication required. Waiting for authorization...",
+		"[115] Browser opened automatically.",
+	}
+	for _, line := range nonAuthLines {
+		if IsMcpLogAuthLine(line) {
+			t.Errorf("IsMcpLogAuthLine(%q) = true, want false", line)
+		}
+	}
+}
+
+func TestIsMcpLogAuthPayloadLine(t *testing.T) {
+	payloadLines := []string{
+		"https://mcp.notion.com/authorize?response_type=code",
+		"http://example.com/anything",
+		"ABCD-1234",
+		"WDJB-MJHT",
+	}
+	for _, line := range payloadLines {
+		if !IsMcpLogAuthPayloadLine(line) {
+			t.Errorf("IsMcpLogAuthPayloadLine(%q) = false, want true", line)
+		}
+	}
+	nonPayloadLines := []string{
+		"Browser opened automatically.",
+		"Creating lockfile for server cb42d1a06ae8 with process 115 on port 9553",
+		"[115]",
+		"code line two",
+		"",
+	}
+	for _, line := range nonPayloadLines {
+		if IsMcpLogAuthPayloadLine(line) {
+			t.Errorf("IsMcpLogAuthPayloadLine(%q) = true, want false", line)
+		}
+	}
+}
+
+func TestPrintMcpErrorBlock_AuthLines(t *testing.T) {
+	var out bytes.Buffer
+	err := PrintMcpErrorBlock(&out, "github", []string{"To use this server, please sign in:", "https://example.com/device"}, 80)
+	if err != nil {
+		t.Fatalf("PrintMcpErrorBlock: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "» To use this server, please sign in:") {
+		t.Errorf("auth line missing » marker; got:\n%s", got)
+	}
+	if !strings.Contains(got, "https://example.com/device") {
+		t.Errorf("auth payload line missing; got:\n%s", got)
+	}
+	if strings.Contains(got, "✗") {
+		t.Errorf("auth line styled as error; got:\n%s", got)
+	}
+}
+
+func TestPrintMcpErrorBlock_WrapsLongAuthURL(t *testing.T) {
+	var out bytes.Buffer
+	url := "https://mcp.notion.com/authorize?response_type=code&code_challenge=" + strings.Repeat("x", 200) + "&state=end-of-url"
+	err := PrintMcpErrorBlock(&out, "notion", []string{"Please authorize this client by visiting:", url}, 80)
+	if err != nil {
+		t.Fatalf("PrintMcpErrorBlock: %v", err)
+	}
+	// Rows are indented, colorized and wrapped; strip decoration and rejoin to
+	// verify the URL survived without truncation.
+	stripped := regexp.MustCompile("\x1b\\[[0-9;]*m").ReplaceAllString(out.String(), "")
+	joined := strings.ReplaceAll(strings.ReplaceAll(stripped, "\n", ""), " ", "")
+	if !strings.Contains(joined, "&state=end-of-url") {
+		t.Errorf("URL tail truncated; got:\n%s", out.String())
+	}
+	if strings.Contains(stripped, "…") {
+		t.Errorf("elevated block truncated a line; got:\n%s", out.String())
+	}
+}
+
+func TestActivityViewport_AppendMcpLogBlock_AuthMarker(t *testing.T) {
+	viewport := NewActivityViewport(60, 30, 30)
+	viewport.AppendMcpLogBlock("github", "server started\nNot logged in. Run 'gh auth login'", 6)
+	joined := strings.Join(viewport.Rows(), "\n")
+	if !strings.Contains(joined, "» Not logged in. Run 'gh auth login'") {
+		t.Errorf("rows missing auth marker; got:\n%s", joined)
+	}
+}
+
 func TestActivityViewport_AppendMcpLogBlock(t *testing.T) {
 	viewport := NewActivityViewport(40, 30, 30)
 	viewport.AppendMcpLogBlock("filesystem", "server started\nWARN: slow request\nerror: boom", 6)
@@ -66,6 +185,20 @@ func TestActivityViewport_AppendMcpLogBlock(t *testing.T) {
 		if !strings.Contains(joined, want) {
 			t.Errorf("rows missing %q; got:\n%s", want, joined)
 		}
+	}
+}
+
+func TestActivityViewport_McpLogBlockWrapsLongAuthURL(t *testing.T) {
+	v := NewActivityViewport(40, 30, 30)
+	url := "https://example.com/authorize?code=" + strings.Repeat("x", 80) + "ENDOFURL"
+	v.AppendMcpLogBlock("notion", url, 8)
+	joined := strings.Join(v.Rows(), "\n")
+	stripped := strings.NewReplacer("\n", "", " ", "", "»", "").Replace(joined)
+	if !strings.Contains(stripped, "ENDOFURL") {
+		t.Errorf("URL tail lost in window; rows:\n%s", joined)
+	}
+	if strings.Contains(joined, "…") {
+		t.Errorf("auth URL truncated in window; rows:\n%s", joined)
 	}
 }
 


### PR DESCRIPTION
In addition: clean up a lot of the code in the text package as it was quite crudly designed. Now it's separated into much more testable components