### PR TITLE
feat: Add mktemp tool

### DIFF
--- a/architecture/tooling.md
+++ b/architecture/tooling.md
@@ -53,6 +53,12 @@ Built-in tools typically run locally (e.g., execute a Go command, search files, 
 - produce deterministic/structured output
 - return errors with context (`fmt.Errorf("<context>: %w", err)`) so failures are explainable
 
+The `mktemp` built-in creates a private directory under the operating system's
+temporary directory and removes it when the calling context is canceled. The
+cleanup lives inside the tool itself, so the CLI and `pkg` agents get identical
+behavior: whoever cancels the query context triggers removal, with no extra
+wiring at the call site.
+
 ### MCP tools
 
 MCP tools are discovered from configured MCP servers (see [MCP servers](#mcp-servers)). During tooling initialization:

--- a/internal/text/querier.go
+++ b/internal/text/querier.go
@@ -24,9 +24,8 @@ const (
 
 	// maxReasoningBuf caps the reasoning text accumulated per stream. A
 	// looping model can stream reasoning tokens forever; without the cap the
-	// strings.Builder here grows unboundedly (O(n) per append, doubling the
-	// backing array) until the process OOMs (kinoview production incident,
-	// 2026-08-11: 2.53 GB heap). Keeping the tail preserves the reasoning
+	// accumulator grows unboundedly until the process OOMs (kinoview production
+	// incident, 2026-08-11: 2.53 GB heap). Keeping the tail preserves the reasoning
 	// context that matters for tool calls and the final answer.
 	maxReasoningBuf = 1 << 20 // 1 MiB
 )
@@ -74,7 +73,7 @@ type Querier[C models.StreamCompleter] struct {
 
 	// reasoningBuf preserves source reasoning for the session and model. The
 	// activity viewport is a separate, bounded terminal-only copy.
-	reasoningBuf     strings.Builder
+	reasoningBuf     tailBuffer
 	reasoningActive  bool
 	activityViewport *utils.ActivityViewport
 	// mcpSink buffers MCP server stderr lines for the rolling window. It is
@@ -256,18 +255,11 @@ func (q *Querier[C]) handleTokenForSession(session *QuerySession, token string) 
 	return nil
 }
 
-// appendReasoning accumulates one reasoning token into reasoningBuf, keeping
-// only the last maxReasoningBuf bytes. An endless reasoning stream (a looping
-// model) otherwise grows the builder without bound — O(n) per append with
-// doubling backing arrays — until the process OOMs. The tail is what survives
-// into tool calls and the final answer.
+// appendReasoning accumulates one reasoning token into reasoningBuf. The
+// bounded circular buffer keeps the newest maxReasoningBuf bytes without
+// repeatedly copying the full retained tail.
 func (q *Querier[C]) appendReasoning(content string) {
 	q.reasoningBuf.WriteString(content)
-	if q.reasoningBuf.Len() > maxReasoningBuf {
-		tail := q.reasoningBuf.String()
-		q.reasoningBuf.Reset()
-		q.reasoningBuf.WriteString(tail[len(tail)-maxReasoningBuf:])
-	}
 }
 
 func (q *Querier[C]) usesActivityViewport() bool {

--- a/internal/text/tail_buffer.go
+++ b/internal/text/tail_buffer.go
@@ -1,0 +1,68 @@
+package text
+
+// tailBuffer is a fixed-size circular byte buffer. Its zero value uses the
+// reasoning-buffer limit, while tests can select a smaller capacity.
+type tailBuffer struct {
+	buf      []byte
+	start    int
+	length   int
+	capacity int
+}
+
+func (b *tailBuffer) WriteString(content string) {
+	capacity := b.capacity
+	if capacity == 0 {
+		capacity = maxReasoningBuf
+	}
+	if len(b.buf) == 0 {
+		b.buf = make([]byte, capacity)
+	}
+	if len(content) >= capacity {
+		copy(b.buf, content[len(content)-capacity:])
+		b.start = 0
+		b.length = capacity
+		return
+	}
+
+	if b.length < capacity {
+		available := capacity - b.length
+		toAppend := min(available, len(content))
+		b.writeAt((b.start+b.length)%capacity, content[:toAppend])
+		b.length += toAppend
+		content = content[toAppend:]
+	}
+	if content == "" {
+		return
+	}
+
+	b.writeAt(b.start, content)
+	b.start = (b.start + len(content)) % capacity
+}
+
+func (b *tailBuffer) writeAt(offset int, content string) {
+	written := copy(b.buf[offset:], content)
+	copy(b.buf, content[written:])
+}
+
+func (b *tailBuffer) Len() int {
+	return b.length
+}
+
+func (b *tailBuffer) String() string {
+	if b.length == 0 {
+		return ""
+	}
+	if b.start+b.length <= len(b.buf) {
+		return string(b.buf[b.start : b.start+b.length])
+	}
+
+	content := make([]byte, b.length)
+	written := copy(content, b.buf[b.start:])
+	copy(content[written:], b.buf[:b.length-written])
+	return string(content)
+}
+
+func (b *tailBuffer) Reset() {
+	b.start = 0
+	b.length = 0
+}

--- a/internal/text/tail_buffer_test.go
+++ b/internal/text/tail_buffer_test.go
@@ -1,0 +1,30 @@
+package text
+
+import "testing"
+
+func TestTailBufferKeepsNewestBytes(t *testing.T) {
+	buf := tailBuffer{capacity: 4}
+	buf.WriteString("abcd")
+	buf.WriteString("ef")
+
+	if got := buf.String(); got != "cdef" {
+		t.Fatalf("String() = %q, want cdef", got)
+	}
+	if buf.Len() != 4 {
+		t.Fatalf("Len() = %d, want 4", buf.Len())
+	}
+
+	buf.WriteString("12345")
+	if got := buf.String(); got != "2345" {
+		t.Fatalf("String() after oversized write = %q, want 2345", got)
+	}
+
+	buf.Reset()
+	if buf.Len() != 0 || buf.String() != "" {
+		t.Fatalf("buffer after Reset() = %q (length %d), want empty", buf.String(), buf.Len())
+	}
+	buf.WriteString("xy")
+	if got := buf.String(); got != "xy" {
+		t.Fatalf("String() after Reset() and write = %q, want xy", got)
+	}
+}

--- a/internal/tools/handler.go
+++ b/internal/tools/handler.go
@@ -35,6 +35,7 @@ func registerLocalTools() {
 	Registry.Set(tools.FileType.Specification().Name, tools.FileType)
 	Registry.Set(tools.LS.Specification().Name, tools.LS)
 	Registry.Set(tools.Mkdir.Specification().Name, tools.Mkdir)
+	Registry.Set(tools.Mktemp.Specification().Name, tools.Mktemp)
 	Registry.Set(tools.WebsiteText.Specification().Name, tools.WebsiteText)
 	Registry.Set(tools.RipGrep.Specification().Name, tools.RipGrep)
 	Registry.Set(tools.Go.Specification().Name, tools.Go)

--- a/internal/tools/mcp/manager_test.go
+++ b/internal/tools/mcp/manager_test.go
@@ -136,8 +136,7 @@ func TestManager(t *testing.T) {
 // TestManager_SkipsFailingServer pins the non-fatal error contract: a server
 // whose handshake fails is skipped while a healthy server still registers.
 func TestManager_SkipsFailingServer(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	goodSrv := pub_models.McpServer{Command: "go", Args: []string{"run", "./testserver"}}
 	goodIn, goodOut, err := Client(ctx, goodSrv, nil)

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -93,7 +93,7 @@ func TestInitRegistersApplyPatch(t *testing.T) {
 	if _, ok := Registry.Get("apply_patch"); !ok {
 		t.Fatalf("expected apply_patch to be registered")
 	}
-	for _, name := range []string{"cmd", "freetext_command", "async_cmd", "async_cmd_run", "async_cmd_status", "async_cmd_logs", "async_cmd_await", "async_cmd_cancel"} {
+	for _, name := range []string{"cmd", "freetext_command", "async_cmd", "async_cmd_run", "async_cmd_status", "async_cmd_logs", "async_cmd_await", "async_cmd_cancel", "mktemp"} {
 		if _, ok := Registry.Get(name); !ok {
 			t.Fatalf("expected %s to be registered", name)
 		}

--- a/main.go
+++ b/main.go
@@ -97,6 +97,7 @@ func triggerCompletionNotification(completed any) {
 
 func run(args []string) int {
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	// Build in cancel into the context to allow it to be called downstream
 	// Anti-pattern? Not sure, honestly, needed here to cleanly stop
 	// clai in case of nested tool calls. Could've been solved by proper structure

--- a/pkg/text/models/tools.go
+++ b/pkg/text/models/tools.go
@@ -38,6 +38,7 @@ const (
 	FindTool               ToolName = "find"
 	FileTypeTool           ToolName = "file_type"
 	LSTool                 ToolName = "ls"
+	MktempTool             ToolName = "mktemp"
 	WebsiteTextTool        ToolName = "website_text"
 	RipGrepTool            ToolName = "rg"
 	GoTool                 ToolName = "go"

--- a/pkg/tools/bash_tool_mktemp.go
+++ b/pkg/tools/bash_tool_mktemp.go
@@ -1,0 +1,53 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	pub_models "github.com/baalimago/clai/pkg/text/models"
+)
+
+type MktempTool pub_models.Specification
+
+var Mktemp = MktempTool{
+	Name:        "mktemp",
+	Description: "Create a temporary directory that is removed when this clai run ends.",
+	Inputs: &pub_models.InputSchema{
+		Type:       "object",
+		Required:   []string{},
+		Properties: map[string]pub_models.ParameterObject{},
+	},
+}
+
+func (m MktempTool) Call(pub_models.Input) (string, error) {
+	return "", fmt.Errorf("mktemp requires a context-aware invocation")
+}
+
+// CallWithContext creates a temporary directory which is removed once ctx is
+// canceled. The tool owns its own cleanup, so CLI runs and pkg agents behave
+// identically as long as the caller cancels the context it queries with.
+func (m MktempTool) CallWithContext(ctx context.Context, _ pub_models.Input) (string, error) {
+	if ctx == nil {
+		return "", fmt.Errorf("mktemp requires a context")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if ctx.Done() == nil {
+		return "", fmt.Errorf("mktemp requires a cancellable context")
+	}
+
+	directory, err := os.MkdirTemp("", "clai-*")
+	if err != nil {
+		return "", fmt.Errorf("create temporary directory: %w", err)
+	}
+	context.AfterFunc(ctx, func() {
+		_ = os.RemoveAll(directory)
+	})
+	return directory, nil
+}
+
+func (m MktempTool) Specification() pub_models.Specification {
+	return pub_models.Specification(Mktemp)
+}

--- a/pkg/tools/bash_tool_mktemp_test.go
+++ b/pkg/tools/bash_tool_mktemp_test.go
@@ -1,0 +1,72 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	pub_models "github.com/baalimago/clai/pkg/text/models"
+)
+
+func TestMktempTool_CallWithContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	directory, err := Mktemp.CallWithContext(ctx, pub_models.Input{})
+	if err != nil {
+		t.Fatalf("Mktemp.CallWithContext(): %v", err)
+	}
+	if !strings.HasPrefix(directory, os.TempDir()+string(os.PathSeparator)) {
+		t.Fatalf("temporary directory %q is outside %q", directory, os.TempDir())
+	}
+	info, err := os.Stat(directory)
+	if err != nil {
+		t.Fatalf("stat temporary directory: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected %q to be a directory", directory)
+	}
+
+	cancel()
+	for range 100 {
+		_, err = os.Stat(directory)
+		if errors.Is(err, os.ErrNotExist) {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("temporary directory still exists after context cancellation: %v", err)
+}
+
+func TestMktempTool_RequiresCancellableContext(t *testing.T) {
+	if _, err := Mktemp.CallWithContext(context.Background(), pub_models.Input{}); err == nil {
+		t.Fatal("expected cancellable-context requirement error")
+	}
+}
+
+func TestMktempTool_RejectsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	if _, err := Mktemp.CallWithContext(ctx, pub_models.Input{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+}
+
+func TestMktempTool_CallRequiresContext(t *testing.T) {
+	if _, err := Mktemp.Call(pub_models.Input{}); err == nil {
+		t.Fatal("expected context requirement error")
+	}
+}
+
+func TestMktempTool_Specification(t *testing.T) {
+	spec := Mktemp.Specification()
+	if spec.Name != "mktemp" {
+		t.Fatalf("spec name = %q, want mktemp", spec.Name)
+	}
+	if spec.Inputs == nil || len(spec.Inputs.Required) != 0 || len(spec.Inputs.Properties) != 0 {
+		t.Fatalf("expected an empty input schema, got %+v", spec.Inputs)
+	}
+}


### PR DESCRIPTION
The `mktemp` tool creates a temporary directory under `/tmp` which will be deleted on context cancel.

Intent is to use this as a scratchpad for the agent, mostly for [slivingdoc](https://github.com/baalimago/slivingdoc) notes.