### PR TITLE
feat: Add `clai audio transcribe` for audio transcriptions

### DIFF
--- a/architecture/README.md
+++ b/architecture/README.md
@@ -21,6 +21,7 @@ This directory contains short design notes for key parts of **clai**. Each file 
 - **[dre.md](./dre.md)** — `clai dre`: prints the last message from the directory-bound conversation for the current working directory.
 - **[photo.md](./photo.md)** — `clai photo`: image generation flow, prompt formatting, vendor routing, and output modes (local/url).
 - **[video.md](./video.md)** — `clai video`: video generation (OpenAI Sora), optional image-to-video prompt parsing, and output modes.
+- **[audio.md](./audio.md)** — `clai audio transcribe`: audio transcription (OpenAI/OpenRouter), local vtt/srt/text/json rendering, ffmpeg split for large files, and the `audio_transcribe` tool bridge.
 - **[tools.md](./tools.md)** — `clai tools` inspection UI: list tools and print JSON schema for one tool.
 - **[profiles.md](./profiles.md)** — `clai profiles`: lists profile JSONs and prints a small summary; profiles are applied via `-p` flags (see CONFIG).
 - **[setup.md](./setup.md)** — `clai setup` interactive wizard for editing mode configs, vendor model files, profiles, and MCP server configs.

--- a/architecture/audio.md
+++ b/architecture/audio.md
@@ -1,0 +1,126 @@
+# Audio Command Architecture
+
+Command: `clai [flags] audio transcribe <file>` (aliases: `a t`)
+
+The **audio** command namespace transcribes audio files using AI models
+(currently the OpenAI multipart transcription protocol, served by OpenAI and
+OpenRouter). The rendered transcript is the only thing written to stdout, so
+it pipes cleanly; all status/progress lines go to stderr. Use `-` as the file
+to read audio bytes from stdin.
+
+## Entry Flow
+
+```
+main.go:run()
+  → internal.Setup(ctx, usage, args)
+    → parseFlags()                     # extract CLI flags
+    → getCmdFromArgs()                 # returns AUDIO mode
+    → handleAudio()                    # verb dispatch (transcribe|help)
+      → resolveAudioInput()           # positional file, or '-' → stdin temp file
+                                      # (container sniffed → real extension, see sniff.go)
+      → LoadConfigFromFile("audioConfig.json")
+      → applyFlagOverridesForAudio()
+      → CreateAudioQuerier()          # vendor routing + splitter
+  → querier.Query(ctx)                # transcribe → render → stdout
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `internal/setup.go` | `Setup()` AUDIO case — dispatches to `handleAudio` |
+| `internal/setup_audio.go` | Verb dispatch, namespace help, stdin `-` input resolution |
+| `internal/audio/audio.go` | `Segment` model, `verbose_json`/`diarized_json` parsing, `vtt|srt|text|json` rendering, `Offset` |
+| `internal/audio/split.go` | `Splitter`: 25 MB size gate, ffmpeg chunking, bounded-parallel transcription, offset stitching |
+| `internal/audio/sniff.go` | `DetectExtension`: container magic → file extension (vendors and ffmpeg infer format from filenames) |
+| `internal/audio/querier.go` | `Configurations` (`audioConfig.json` schema), `TranscribeQuerier`, mock transcriber |
+| `internal/audio/generic/transcriber.go` | Generic OpenAI-protocol multipart transcription client |
+| `internal/vendors/openai/transcribe.go` | OpenAI vendor struct (`OPENAI_API_KEY`, api.openai.com) |
+| `internal/vendors/openrouter/transcribe.go` | OpenRouter vendor struct (`OPENROUTER_API_KEY`, `or:` prefix trim, extra headers) |
+| `internal/create_queriers.go` | `CreateAudioQuerier()`/`createAudioSplitter()` — model → vendor routing |
+| `pkg/tools/audio_tool_transcribe.go` | `audio_transcribe` built-in tool (thin adapter, injected engine) |
+
+## Configuration
+
+### `audioConfig.json`
+
+```json
+{
+  "transcribe": {
+    "model": "whisper-1",
+    "output-format": "vtt",
+    "parallelism": 3
+  }
+}
+```
+
+### Key Fields
+
+| Field | Description |
+|-------|-------------|
+| `transcribe.model` | Transcription model; routed to a vendor by name (see Vendor Routing) |
+| `transcribe.output-format` | Local render format: `vtt` (default), `srt`, `text`, or `json` |
+| `transcribe.parallelism` | Max concurrent chunk requests when a large file is split (default 3) |
+
+### Flag Overrides
+
+| Flag | Config Field |
+|------|-------------|
+| `-am` / `-audio-model` | `transcribe.model` |
+| `-af` / `-audio-format` | `transcribe.output-format` |
+| `-parallelism` | `transcribe.parallelism` |
+
+Precedence is the standard cascade: flags > file > defaults (see
+[`config.md`](./config.md)).
+
+## Vendor Routing
+
+`CreateAudioQuerier()` in `internal/create_queriers.go` routes explicitly:
+
+| Model Pattern | Vendor |
+|---------------|--------|
+| `or:` prefix | OpenRouter (`or:` trimmed from the wire model) |
+| contains `whisper` or `transcribe` | OpenAI |
+| `test`/`mock_test` prefix | Mock transcriber (deterministic, network-free; contains `diarize` → speaker labels) |
+
+## Response-Format Negotiation
+
+The vendor request always asks for the richest machine format the endpoint
+supports: `diarized_json` when the model name contains `diarize`, else
+`verbose_json`. `text`/`srt`/`vtt` are never requested from a vendor
+(OpenRouter rejects them); those are local renderings from the shared
+`Segment` model. Speaker labels render as WebVTT voice tags (`<v A>`), SRT/text
+`A: ` prefixes, and a `speaker` field in `json` output (float-second
+timestamps).
+
+## Large Files: Split and Stitch
+
+Files over 25 MB exceed the vendor request cap. The `Splitter`
+(`internal/audio/split.go`):
+
+1. Requires `ffmpeg` **and** `ffprobe` on PATH (only for oversized files);
+   missing binaries produce an actionable error with a manual split command.
+2. Probes total duration, splits into fixed-duration chunks targeting ~20 MB
+   each (`-f segment -c copy`, temp dir, removed afterwards).
+3. Transcribes chunks in a bounded worker pool (`parallelism`), offsets each
+   chunk's timestamps by its planned start, and stitches in order.
+4. Warns on stderr when measured chunk durations drift > 1 s from the plan,
+   and when a diarize model meets a split file (speaker labels are
+   per-request and may drift across chunks).
+
+## Tool Bridge
+
+`audio_transcribe` (built-in tool) is a thin adapter over the same engine:
+`pkg/tools` declares the schema (`file_path` required; `output_format` enum
+defaulting to `text` — model context rarely wants VTT framing) and delegates
+to an engine function injected by the clai runtime. The tool layer contains no
+transcription logic. Select it with `-t audio_transcribe` or `-t "*"`; inspect
+it with `clai tools audio_transcribe`.
+
+## Example
+
+```bash
+clai a t meeting.wav | clai -p meetingnotes q "File these meeting notes: {}"
+# or agentically:
+clai -t "*" q "Transcribe meeting.wav and file the meeting notes"
+```

--- a/examples.md
+++ b/examples.md
@@ -144,6 +144,22 @@ clai video "A slow pan across a terminal showing streaming output"
 
 See: [`photo.md`](./architecture/photo.md), [`video.md`](./architecture/video.md), [`config.md`](./architecture/config.md).
 
+## Audio transcription
+
+```bash
+clai audio transcribe meeting.wav
+clai -af text a t meeting.wav
+cat meeting.wav | clai a t -
+
+clai a t meeting.wav | clai q "Summarize these meeting notes: {}"
+```
+
+- Transcripts render locally as `vtt` (default), `srt`, `text`, or `json`; stdout carries only the transcript, so it pipes cleanly.
+- Files over 25 MB are split via ffmpeg and stitched back with adjusted timestamps.
+- The `audio_transcribe` built-in tool exposes the same engine to agents: `clai -t "*" q "Transcribe meeting.wav and summarize it"`.
+
+See: [`audio.md`](./architecture/audio.md).
+
 ## Streaming: one normalized event loop
 
 - All vendors map their streaming responses to a small set of normalized events:

--- a/internal/audio/audio.go
+++ b/internal/audio/audio.go
@@ -1,0 +1,200 @@
+// Package audio holds the vendor-agnostic transcription segment model,
+// wire-payload normalization, local output rendering, and the ffmpeg-backed
+// split/stitch orchestration for oversized files. No HTTP: vendor clients
+// live in audio/generic and internal/vendors.
+package audio
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+)
+
+// Segment is the shared transcript unit all vendor payloads normalize into
+// and all output formats render from.
+type Segment struct {
+	Start   time.Duration
+	End     time.Duration
+	Speaker string // "" when model does not diarize
+	Text    string
+}
+
+type OutputFormat string
+
+const (
+	FormatVTT  OutputFormat = "vtt"
+	FormatSRT  OutputFormat = "srt"
+	FormatText OutputFormat = "text"
+	FormatJSON OutputFormat = "json"
+)
+
+// ParseOutputFormat validates a flag/config value into an OutputFormat.
+func ParseOutputFormat(s string) (OutputFormat, error) {
+	switch OutputFormat(s) {
+	case FormatVTT, FormatSRT, FormatText, FormatJSON:
+		return OutputFormat(s), nil
+	default:
+		return "", fmt.Errorf("unknown output format: %q, valid formats are: vtt, srt, text, json", s)
+	}
+}
+
+type wireSegment struct {
+	Start   float64 `json:"start"`
+	End     float64 `json:"end"`
+	Speaker string  `json:"speaker"`
+	Text    string  `json:"text"`
+}
+
+type wirePayload struct {
+	// Pointer distinguishes a missing segments field from an empty array
+	Segments *[]wireSegment `json:"segments"`
+}
+
+func parsePayload(data []byte, formatName string) ([]Segment, error) {
+	var payload wirePayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse %v payload: %w", formatName, err)
+	}
+	if payload.Segments == nil {
+		return nil, fmt.Errorf("%v payload has no segments field", formatName)
+	}
+	segs := make([]Segment, 0, len(*payload.Segments))
+	for _, ws := range *payload.Segments {
+		segs = append(segs, Segment{
+			Start:   secondsToDuration(ws.Start),
+			End:     secondsToDuration(ws.End),
+			Speaker: ws.Speaker,
+			Text:    strings.TrimSpace(ws.Text),
+		})
+	}
+	return segs, nil
+}
+
+// ParseVerboseJSON normalizes an OpenAI/OpenRouter verbose_json payload.
+func ParseVerboseJSON(data []byte) ([]Segment, error) {
+	return parsePayload(data, "verbose_json")
+}
+
+// ParseDiarizedJSON normalizes a gpt-4o-transcribe-diarize diarized_json payload.
+func ParseDiarizedJSON(data []byte) ([]Segment, error) {
+	return parsePayload(data, "diarized_json")
+}
+
+// secondsToDuration rounds to millisecond precision, matching subtitle
+// timestamp resolution and keeping float-seconds render output clean.
+func secondsToDuration(s float64) time.Duration {
+	return time.Duration(math.Round(s*1000)) * time.Millisecond
+}
+
+// Offset returns a copy of segs with all timestamps shifted by delta.
+func Offset(segs []Segment, delta time.Duration) []Segment {
+	shifted := make([]Segment, len(segs))
+	for i, s := range segs {
+		s.Start += delta
+		s.End += delta
+		shifted[i] = s
+	}
+	return shifted
+}
+
+// Render formats segments into the given output format.
+func Render(segs []Segment, format OutputFormat) (string, error) {
+	switch format {
+	case FormatVTT:
+		return renderVTT(segs), nil
+	case FormatSRT:
+		return renderSRT(segs), nil
+	case FormatText:
+		return renderText(segs), nil
+	case FormatJSON:
+		return renderJSON(segs)
+	default:
+		return "", fmt.Errorf("unknown output format: %q", format)
+	}
+}
+
+func renderVTT(segs []Segment) string {
+	var sb strings.Builder
+	sb.WriteString("WEBVTT\n")
+	for _, s := range segs {
+		text := s.Text
+		if s.Speaker != "" {
+			text = fmt.Sprintf("<v %v>%v</v>", s.Speaker, s.Text)
+		}
+		fmt.Fprintf(&sb, "\n%v --> %v\n%v\n", formatTimestamp(s.Start, "."), formatTimestamp(s.End, "."), text)
+	}
+	return sb.String()
+}
+
+func renderSRT(segs []Segment) string {
+	var sb strings.Builder
+	for i, s := range segs {
+		if i > 0 {
+			sb.WriteString("\n")
+		}
+		fmt.Fprintf(&sb, "%v\n%v --> %v\n%v\n", i+1, formatTimestamp(s.Start, ","), formatTimestamp(s.End, ","), speakerPrefixed(s))
+	}
+	return sb.String()
+}
+
+func renderText(segs []Segment) string {
+	var sb strings.Builder
+	for _, s := range segs {
+		sb.WriteString(speakerPrefixed(s))
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func speakerPrefixed(s Segment) string {
+	if s.Speaker == "" {
+		return s.Text
+	}
+	return fmt.Sprintf("%v: %v", s.Speaker, s.Text)
+}
+
+// renderSegment is the render-time DTO for the json output format. Segment is
+// never marshaled directly: time.Duration would emit nanosecond ints, while
+// the wire contract is float seconds.
+type renderSegment struct {
+	Start   float64 `json:"start"`
+	End     float64 `json:"end"`
+	Speaker string  `json:"speaker,omitempty"`
+	Text    string  `json:"text"`
+}
+
+func renderJSON(segs []Segment) (string, error) {
+	dtos := make([]renderSegment, 0, len(segs))
+	for _, s := range segs {
+		dtos = append(dtos, renderSegment{
+			Start:   s.Start.Seconds(),
+			End:     s.End.Seconds(),
+			Speaker: s.Speaker,
+			Text:    s.Text,
+		})
+	}
+	b, err := json.Marshal(dtos)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal segments to json: %w", err)
+	}
+	return string(b), nil
+}
+
+func formatTimestamp(d time.Duration, millisSeparator string) string {
+	sign := ""
+	if d < 0 {
+		sign = "-"
+		d = -d
+	}
+	ms := d.Milliseconds()
+	return fmt.Sprintf("%v%02d:%02d:%02d%v%03d",
+		sign,
+		ms/3600000,
+		ms/60000%60,
+		ms/1000%60,
+		millisSeparator,
+		ms%1000,
+	)
+}

--- a/internal/audio/audio_test.go
+++ b/internal/audio/audio_test.go
@@ -1,0 +1,358 @@
+package audio
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("failed to read fixture %v: %v", name, err)
+	}
+	return b
+}
+
+func TestParseVerboseJSON_Whisper1Fixture(t *testing.T) {
+	got, err := ParseVerboseJSON(loadFixture(t, "openai_whisper1_verbose.json"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []Segment{
+		{Start: 0, End: 5280 * time.Millisecond, Text: "Hello and welcome to the meeting."},
+		{Start: 5280 * time.Millisecond, End: 9040 * time.Millisecond, Text: "Let's get started with the agenda."},
+	}
+	assertSegments(t, want, got)
+}
+
+func TestParseVerboseJSON_OpenRouterFixture(t *testing.T) {
+	got, err := ParseVerboseJSON(loadFixture(t, "openrouter_verbose.json"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []Segment{
+		{Start: 0, End: 3840 * time.Millisecond, Text: "Testing OpenRouter transcription."},
+	}
+	assertSegments(t, want, got)
+}
+
+func TestParseDiarizedJSON_PreservesSpeakers(t *testing.T) {
+	got, err := ParseDiarizedJSON(loadFixture(t, "openai_diarized.json"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []Segment{
+		{Start: 0, End: 4900 * time.Millisecond, Speaker: "A", Text: "Hi Bob, how are you?"},
+		{Start: 5100 * time.Millisecond, End: 12500 * time.Millisecond, Speaker: "B", Text: "I'm doing great, thanks Alice."},
+	}
+	assertSegments(t, want, got)
+}
+
+func assertSegments(t *testing.T, want, got []Segment) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("expected %v segments, got %v: %+v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("segment %v: expected %+v, got %+v", i, want[i], got[i])
+		}
+	}
+}
+
+func TestParse_MalformedJSON(t *testing.T) {
+	testCases := []struct {
+		name      string
+		parse     func([]byte) ([]Segment, error)
+		wantInErr string
+	}{
+		{"verbose", ParseVerboseJSON, "verbose_json"},
+		{"diarized", ParseDiarizedJSON, "diarized_json"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.parse([]byte("{not json"))
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantInErr) {
+				t.Errorf("expected error naming %q, got: %v", tc.wantInErr, err)
+			}
+		})
+	}
+}
+
+func TestParse_MissingSegmentsField(t *testing.T) {
+	testCases := []struct {
+		name  string
+		parse func([]byte) ([]Segment, error)
+	}{
+		{"verbose", ParseVerboseJSON},
+		{"diarized", ParseDiarizedJSON},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.parse([]byte(`{"text": "hello", "duration": 1.0}`))
+			if err == nil {
+				t.Fatal("expected error for missing segments field, got nil")
+			}
+			if !strings.Contains(err.Error(), "segments") {
+				t.Errorf("expected error naming missing segments field, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestParse_EmptySegmentsArray(t *testing.T) {
+	testCases := []struct {
+		name  string
+		parse func([]byte) ([]Segment, error)
+	}{
+		{"verbose", ParseVerboseJSON},
+		{"diarized", ParseDiarizedJSON},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.parse([]byte(`{"segments": []}`))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil {
+				t.Fatal("expected non-nil empty slice")
+			}
+			if len(got) != 0 {
+				t.Fatalf("expected empty slice, got: %+v", got)
+			}
+		})
+	}
+}
+
+func TestOffset(t *testing.T) {
+	segs := []Segment{
+		{Start: 0, End: time.Second, Speaker: "A", Text: "one"},
+		{Start: time.Second, End: 2 * time.Second, Text: "two"},
+	}
+	t.Run("shifts start and end uniformly", func(t *testing.T) {
+		got := Offset(segs, 10*time.Second)
+		want := []Segment{
+			{Start: 10 * time.Second, End: 11 * time.Second, Speaker: "A", Text: "one"},
+			{Start: 11 * time.Second, End: 12 * time.Second, Text: "two"},
+		}
+		assertSegments(t, want, got)
+	})
+	t.Run("no-op at delta 0", func(t *testing.T) {
+		got := Offset(segs, 0)
+		assertSegments(t, segs, got)
+	})
+	t.Run("does not mutate input", func(t *testing.T) {
+		Offset(segs, time.Hour)
+		if segs[0].Start != 0 {
+			t.Errorf("input mutated: %+v", segs[0])
+		}
+	})
+}
+
+var diarizedSegs = []Segment{
+	{Start: 0, End: 5280 * time.Millisecond, Speaker: "A", Text: "Hello and welcome to the meeting."},
+	{Start: 5280 * time.Millisecond, End: 9040 * time.Millisecond, Speaker: "B", Text: "Let's get started with the agenda."},
+}
+
+var plainSegs = []Segment{
+	{Start: 0, End: 5280 * time.Millisecond, Text: "Hello and welcome to the meeting."},
+	{Start: 5280 * time.Millisecond, End: 9040 * time.Millisecond, Text: "Let's get started with the agenda."},
+}
+
+func TestRender(t *testing.T) {
+	testCases := []struct {
+		name   string
+		segs   []Segment
+		format OutputFormat
+		want   string
+	}{
+		{
+			name:   "vtt with speakers",
+			segs:   diarizedSegs,
+			format: FormatVTT,
+			want: `WEBVTT
+
+00:00:00.000 --> 00:00:05.280
+<v A>Hello and welcome to the meeting.</v>
+
+00:00:05.280 --> 00:00:09.040
+<v B>Let's get started with the agenda.</v>
+`,
+		},
+		{
+			name:   "vtt without speakers",
+			segs:   plainSegs,
+			format: FormatVTT,
+			want: `WEBVTT
+
+00:00:00.000 --> 00:00:05.280
+Hello and welcome to the meeting.
+
+00:00:05.280 --> 00:00:09.040
+Let's get started with the agenda.
+`,
+		},
+		{
+			name:   "srt with speakers",
+			segs:   diarizedSegs,
+			format: FormatSRT,
+			want: `1
+00:00:00,000 --> 00:00:05,280
+A: Hello and welcome to the meeting.
+
+2
+00:00:05,280 --> 00:00:09,040
+B: Let's get started with the agenda.
+`,
+		},
+		{
+			name:   "srt without speakers",
+			segs:   plainSegs,
+			format: FormatSRT,
+			want: `1
+00:00:00,000 --> 00:00:05,280
+Hello and welcome to the meeting.
+
+2
+00:00:05,280 --> 00:00:09,040
+Let's get started with the agenda.
+`,
+		},
+		{
+			name:   "text with speakers",
+			segs:   diarizedSegs,
+			format: FormatText,
+			want:   "A: Hello and welcome to the meeting.\nB: Let's get started with the agenda.\n",
+		},
+		{
+			name:   "text without speakers",
+			segs:   plainSegs,
+			format: FormatText,
+			want:   "Hello and welcome to the meeting.\nLet's get started with the agenda.\n",
+		},
+		{
+			name:   "json with speakers",
+			segs:   diarizedSegs,
+			format: FormatJSON,
+			want:   `[{"start":0,"end":5.28,"speaker":"A","text":"Hello and welcome to the meeting."},{"start":5.28,"end":9.04,"speaker":"B","text":"Let's get started with the agenda."}]`,
+		},
+		{
+			name:   "json without speakers",
+			segs:   plainSegs,
+			format: FormatJSON,
+			want:   `[{"start":0,"end":5.28,"text":"Hello and welcome to the meeting."},{"start":5.28,"end":9.04,"text":"Let's get started with the agenda."}]`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Render(tc.segs, tc.format)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("expected:\n%q\ngot:\n%q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestRenderJSON_FloatSecondsContract(t *testing.T) {
+	got, err := Render(plainSegs, FormatJSON)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got, `"end":5.28`) {
+		t.Errorf("expected float seconds 5.28 in output, got: %v", got)
+	}
+	if strings.Contains(got, "speaker") {
+		t.Errorf("expected speaker to be omitted, got: %v", got)
+	}
+	if strings.Contains(got, "5280000000") {
+		t.Errorf("nanosecond integer leaked into output: %v", got)
+	}
+}
+
+func TestRenderEmpty(t *testing.T) {
+	testCases := []struct {
+		format OutputFormat
+		want   string
+	}{
+		{FormatVTT, "WEBVTT\n"},
+		{FormatSRT, ""},
+		{FormatText, ""},
+		{FormatJSON, "[]"},
+	}
+	for _, tc := range testCases {
+		t.Run(string(tc.format), func(t *testing.T) {
+			got, err := Render([]Segment{}, tc.format)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestRenderGarbageTimestampsDoesNotPanic(t *testing.T) {
+	garbage := []Segment{
+		{Start: -3 * time.Second, End: -time.Second, Text: "negative"},
+		{Start: 10 * time.Second, End: 2 * time.Second, Text: "end before start"},
+	}
+	for _, format := range []OutputFormat{FormatVTT, FormatSRT, FormatText, FormatJSON} {
+		t.Run(string(format), func(t *testing.T) {
+			if _, err := Render(garbage, format); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRenderUnknownFormat(t *testing.T) {
+	_, err := Render(plainSegs, OutputFormat("yaml"))
+	if err == nil {
+		t.Fatal("expected error for unknown format, got nil")
+	}
+}
+
+func TestParseOutputFormat(t *testing.T) {
+	t.Run("valid values", func(t *testing.T) {
+		testCases := []struct {
+			in   string
+			want OutputFormat
+		}{
+			{"vtt", FormatVTT},
+			{"srt", FormatSRT},
+			{"text", FormatText},
+			{"json", FormatJSON},
+		}
+		for _, tc := range testCases {
+			got, err := ParseOutputFormat(tc.in)
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("expected %v, got %v", tc.want, got)
+			}
+		}
+	})
+	t.Run("unknown value lists valid formats", func(t *testing.T) {
+		_, err := ParseOutputFormat("yaml")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		for _, valid := range []string{"vtt", "srt", "text", "json"} {
+			if !strings.Contains(err.Error(), valid) {
+				t.Errorf("expected error to list %q, got: %v", valid, err)
+			}
+		}
+	})
+}

--- a/internal/audio/generic/transcriber.go
+++ b/internal/audio/generic/transcriber.go
@@ -1,0 +1,152 @@
+// Package generic implements the OpenAI-protocol multipart transcription
+// client shared by all compatible vendors. Vendor-specific behavior (env keys,
+// URLs, model prefixes, headers) lives in the vendor packages.
+package generic
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/baalimago/clai/internal/audio"
+	"github.com/baalimago/clai/internal/debugflags"
+)
+
+const (
+	formatVerboseJSON  = "verbose_json"
+	formatDiarizedJSON = "diarized_json"
+)
+
+type Transcriber struct {
+	Model        string
+	URL          string
+	ExtraHeaders map[string]string
+	Client       *http.Client
+	apiKey       string
+	debug        bool
+}
+
+func (t *Transcriber) Setup(apiKeyEnv, url, debugEnv string) error {
+	apiKey := os.Getenv(apiKeyEnv)
+	if apiKey == "" {
+		return fmt.Errorf("environment variable '%v' not set", apiKeyEnv)
+	}
+	if t.Client == nil {
+		t.Client = &http.Client{}
+	}
+	t.apiKey = apiKey
+	t.URL = url
+	if debugflags.EnabledEnv(debugEnv) {
+		t.debug = true
+	}
+	return nil
+}
+
+// responseFormat implements the negotiation rule: always the richest machine
+// format the endpoint supports, never text/srt/vtt (rendered locally).
+func (t *Transcriber) responseFormat() string {
+	if strings.Contains(t.Model, "diarize") {
+		return formatDiarizedJSON
+	}
+	return formatVerboseJSON
+}
+
+func (t *Transcriber) Transcribe(ctx context.Context, filePath string) ([]audio.Segment, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open audio file: %w", err)
+	}
+	defer file.Close()
+	respFormat := t.responseFormat()
+	body, err := t.post(ctx, file, respFormat)
+	if err != nil {
+		return nil, err
+	}
+	if respFormat == formatDiarizedJSON {
+		return audio.ParseDiarizedJSON(body)
+	}
+	return audio.ParseVerboseJSON(body)
+}
+
+func (t *Transcriber) post(ctx context.Context, file *os.File, respFormat string) ([]byte, error) {
+	// Pipe streams the file part to the request without buffering it in memory
+	pipeReader, pipeWriter := io.Pipe()
+	multipartWriter := multipart.NewWriter(pipeWriter)
+	go func() {
+		err := writeMultipart(multipartWriter, file, t.Model, respFormat)
+		if closeErr := multipartWriter.Close(); err == nil {
+			err = closeErr
+		}
+		pipeWriter.CloseWithError(err)
+	}()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.URL, pipeReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transcription request: %w", err)
+	}
+	req.Header.Set("Content-Type", multipartWriter.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer "+t.apiKey)
+	for key, value := range t.ExtraHeaders {
+		req.Header.Set(key, value)
+	}
+	if t.debug {
+		slog.Debug("transcription request", "url", t.URL, "model", t.Model, "response_format", respFormat)
+	}
+	resp, err := t.Client.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("transcription request aborted: %w", ctx.Err())
+		}
+		return nil, fmt.Errorf("failed to post transcription request: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("transcription response read aborted: %w", ctx.Err())
+		}
+		return nil, fmt.Errorf("failed to read transcription response: %w", err)
+	}
+	if t.debug {
+		slog.Debug("transcription response", "status", resp.Status, "body", string(body))
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("transcription request failed with status: %v, body: %v", resp.Status, truncate(body, 1024))
+	}
+	return body, nil
+}
+
+func writeMultipart(w *multipart.Writer, file *os.File, model, respFormat string) error {
+	part, err := w.CreateFormFile("file", filepath.Base(file.Name()))
+	if err != nil {
+		return fmt.Errorf("failed to create file part: %w", err)
+	}
+	if _, err := io.Copy(part, file); err != nil {
+		return fmt.Errorf("failed to stream audio file: %w", err)
+	}
+	if err := w.WriteField("model", model); err != nil {
+		return fmt.Errorf("failed to write model field: %w", err)
+	}
+	if err := w.WriteField("response_format", respFormat); err != nil {
+		return fmt.Errorf("failed to write response_format field: %w", err)
+	}
+	// OpenAI requires chunking_strategy for diarization models (400 without it)
+	if respFormat == formatDiarizedJSON {
+		if err := w.WriteField("chunking_strategy", "auto"); err != nil {
+			return fmt.Errorf("failed to write chunking_strategy field: %w", err)
+		}
+	}
+	return nil
+}
+
+func truncate(b []byte, limit int) string {
+	if len(b) <= limit {
+		return string(b)
+	}
+	return string(b[:limit]) + "…"
+}

--- a/internal/audio/generic/transcriber_test.go
+++ b/internal/audio/generic/transcriber_test.go
@@ -1,0 +1,282 @@
+package generic
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/baalimago/clai/internal/audio"
+)
+
+func writeTestAudioFile(t *testing.T, content []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.wav")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("failed to write test audio file: %v", err)
+	}
+	return path
+}
+
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("..", "testdata", name))
+	if err != nil {
+		t.Fatalf("failed to read fixture %v: %v", name, err)
+	}
+	return b
+}
+
+func setupTranscriber(t *testing.T, model, url string) *Transcriber {
+	t.Helper()
+	t.Setenv("TEST_AUDIO_API_KEY", "test-key")
+	trans := &Transcriber{Model: model}
+	if err := trans.Setup("TEST_AUDIO_API_KEY", url, "DEBUG_TEST_AUDIO"); err != nil {
+		t.Fatalf("failed to setup transcriber: %v", err)
+	}
+	return trans
+}
+
+func TestSetup_MissingAPIKey(t *testing.T) {
+	t.Setenv("TEST_AUDIO_API_KEY", "")
+	trans := &Transcriber{}
+	err := trans.Setup("TEST_AUDIO_API_KEY", "http://localhost", "DEBUG_TEST_AUDIO")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "TEST_AUDIO_API_KEY") {
+		t.Errorf("expected error naming the env var, got: %v", err)
+	}
+}
+
+type recordedRequest struct {
+	auth             string
+	model            string
+	responseFormat   string
+	chunkingStrategy string
+	fileBytes        []byte
+	contentLength    int64
+	headers          http.Header
+}
+
+func multipartRecorder(t *testing.T, rec *recordedRequest, respBody []byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.auth = r.Header.Get("Authorization")
+		rec.contentLength = r.ContentLength
+		rec.headers = r.Header.Clone()
+		if err := r.ParseMultipartForm(32 << 20); err != nil {
+			t.Errorf("failed to parse multipart form: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		rec.model = r.FormValue("model")
+		rec.responseFormat = r.FormValue("response_format")
+		rec.chunkingStrategy = r.FormValue("chunking_strategy")
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			t.Errorf("failed to get file part: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		defer file.Close()
+		rec.fileBytes, err = io.ReadAll(file)
+		if err != nil {
+			t.Errorf("failed to read file part: %v", err)
+		}
+		w.Write(respBody)
+	}))
+}
+
+func TestTranscribe_VerboseJSON(t *testing.T) {
+	var rec recordedRequest
+	server := multipartRecorder(t, &rec, loadFixture(t, "openai_whisper1_verbose.json"))
+	defer server.Close()
+	trans := setupTranscriber(t, "whisper-1", server.URL)
+	audioContent := []byte("RIFF-fake-wav-content")
+
+	got, err := trans.Transcribe(context.Background(), writeTestAudioFile(t, audioContent))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if rec.auth != "Bearer test-key" {
+		t.Errorf("expected bearer auth, got: %q", rec.auth)
+	}
+	if rec.model != "whisper-1" {
+		t.Errorf("expected model whisper-1, got: %q", rec.model)
+	}
+	if rec.responseFormat != "verbose_json" {
+		t.Errorf("expected response_format verbose_json, got: %q", rec.responseFormat)
+	}
+	if rec.chunkingStrategy != "" {
+		t.Errorf("expected no chunking_strategy for non-diarize models, got: %q", rec.chunkingStrategy)
+	}
+	if string(rec.fileBytes) != string(audioContent) {
+		t.Errorf("file content mismatch, got: %q", rec.fileBytes)
+	}
+	want := []audio.Segment{
+		{Start: 0, End: 5280 * time.Millisecond, Text: "Hello and welcome to the meeting."},
+		{Start: 5280 * time.Millisecond, End: 9040 * time.Millisecond, Text: "Let's get started with the agenda."},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v segments, got %v", len(want), len(got))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("segment %v: expected %+v, got %+v", i, want[i], got[i])
+		}
+	}
+}
+
+func TestTranscribe_DiarizedModel(t *testing.T) {
+	var rec recordedRequest
+	server := multipartRecorder(t, &rec, loadFixture(t, "openai_diarized.json"))
+	defer server.Close()
+	trans := setupTranscriber(t, "gpt-4o-transcribe-diarize", server.URL)
+
+	got, err := trans.Transcribe(context.Background(), writeTestAudioFile(t, []byte("x")))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if rec.responseFormat != "diarized_json" {
+		t.Errorf("expected response_format diarized_json, got: %q", rec.responseFormat)
+	}
+	// OpenAI 400s diarize requests without it: "chunking_strategy is required
+	// for diarization models"
+	if rec.chunkingStrategy != "auto" {
+		t.Errorf("expected chunking_strategy auto for diarize models, got: %q", rec.chunkingStrategy)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 segments, got %v", len(got))
+	}
+	if got[0].Speaker != "A" || got[1].Speaker != "B" {
+		t.Errorf("expected speakers A and B, got: %q, %q", got[0].Speaker, got[1].Speaker)
+	}
+}
+
+func TestTranscribe_ExtraHeaders(t *testing.T) {
+	var rec recordedRequest
+	server := multipartRecorder(t, &rec, loadFixture(t, "openrouter_verbose.json"))
+	defer server.Close()
+	trans := setupTranscriber(t, "whisper-1", server.URL)
+	trans.ExtraHeaders = map[string]string{"HTTP-Referer": "clai"}
+
+	if _, err := trans.Transcribe(context.Background(), writeTestAudioFile(t, []byte("x"))); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := rec.headers.Get("HTTP-Referer"); got != "clai" {
+		t.Errorf("expected extra header to be sent, got: %q", got)
+	}
+}
+
+func TestTranscribe_StreamsLargeFile(t *testing.T) {
+	var rec recordedRequest
+	server := multipartRecorder(t, &rec, loadFixture(t, "openai_whisper1_verbose.json"))
+	defer server.Close()
+	trans := setupTranscriber(t, "whisper-1", server.URL)
+	largeContent := make([]byte, 3<<20)
+	for i := range largeContent {
+		largeContent[i] = byte(i % 251)
+	}
+
+	if _, err := trans.Transcribe(context.Background(), writeTestAudioFile(t, largeContent)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Streamed pipe bodies have unknown length: chunked transfer, no Content-Length
+	if rec.contentLength > 0 {
+		t.Errorf("expected streamed (chunked) body without Content-Length, got: %v", rec.contentLength)
+	}
+	if len(rec.fileBytes) != len(largeContent) {
+		t.Fatalf("expected %v file bytes, got %v", len(largeContent), len(rec.fileBytes))
+	}
+}
+
+func TestTranscribe_FileMissing(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+	}))
+	defer server.Close()
+	trans := setupTranscriber(t, "whisper-1", server.URL)
+
+	_, err := trans.Transcribe(context.Background(), filepath.Join(t.TempDir(), "nonexistent.wav"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if requests != 0 {
+		t.Errorf("expected no HTTP request for missing file, got %v requests", requests)
+	}
+}
+
+func TestTranscribe_Non200(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error": "unsupported response_format"}`))
+	}))
+	defer server.Close()
+	trans := setupTranscriber(t, "whisper-1", server.URL)
+
+	_, err := trans.Transcribe(context.Background(), writeTestAudioFile(t, []byte("x")))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("expected status in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "unsupported response_format") {
+		t.Errorf("expected body in error, got: %v", err)
+	}
+}
+
+func TestTranscribe_MalformedResponseBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("{not json"))
+	}))
+	defer server.Close()
+	trans := setupTranscriber(t, "whisper-1", server.URL)
+
+	_, err := trans.Transcribe(context.Background(), writeTestAudioFile(t, []byte("x")))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "verbose_json") {
+		t.Errorf("expected wrapped parse error naming format, got: %v", err)
+	}
+}
+
+func TestTranscribe_ContextCancelled(t *testing.T) {
+	blockUntilClosed := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-blockUntilClosed
+	}))
+	defer func() {
+		close(blockUntilClosed)
+		server.Close()
+	}()
+	trans := setupTranscriber(t, "whisper-1", server.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := trans.Transcribe(ctx, writeTestAudioFile(t, []byte("x")))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled in error chain, got: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("expected prompt abort, took: %v", elapsed)
+	}
+}

--- a/internal/audio/querier.go
+++ b/internal/audio/querier.go
@@ -1,0 +1,94 @@
+package audio
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+// TranscribeConfig is the transcribe verb's section of audioConfig.json.
+type TranscribeConfig struct {
+	Model        string `json:"model"`
+	OutputFormat string `json:"output-format"`
+	Parallelism  int    `json:"parallelism"`
+}
+
+// Configurations is the audioConfig.json schema.
+type Configurations struct {
+	Transcribe TranscribeConfig `json:"transcribe"`
+}
+
+var Default = Configurations{
+	Transcribe: TranscribeConfig{
+		Model:        "whisper-1",
+		OutputFormat: string(FormatVTT),
+		Parallelism:  3,
+	},
+}
+
+// MockTranscriber returns deterministic segments without network access,
+// mirroring the text 'test' mock model for e2e tests. Diarized adds speaker
+// labels, emulating a diarize-capable model.
+type MockTranscriber struct {
+	Diarized bool
+}
+
+func (m MockTranscriber) Transcribe(_ context.Context, filePath string) ([]Segment, error) {
+	if _, err := os.Stat(filePath); err != nil {
+		return nil, fmt.Errorf("failed to stat audio file: %w", err)
+	}
+	segs := []Segment{
+		{Start: 0, End: 1500 * time.Millisecond, Text: "mock transcription"},
+		{Start: 1500 * time.Millisecond, End: 3 * time.Second, Text: "of an audio file"},
+	}
+	if m.Diarized {
+		segs[0].Speaker = "A"
+		segs[1].Speaker = "B"
+	}
+	return segs, nil
+}
+
+// TranscribeQuerier implements models.Querier: transcribe (splitting when
+// oversized), render, write the transcript to Out (stdout in production).
+type TranscribeQuerier struct {
+	Splitter *Splitter
+	FilePath string
+	Format   OutputFormat
+	Out      io.Writer
+	// Cleanup removes temp input (stdin '-' mode); always runs after Query
+	Cleanup func()
+}
+
+func (q *TranscribeQuerier) Query(ctx context.Context) error {
+	if q.Cleanup != nil {
+		defer q.Cleanup()
+	}
+	segs, err := q.Splitter.Transcribe(ctx, q.FilePath)
+	if err != nil {
+		return fmt.Errorf("failed to transcribe %v: %w", q.FilePath, err)
+	}
+	rendered, err := Render(segs, q.Format)
+	if err != nil {
+		return fmt.Errorf("failed to render transcript: %w", err)
+	}
+	if rendered != "" && !strings.HasSuffix(rendered, "\n") {
+		rendered += "\n"
+	}
+	out := q.Out
+	if out == nil {
+		out = os.Stdout
+	}
+	if _, err := io.WriteString(out, rendered); err != nil {
+		return fmt.Errorf("failed to write transcript: %w", err)
+	}
+	return nil
+}
+
+// SuppressCompletionNotification keeps the completion bell off stdout so
+// piped transcripts stay clean.
+func (q *TranscribeQuerier) SuppressCompletionNotification() bool {
+	return true
+}

--- a/internal/audio/querier_test.go
+++ b/internal/audio/querier_test.go
@@ -1,0 +1,90 @@
+package audio
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMockTranscriber(t *testing.T) {
+	t.Run("returns deterministic segments for existing file", func(t *testing.T) {
+		segs, err := MockTranscriber{}.Transcribe(context.Background(), sparseFile(t, 8))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(segs) != 2 {
+			t.Fatalf("expected 2 segments, got %v", len(segs))
+		}
+		if segs[0].Text != "mock transcription" {
+			t.Errorf("unexpected first segment: %+v", segs[0])
+		}
+	})
+	t.Run("errors on missing file", func(t *testing.T) {
+		_, err := MockTranscriber{}.Transcribe(context.Background(), filepath.Join(t.TempDir(), "gone.wav"))
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestTranscribeQuerier_Query(t *testing.T) {
+	newQuerier := func(t *testing.T, format OutputFormat) (*TranscribeQuerier, *strings.Builder) {
+		t.Helper()
+		out := &strings.Builder{}
+		return &TranscribeQuerier{
+			Splitter: NewSplitter(MockTranscriber{}, &fakeRunner{}),
+			FilePath: sparseFile(t, 8),
+			Format:   format,
+			Out:      out,
+		}, out
+	}
+	t.Run("renders vtt to out", func(t *testing.T) {
+		q, out := newQuerier(t, FormatVTT)
+		if err := q.Query(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.HasPrefix(out.String(), "WEBVTT\n") {
+			t.Errorf("expected VTT output, got: %q", out.String())
+		}
+	})
+	t.Run("json output ends with newline", func(t *testing.T) {
+		q, out := newQuerier(t, FormatJSON)
+		if err := q.Query(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := out.String()
+		if !strings.HasSuffix(got, "]\n") {
+			t.Errorf("expected newline-terminated json, got: %q", got)
+		}
+	})
+	t.Run("cleanup runs after query", func(t *testing.T) {
+		q, _ := newQuerier(t, FormatText)
+		cleaned := false
+		q.Cleanup = func() { cleaned = true }
+		if err := q.Query(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !cleaned {
+			t.Error("expected cleanup to run")
+		}
+	})
+	t.Run("transcription error propagates and cleanup still runs", func(t *testing.T) {
+		q, _ := newQuerier(t, FormatText)
+		q.FilePath = filepath.Join(t.TempDir(), "gone.wav")
+		cleaned := false
+		q.Cleanup = func() { cleaned = true }
+		if err := q.Query(context.Background()); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !cleaned {
+			t.Error("expected cleanup to run on error")
+		}
+	})
+	t.Run("suppresses completion bell to keep stdout clean", func(t *testing.T) {
+		q, _ := newQuerier(t, FormatText)
+		if !q.SuppressCompletionNotification() {
+			t.Error("expected completion notification suppression")
+		}
+	})
+}

--- a/internal/audio/sniff.go
+++ b/internal/audio/sniff.go
@@ -1,0 +1,37 @@
+package audio
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// SniffLen is the number of leading bytes DetectExtension needs to inspect.
+const SniffLen = 12
+
+// DetectExtension identifies the audio container from the file's leading
+// bytes and returns its canonical extension. The extension is part of the
+// transcription contract: vendors infer the upload format from the multipart
+// filename and ffmpeg infers the chunk container from the output pattern.
+func DetectExtension(header []byte) (string, error) {
+	switch {
+	case len(header) >= SniffLen && bytes.HasPrefix(header, []byte("RIFF")) && bytes.Equal(header[8:12], []byte("WAVE")):
+		return ".wav", nil
+	case len(header) >= 4 && bytes.HasPrefix(header, []byte("fLaC")):
+		return ".flac", nil
+	case len(header) >= 4 && bytes.HasPrefix(header, []byte("OggS")):
+		return ".ogg", nil
+	case len(header) >= 3 && bytes.HasPrefix(header, []byte("ID3")):
+		return ".mp3", nil
+	case len(header) >= 2 && header[0] == 0xFF && header[1]&0xE0 == 0xE0:
+		return ".mp3", nil
+	case len(header) >= SniffLen && bytes.Equal(header[4:8], []byte("ftyp")):
+		if bytes.HasPrefix(header[8:12], []byte("M4A")) {
+			return ".m4a", nil
+		}
+		return ".mp4", nil
+	case len(header) >= 4 && bytes.Equal(header[:4], []byte{0x1A, 0x45, 0xDF, 0xA3}):
+		return ".webm", nil
+	default:
+		return "", fmt.Errorf("unrecognized audio format, expected one of: wav, mp3, flac, ogg, m4a, mp4, webm")
+	}
+}

--- a/internal/audio/sniff_test.go
+++ b/internal/audio/sniff_test.go
@@ -1,0 +1,55 @@
+package audio
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectExtension(t *testing.T) {
+	tests := []struct {
+		name   string
+		header []byte
+		want   string
+	}{
+		{"wav", []byte("RIFF\x24\x08\x00\x00WAVEfmt "), ".wav"},
+		{"flac", []byte("fLaC\x00\x00\x00\x22"), ".flac"},
+		{"ogg", []byte("OggS\x00\x02\x00\x00"), ".ogg"},
+		{"mp3 id3 tag", []byte("ID3\x04\x00\x00\x00\x00\x00\x00"), ".mp3"},
+		{"mp3 frame sync", []byte{0xFF, 0xFB, 0x90, 0x00, 0x00, 0x00}, ".mp3"},
+		{"m4a", append([]byte{0x00, 0x00, 0x00, 0x20}, []byte("ftypM4A ")...), ".m4a"},
+		{"mp4", append([]byte{0x00, 0x00, 0x00, 0x18}, []byte("ftypisom")...), ".mp4"},
+		{"webm", []byte{0x1A, 0x45, 0xDF, 0xA3, 0x9F, 0x42, 0x86, 0x81}, ".webm"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DetectExtension(tt.header)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+	t.Run("unknown bytes error and list recognized formats", func(t *testing.T) {
+		_, err := DetectExtension([]byte("definitely not audio"))
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		for _, format := range []string{"wav", "mp3", "flac", "ogg", "m4a", "mp4", "webm"} {
+			if !strings.Contains(err.Error(), format) {
+				t.Errorf("expected %v in error, got: %v", format, err)
+			}
+		}
+	})
+	t.Run("too-short input errors", func(t *testing.T) {
+		if _, err := DetectExtension([]byte("RI")); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+	t.Run("riff without wave errors", func(t *testing.T) {
+		if _, err := DetectExtension([]byte("RIFF-fake-not-wave-x")); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}

--- a/internal/audio/split.go
+++ b/internal/audio/split.go
@@ -1,0 +1,287 @@
+package audio
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
+)
+
+const (
+	// MaxRequestBytes is the vendor single-request size cap (OpenAI: 25 MB)
+	MaxRequestBytes  = 25 << 20
+	targetChunkBytes = 20 << 20
+	ffprobeBin       = "ffprobe"
+	ffmpegBin        = "ffmpeg"
+)
+
+type Transcriber interface {
+	Transcribe(ctx context.Context, filePath string) ([]Segment, error)
+}
+
+// CommandRunner abstracts external binary invocation so the split path is
+// testable without ffmpeg/ffprobe installed.
+type CommandRunner interface {
+	LookPath(name string) (string, error)
+	Run(ctx context.Context, name string, args ...string) (stdout, stderr string, err error)
+}
+
+// ExecRunner is the production CommandRunner backed by os/exec.
+type ExecRunner struct{}
+
+func (ExecRunner) LookPath(name string) (string, error) {
+	return exec.LookPath(name)
+}
+
+func (ExecRunner) Run(ctx context.Context, name string, args ...string) (string, string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
+}
+
+// Splitter transparently chunks oversized audio files via ffmpeg, transcribes
+// the chunks with bounded parallelism and stitches the offset segments.
+// Sub-cap files pass straight through to the inner Transcriber.
+type Splitter struct {
+	Transcriber Transcriber
+	Runner      CommandRunner
+	Parallelism int
+	MaxBytes    int64
+	Model       string
+	StatusOut   io.Writer
+}
+
+func NewSplitter(transcriber Transcriber, runner CommandRunner) *Splitter {
+	return &Splitter{
+		Transcriber: transcriber,
+		Runner:      runner,
+		Parallelism: 3,
+		MaxBytes:    MaxRequestBytes,
+		StatusOut:   os.Stderr,
+	}
+}
+
+func (s *Splitter) Transcribe(ctx context.Context, filePath string) ([]Segment, error) {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat audio file: %w", err)
+	}
+	maxBytes := s.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = MaxRequestBytes
+	}
+	if info.Size() <= maxBytes {
+		return s.Transcriber.Transcribe(ctx, filePath)
+	}
+	return s.splitTranscribeStitch(ctx, filePath, info.Size(), maxBytes)
+}
+
+// status writes a line to StatusOut (stderr in production), keeping stdout
+// reserved for the rendered transcript
+func (s *Splitter) status(mu *sync.Mutex, msg string) {
+	out := s.StatusOut
+	if out == nil {
+		out = os.Stderr
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	fmt.Fprintln(out, msg)
+}
+
+func (s *Splitter) notice(mu *sync.Mutex, msg string) {
+	if ancli.UseColor {
+		msg = ancli.ColoredMessage(ancli.CYAN, msg)
+	}
+	s.status(mu, msg)
+}
+
+func (s *Splitter) warn(mu *sync.Mutex, msg string) {
+	if ancli.UseColor {
+		msg = ancli.ColoredMessage(ancli.YELLOW, msg)
+	}
+	s.status(mu, msg)
+}
+
+func (s *Splitter) chunkDone(mu *sync.Mutex, msg string) {
+	if ancli.UseColor {
+		msg = ancli.ColoredMessage(ancli.GREEN, msg)
+	}
+	s.status(mu, msg)
+}
+
+func (s *Splitter) splitTranscribeStitch(ctx context.Context, filePath string, size, maxBytes int64) ([]Segment, error) {
+	var statusMu sync.Mutex
+	for _, bin := range []string{ffmpegBin, ffprobeBin} {
+		if _, err := s.Runner.LookPath(bin); err != nil {
+			return nil, fmt.Errorf("'%v' is required to transcribe files over %.0f MB, but it wasn't found: %w. Install it, or split the file manually: 'ffmpeg -i %v -f segment -segment_time 600 -c copy chunk_%%03d%v'",
+				bin, toMB(maxBytes), err, filePath, filepath.Ext(filePath))
+		}
+	}
+	duration, err := s.probeDuration(ctx, filePath)
+	if err != nil {
+		return nil, err
+	}
+	numChunks := int(math.Ceil(float64(size) / float64(targetChunkBytes)))
+	segmentTime := duration / float64(numChunks)
+	s.notice(&statusMu, fmt.Sprintf("%v is %.1f MB (> %.0f MB limit) → splitting via ffmpeg: %v chunks × ~%.1f min",
+		filePath, toMB(size), toMB(maxBytes), numChunks, segmentTime/60))
+	if strings.Contains(s.Model, "diarize") {
+		s.warn(&statusMu, "diarization speaker labels are per-request: chunk 1's 'A' may not be chunk 2's 'A', labels may drift across chunks")
+	}
+
+	tempDir, err := os.MkdirTemp("", "clai-audio-split-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create chunk temp dir: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+	chunks, err := s.split(ctx, filePath, tempDir, segmentTime)
+	if err != nil {
+		return nil, err
+	}
+	s.verifyChunkOffsets(ctx, chunks, segmentTime, &statusMu)
+	return s.transcribePool(ctx, chunks, segmentTime, &statusMu)
+}
+
+func (s *Splitter) probeDuration(ctx context.Context, filePath string) (float64, error) {
+	stdout, stderr, err := s.Runner.Run(ctx, ffprobeBin,
+		"-v", "error",
+		"-show_entries", "format=duration",
+		"-of", "default=noprint_wrappers=1:nokey=1",
+		filePath)
+	if err != nil {
+		if ctx.Err() != nil {
+			return 0, fmt.Errorf("ffprobe aborted: %w", ctx.Err())
+		}
+		return 0, fmt.Errorf("ffprobe failed on %v: %w, stderr: %v", filePath, err, tail(stderr))
+	}
+	duration, err := strconv.ParseFloat(strings.TrimSpace(stdout), 64)
+	if err != nil || duration <= 0 {
+		return 0, fmt.Errorf("failed to parse ffprobe duration %q for %v: %v", strings.TrimSpace(stdout), filePath, err)
+	}
+	return duration, nil
+}
+
+func (s *Splitter) split(ctx context.Context, filePath, tempDir string, segmentTime float64) ([]string, error) {
+	pattern := filepath.Join(tempDir, "chunk_%03d"+filepath.Ext(filePath))
+	_, stderr, err := s.Runner.Run(ctx, ffmpegBin,
+		"-v", "error",
+		"-i", filePath,
+		"-f", "segment",
+		"-segment_time", strconv.FormatFloat(segmentTime, 'f', 3, 64),
+		"-c", "copy",
+		pattern)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("ffmpeg split aborted: %w", ctx.Err())
+		}
+		return nil, fmt.Errorf("ffmpeg failed to split %v: %w, stderr: %v", filePath, err, tail(stderr))
+	}
+	chunks, err := filepath.Glob(filepath.Join(tempDir, "chunk_*"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to glob chunk files: %w", err)
+	}
+	if len(chunks) == 0 {
+		return nil, fmt.Errorf("ffmpeg produced no chunks for %v", filePath)
+	}
+	return chunks, nil
+}
+
+// verifyChunkOffsets best-effort compares the planned i×segmentTime starts
+// against ffprobe-measured chunk durations, warning once on drift > 1 s
+func (s *Splitter) verifyChunkOffsets(ctx context.Context, chunks []string, segmentTime float64, statusMu *sync.Mutex) {
+	measuredStart := 0.0
+	for i, chunk := range chunks {
+		planned := float64(i) * segmentTime
+		if diff := math.Abs(measuredStart - planned); diff > 1 {
+			s.warn(statusMu, fmt.Sprintf("chunk %v timestamp drift: planned start %.1f s, measured %.1f s (%.1f s drift), stitched timestamps may be off",
+				i, planned, measuredStart, diff))
+			return
+		}
+		stdout, _, err := s.Runner.Run(ctx, ffprobeBin,
+			"-v", "error",
+			"-show_entries", "format=duration",
+			"-of", "default=noprint_wrappers=1:nokey=1",
+			chunk)
+		if err != nil {
+			return
+		}
+		chunkDuration, err := strconv.ParseFloat(strings.TrimSpace(stdout), 64)
+		if err != nil {
+			return
+		}
+		measuredStart += chunkDuration
+	}
+}
+
+func (s *Splitter) transcribePool(ctx context.Context, chunks []string, segmentTime float64, statusMu *sync.Mutex) ([]Segment, error) {
+	poolCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	parallelism := s.Parallelism
+	if parallelism <= 0 {
+		parallelism = 3
+	}
+	sem := make(chan struct{}, parallelism)
+	results := make([][]Segment, len(chunks))
+	var wg sync.WaitGroup
+	var errMu sync.Mutex
+	var firstErr error
+	for i, chunk := range chunks {
+		wg.Add(1)
+		go func(i int, chunk string) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+			case <-poolCtx.Done():
+				return
+			}
+			defer func() { <-sem }()
+			segs, err := s.Transcriber.Transcribe(poolCtx, chunk)
+			if err != nil {
+				errMu.Lock()
+				if firstErr == nil {
+					firstErr = fmt.Errorf("failed to transcribe chunk %v/%v: %w", i+1, len(chunks), err)
+				}
+				errMu.Unlock()
+				cancel()
+				return
+			}
+			results[i] = Offset(segs, secondsToDuration(float64(i)*segmentTime))
+			s.chunkDone(statusMu, fmt.Sprintf("chunk %v/%v transcribed", i+1, len(chunks)))
+		}(i, chunk)
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	var stitched []Segment
+	for _, segs := range results {
+		stitched = append(stitched, segs...)
+	}
+	return stitched, nil
+}
+
+func toMB(bytes int64) float64 {
+	return float64(bytes) / (1 << 20)
+}
+
+func tail(s string) string {
+	const limit = 512
+	if len(s) <= limit {
+		return s
+	}
+	return "…" + s[len(s)-limit:]
+}

--- a/internal/audio/split_test.go
+++ b/internal/audio/split_test.go
@@ -1,0 +1,429 @@
+package audio
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func sparseFile(t *testing.T, size int64) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "input.wav")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("failed to create sparse file: %v", err)
+	}
+	if err := f.Truncate(size); err != nil {
+		t.Fatalf("failed to truncate sparse file: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close sparse file: %v", err)
+	}
+	return path
+}
+
+type fakeTranscriber struct {
+	mu          sync.Mutex
+	calls       []string
+	inFlight    atomic.Int64
+	maxInFlight atomic.Int64
+	delay       time.Duration
+	// transcribe overrides the default per-path segment response when set
+	transcribe func(ctx context.Context, filePath string) ([]Segment, error)
+}
+
+func (f *fakeTranscriber) Transcribe(ctx context.Context, filePath string) ([]Segment, error) {
+	current := f.inFlight.Add(1)
+	defer f.inFlight.Add(-1)
+	for {
+		max := f.maxInFlight.Load()
+		if current <= max || f.maxInFlight.CompareAndSwap(max, current) {
+			break
+		}
+	}
+	f.mu.Lock()
+	f.calls = append(f.calls, filePath)
+	f.mu.Unlock()
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
+	if f.transcribe != nil {
+		return f.transcribe(ctx, filePath)
+	}
+	return []Segment{
+		{Start: 5 * time.Second, End: 6 * time.Second, Text: filepath.Base(filePath)},
+	}, nil
+}
+
+func (f *fakeTranscriber) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+type fakeRunner struct {
+	mu           sync.Mutex
+	calls        [][]string
+	lookPathErrs map[string]error
+	// durations keys ffprobe stdout by target file base name; defaultDur is the fallback
+	durations  map[string]string
+	defaultDur string
+	chunkCount int
+	ffmpegErr  error
+	ffmpegOut  string
+	blockOnRun bool
+	chunkDir   string
+}
+
+func (f *fakeRunner) LookPath(name string) (string, error) {
+	if err := f.lookPathErrs[name]; err != nil {
+		return "", err
+	}
+	return "/usr/bin/" + name, nil
+}
+
+func (f *fakeRunner) Run(ctx context.Context, name string, args ...string) (string, string, error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, append([]string{name}, args...))
+	f.mu.Unlock()
+	if f.blockOnRun {
+		<-ctx.Done()
+		return "", "", ctx.Err()
+	}
+	switch name {
+	case "ffprobe":
+		target := filepath.Base(args[len(args)-1])
+		if d, ok := f.durations[target]; ok {
+			return d, "", nil
+		}
+		return f.defaultDur, "", nil
+	case "ffmpeg":
+		if f.ffmpegErr != nil {
+			return "", f.ffmpegOut, f.ffmpegErr
+		}
+		pattern := args[len(args)-1]
+		f.mu.Lock()
+		f.chunkDir = filepath.Dir(pattern)
+		f.mu.Unlock()
+		for i := range f.chunkCount {
+			if err := os.WriteFile(fmt.Sprintf(pattern, i), []byte("chunk"), 0o644); err != nil {
+				return "", "", err
+			}
+		}
+	}
+	return "", "", nil
+}
+
+func (f *fakeRunner) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+func (f *fakeRunner) tempDir() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.chunkDir
+}
+
+// newOversizedSplitter wires a 60 MB input against a 3-chunk happy-path fake:
+// total 1800 s, chunks of 600 s each.
+func newOversizedSplitter(t *testing.T) (*Splitter, *fakeTranscriber, *fakeRunner, *bytes.Buffer, string) {
+	t.Helper()
+	trans := &fakeTranscriber{}
+	runner := &fakeRunner{
+		defaultDur: "600.000000",
+		durations:  map[string]string{"input.wav": "1800.000000"},
+		chunkCount: 3,
+	}
+	statusOut := &bytes.Buffer{}
+	splitter := NewSplitter(trans, runner)
+	splitter.StatusOut = statusOut
+	return splitter, trans, runner, statusOut, sparseFile(t, 60<<20)
+}
+
+func TestSplitter_SubCapBypassesSplit(t *testing.T) {
+	trans := &fakeTranscriber{}
+	runner := &fakeRunner{}
+	splitter := NewSplitter(trans, runner)
+	splitter.StatusOut = &bytes.Buffer{}
+	input := sparseFile(t, 10<<20)
+
+	got, err := splitter.Transcribe(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if runner.callCount() != 0 {
+		t.Errorf("expected zero runner calls for sub-cap file, got: %v", runner.calls)
+	}
+	if trans.callCount() != 1 || trans.calls[0] != input {
+		t.Errorf("expected single transcription of original file, got: %v", trans.calls)
+	}
+	if got[0].Start != 5*time.Second {
+		t.Errorf("expected unmodified timestamps, got: %v", got[0].Start)
+	}
+}
+
+func TestSplitter_OversizedSplitsAndStitches(t *testing.T) {
+	splitter, _, runner, statusOut, input := newOversizedSplitter(t)
+
+	origStdout := os.Stdout
+	pipeRead, pipeWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdout capture pipe: %v", err)
+	}
+	os.Stdout = pipeWrite
+
+	got, transcribeErr := splitter.Transcribe(context.Background(), input)
+
+	os.Stdout = origStdout
+	pipeWrite.Close()
+	stdoutContent, _ := io.ReadAll(pipeRead)
+	if transcribeErr != nil {
+		t.Fatalf("unexpected error: %v", transcribeErr)
+	}
+	if len(stdoutContent) != 0 {
+		t.Errorf("expected nothing on stdout, got: %q", stdoutContent)
+	}
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 stitched segments, got %v: %+v", len(got), got)
+	}
+	wantOffsets := []time.Duration{0, 600 * time.Second, 1200 * time.Second}
+	for i, offset := range wantOffsets {
+		wantStart := offset + 5*time.Second
+		if got[i].Start != wantStart {
+			t.Errorf("segment %v: expected start %v, got %v", i, wantStart, got[i].Start)
+		}
+		wantText := fmt.Sprintf("chunk_%03d.wav", i)
+		if got[i].Text != wantText {
+			t.Errorf("segment %v: expected text %q (in-order stitch), got %q", i, wantText, got[i].Text)
+		}
+	}
+
+	vtt, err := Render(got, FormatVTT)
+	if err != nil {
+		t.Fatalf("unexpected render error: %v", err)
+	}
+	if !strings.Contains(vtt, "00:20:05.000") {
+		t.Errorf("expected chunk 3 local 00:00:05 to render at 00:20:05, got:\n%v", vtt)
+	}
+
+	status := statusOut.String()
+	if !strings.Contains(status, "splitting via ffmpeg") || !strings.Contains(status, "3 chunks") {
+		t.Errorf("expected split notice on status writer, got: %q", status)
+	}
+	if _, err := os.Stat(runner.tempDir()); !os.IsNotExist(err) {
+		t.Errorf("expected temp chunk dir to be removed, stat err: %v", err)
+	}
+}
+
+func TestSplitter_ParallelismBounded(t *testing.T) {
+	splitter, trans, _, _, input := newOversizedSplitter(t)
+	splitter.Parallelism = 2
+	trans.delay = 30 * time.Millisecond
+
+	if _, err := splitter.Transcribe(context.Background(), input); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if trans.callCount() != 3 {
+		t.Fatalf("expected 3 chunk transcriptions, got %v", trans.callCount())
+	}
+	if max := trans.maxInFlight.Load(); max > 2 {
+		t.Errorf("expected at most 2 in-flight transcriptions, observed %v", max)
+	}
+}
+
+func TestSplitter_ChunkFailureCancelsSiblings(t *testing.T) {
+	splitter, trans, runner, _, input := newOversizedSplitter(t)
+	splitter.Parallelism = 3
+	trans.transcribe = func(ctx context.Context, filePath string) ([]Segment, error) {
+		if strings.Contains(filePath, "chunk_001") {
+			return nil, errors.New("boom on chunk 1")
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(5 * time.Second):
+			return nil, errors.New("sibling was never cancelled")
+		}
+	}
+
+	start := time.Now()
+	_, err := splitter.Transcribe(context.Background(), input)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "boom on chunk 1") {
+		t.Errorf("expected first error propagated, got: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("expected prompt cancellation of siblings, took %v", elapsed)
+	}
+	if _, statErr := os.Stat(runner.tempDir()); !os.IsNotExist(statErr) {
+		t.Errorf("expected temp chunk dir removed on error, stat err: %v", statErr)
+	}
+}
+
+func TestSplitter_DiarizeWarning(t *testing.T) {
+	splitter, _, _, statusOut, input := newOversizedSplitter(t)
+	splitter.Model = "gpt-4o-transcribe-diarize"
+
+	if _, err := splitter.Transcribe(context.Background(), input); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(statusOut.String(), "speaker labels") {
+		t.Errorf("expected speaker-label drift warning, got: %q", statusOut.String())
+	}
+}
+
+func TestSplitter_NoDiarizeWarningForPlainModel(t *testing.T) {
+	splitter, _, _, statusOut, input := newOversizedSplitter(t)
+	splitter.Model = "whisper-1"
+
+	if _, err := splitter.Transcribe(context.Background(), input); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(statusOut.String(), "speaker labels") {
+		t.Errorf("unexpected diarize warning for non-diarize model: %q", statusOut.String())
+	}
+}
+
+func TestSplitter_ChunkDriftWarning(t *testing.T) {
+	splitter, _, runner, statusOut, input := newOversizedSplitter(t)
+	// Actual chunk durations 660 s vs planned 600 s: chunk 1 starts 60 s late
+	runner.defaultDur = "660.000000"
+
+	if _, err := splitter.Transcribe(context.Background(), input); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(statusOut.String(), "drift") {
+		t.Errorf("expected drift warning, got: %q", statusOut.String())
+	}
+}
+
+func TestSplitter_MissingBinary(t *testing.T) {
+	for _, missing := range []string{"ffmpeg", "ffprobe"} {
+		t.Run(missing, func(t *testing.T) {
+			splitter, trans, runner, _, input := newOversizedSplitter(t)
+			runner.lookPathErrs = map[string]error{missing: errors.New("not found")}
+
+			_, err := splitter.Transcribe(context.Background(), input)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), missing) {
+				t.Errorf("expected error naming %v, got: %v", missing, err)
+			}
+			if !strings.Contains(err.Error(), "ffmpeg -i") {
+				t.Errorf("expected manual split command hint, got: %v", err)
+			}
+			if trans.callCount() != 0 {
+				t.Errorf("expected no transcription requests, got: %v", trans.calls)
+			}
+		})
+	}
+}
+
+func TestSplitter_FfmpegFails(t *testing.T) {
+	splitter, _, runner, _, input := newOversizedSplitter(t)
+	runner.ffmpegErr = errors.New("exit status 1")
+	runner.ffmpegOut = "Invalid data found when processing input"
+
+	_, err := splitter.Transcribe(context.Background(), input)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "Invalid data found") {
+		t.Errorf("expected ffmpeg stderr in error, got: %v", err)
+	}
+	if dir := runner.tempDir(); dir != "" {
+		if _, statErr := os.Stat(dir); !os.IsNotExist(statErr) {
+			t.Errorf("expected temp dir removed, stat err: %v", statErr)
+		}
+	}
+}
+
+func TestSplitter_ZeroChunks(t *testing.T) {
+	splitter, _, runner, _, input := newOversizedSplitter(t)
+	runner.chunkCount = 0
+
+	_, err := splitter.Transcribe(context.Background(), input)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no chunks") {
+		t.Errorf("expected explicit zero-chunk error, got: %v", err)
+	}
+}
+
+func TestSplitter_CtxCancelledDuringSplit(t *testing.T) {
+	splitter, _, runner, _, input := newOversizedSplitter(t)
+	runner.blockOnRun = true
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := splitter.Transcribe(ctx, input)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled in chain, got: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("expected prompt abort, took %v", elapsed)
+	}
+}
+
+func TestSplitter_InputFileMissing(t *testing.T) {
+	splitter, _, _, _, _ := newOversizedSplitter(t)
+	_, err := splitter.Transcribe(context.Background(), filepath.Join(t.TempDir(), "gone.wav"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestExecRunner(t *testing.T) {
+	runner := ExecRunner{}
+	t.Run("lookpath finds existing binary", func(t *testing.T) {
+		if _, err := runner.LookPath("sh"); err != nil {
+			t.Errorf("expected sh on PATH, got: %v", err)
+		}
+	})
+	t.Run("lookpath errors on missing binary", func(t *testing.T) {
+		if _, err := runner.LookPath("clai-definitely-not-a-binary"); err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+	t.Run("run captures stdout and stderr", func(t *testing.T) {
+		stdout, stderr, err := runner.Run(context.Background(), "sh", "-c", "echo out; echo err >&2")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.TrimSpace(stdout) != "out" {
+			t.Errorf("expected stdout 'out', got: %q", stdout)
+		}
+		if strings.TrimSpace(stderr) != "err" {
+			t.Errorf("expected stderr 'err', got: %q", stderr)
+		}
+	})
+	t.Run("run returns error on non-zero exit", func(t *testing.T) {
+		if _, _, err := runner.Run(context.Background(), "sh", "-c", "exit 3"); err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+}

--- a/internal/audio/testdata/README.md
+++ b/internal/audio/testdata/README.md
@@ -1,0 +1,18 @@
+# Fixture provenance
+
+No live API keys were available during phase 1; all fixtures are authored from
+vendor documentation per the worklog fixture-provenance rule
+(worklogs/2026-08-26-audio-transcription-design/phase-1-segments-and-renderers.md).
+
+- `openai_whisper1_verbose.json` — authored 2026-08-26 from the OpenAI API
+  reference, "The transcription object (Verbose JSON)"
+  (https://platform.openai.com/docs/api-reference/audio/verbose-json-object),
+  model `whisper-1`.
+- `openrouter_verbose.json` — authored 2026-08-26 from the OpenRouter audio
+  transcriptions endpoint docs (https://openrouter.ai/docs/features/multimodal/audio),
+  which mirror the OpenAI `verbose_json` shape; see the worklog README protocol
+  survey (2026-08).
+- `openai_diarized.json` — authored 2026-08-26 from the OpenAI
+  `gpt-4o-transcribe-diarize` `diarized_json` documentation
+  (https://platform.openai.com/docs/api-reference/audio/createTranscription);
+  labels `A`/`B` per the worklog README protocol survey (2026-08).

--- a/internal/audio/testdata/openai_diarized.json
+++ b/internal/audio/testdata/openai_diarized.json
@@ -1,0 +1,23 @@
+{
+  "task": "transcribe",
+  "duration": 12.5,
+  "text": "Hi Bob, how are you? I'm doing great, thanks Alice.",
+  "segments": [
+    {
+      "id": "seg_001",
+      "type": "transcript.text.segment",
+      "start": 0.0,
+      "end": 4.9,
+      "text": "Hi Bob, how are you?",
+      "speaker": "A"
+    },
+    {
+      "id": "seg_002",
+      "type": "transcript.text.segment",
+      "start": 5.1,
+      "end": 12.5,
+      "text": "I'm doing great, thanks Alice.",
+      "speaker": "B"
+    }
+  ]
+}

--- a/internal/audio/testdata/openai_whisper1_verbose.json
+++ b/internal/audio/testdata/openai_whisper1_verbose.json
@@ -1,0 +1,32 @@
+{
+  "task": "transcribe",
+  "language": "english",
+  "duration": 9.04,
+  "text": "Hello and welcome to the meeting. Let's get started with the agenda.",
+  "segments": [
+    {
+      "id": 0,
+      "seek": 0,
+      "start": 0.0,
+      "end": 5.28,
+      "text": " Hello and welcome to the meeting.",
+      "tokens": [50364, 2425, 293, 2928, 281, 264, 3440, 13, 50628],
+      "temperature": 0.0,
+      "avg_logprob": -0.2861,
+      "compression_ratio": 1.2363,
+      "no_speech_prob": 0.0101
+    },
+    {
+      "id": 1,
+      "seek": 0,
+      "start": 5.28,
+      "end": 9.04,
+      "text": " Let's get started with the agenda.",
+      "tokens": [50628, 961, 311, 483, 1409, 365, 264, 9832, 13, 50816],
+      "temperature": 0.0,
+      "avg_logprob": -0.2861,
+      "compression_ratio": 1.2363,
+      "no_speech_prob": 0.0101
+    }
+  ]
+}

--- a/internal/audio/testdata/openrouter_verbose.json
+++ b/internal/audio/testdata/openrouter_verbose.json
@@ -1,0 +1,19 @@
+{
+  "task": "transcribe",
+  "language": "en",
+  "duration": 3.84,
+  "text": "Testing OpenRouter transcription.",
+  "segments": [
+    {
+      "id": 0,
+      "seek": 0,
+      "start": 0.0,
+      "end": 3.84,
+      "text": " Testing OpenRouter transcription.",
+      "temperature": 0.0,
+      "avg_logprob": -0.31,
+      "compression_ratio": 1.0,
+      "no_speech_prob": 0.02
+    }
+  ]
+}

--- a/internal/completion.go
+++ b/internal/completion.go
@@ -55,6 +55,8 @@ type completionFlagSpec struct {
 }
 
 var completionCommands = []string{
+	"a",
+	"audio",
 	"c",
 	"chat",
 	"completion",
@@ -95,6 +97,11 @@ var completionChatSubcommands = []string{"continue", "delete", "dir", "dirv2", "
 var completionGlobalFlags = []completionFlagSpec{
 	{Name: "-I", TakesValue: true},
 	{Name: "-add-shell-context", TakesValue: true, ValueSource: "shell-context"},
+	{Name: "-af", TakesValue: true},
+	{Name: "-am", TakesValue: true},
+	{Name: "-audio-format", TakesValue: true},
+	{Name: "-audio-model", TakesValue: true},
+	{Name: "-parallelism", TakesValue: true},
 	{Name: "-asc", TakesValue: true, ValueSource: "shell-context"},
 	{Name: "-chat-model", TakesValue: true, ValueSource: "model"},
 	{Name: "-cm", TakesValue: true, ValueSource: "model"},

--- a/internal/completion_test.go
+++ b/internal/completion_test.go
@@ -46,15 +46,15 @@ func TestCompletionEngineComplete(t *testing.T) {
 			{
 				name:        "top level after trailing space lists commands and flags",
 				line:        []string{"clai", ""},
-				wantValues:  []string{"c", "chat", "completion", "confdir", "g", "glob", "h", "help", "p", "photo", "profiles", "q", "query", "re", "replay", "s", "setup", "t", "tools", "v", "version", "video", "-I", "-add-shell-context", "-asc", "-chat-model", "-cm", "-dir-reply", "-dre", "-g", "-glob", "-i", "-p", "-pd", "-photo-dir", "-photo-model", "-photo-prefix", "-pm", "-pp", "-profile", "-profile-path", "-prp", "-r", "-raw", "-re", "-replace", "-reply", "-t", "-tools", "-vd", "-video-dir", "-video-model", "-video-prefix", "-vm", "-vp"},
-				wantKinds:   repeatKind(completionResultKindPlain, 55),
+				wantValues:  []string{"a", "audio", "c", "chat", "completion", "confdir", "g", "glob", "h", "help", "p", "photo", "profiles", "q", "query", "re", "replay", "s", "setup", "t", "tools", "v", "version", "video", "-I", "-add-shell-context", "-af", "-am", "-asc", "-audio-format", "-audio-model", "-chat-model", "-cm", "-dir-reply", "-dre", "-g", "-glob", "-i", "-p", "-parallelism", "-pd", "-photo-dir", "-photo-model", "-photo-prefix", "-pm", "-pp", "-profile", "-profile-path", "-prp", "-r", "-raw", "-re", "-replace", "-reply", "-t", "-tools", "-vd", "-video-dir", "-video-model", "-video-prefix", "-vm", "-vp"},
+				wantKinds:   repeatKind(completionResultKindPlain, 62),
 				wantReplace: "",
 			},
 			{
 				name:        "dash completes global flags",
 				line:        []string{"clai", "-"},
-				wantValues:  []string{"-I", "-add-shell-context", "-asc", "-chat-model", "-cm", "-dir-reply", "-dre", "-g", "-glob", "-i", "-p", "-pd", "-photo-dir", "-photo-model", "-photo-prefix", "-pm", "-pp", "-profile", "-profile-path", "-prp", "-r", "-raw", "-re", "-replace", "-reply", "-t", "-tools", "-vd", "-video-dir", "-video-model", "-video-prefix", "-vm", "-vp"},
-				wantKinds:   repeatKind(completionResultKindPlain, 33),
+				wantValues:  []string{"-I", "-add-shell-context", "-af", "-am", "-asc", "-audio-format", "-audio-model", "-chat-model", "-cm", "-dir-reply", "-dre", "-g", "-glob", "-i", "-p", "-parallelism", "-pd", "-photo-dir", "-photo-model", "-photo-prefix", "-pm", "-pp", "-profile", "-profile-path", "-prp", "-r", "-raw", "-re", "-replace", "-reply", "-t", "-tools", "-vd", "-video-dir", "-video-model", "-video-prefix", "-vm", "-vp"},
+				wantKinds:   repeatKind(completionResultKindPlain, 38),
 				wantReplace: "-",
 			},
 			{

--- a/internal/create_queriers.go
+++ b/internal/create_queriers.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/baalimago/clai/internal/audio"
 	"github.com/baalimago/clai/internal/chat"
 	"github.com/baalimago/clai/internal/models"
 	"github.com/baalimago/clai/internal/photo"
@@ -25,6 +26,7 @@ import (
 	"github.com/baalimago/clai/internal/vendors/openrouter"
 	"github.com/baalimago/clai/internal/vendors/xai"
 	"github.com/baalimago/clai/internal/video"
+	pkgtools "github.com/baalimago/clai/pkg/tools"
 	"github.com/baalimago/go_away_boilerplate/pkg/ancli"
 	"github.com/baalimago/go_away_boilerplate/pkg/misc"
 )
@@ -252,6 +254,96 @@ func CreatePhotoQuerier(conf photo.Configurations) (models.Querier, error) {
 	}
 
 	return nil, fmt.Errorf("failed to find photo querier for model: %v", conf.Model)
+}
+
+// createAudioSplitter routes the model to a transcriber vendor by explicit
+// prefix/substring per the audio strategy and wraps it in the split/stitch
+// orchestrator. Shared by the subcommand querier and the audio_transcribe tool.
+func createAudioSplitter(conf audio.Configurations) (*audio.Splitter, error) {
+	model := conf.Transcribe.Model
+	var transcriber audio.Transcriber
+	switch {
+	case strings.HasPrefix(model, "test") || strings.HasPrefix(model, "mock_test"):
+		transcriber = audio.MockTranscriber{Diarized: strings.Contains(model, "diarize")}
+	case strings.HasPrefix(model, "or:"):
+		vendorCpy := openrouter.TranscriberDefault
+		vendorCpy.Model = model
+		if err := vendorCpy.Setup(); err != nil {
+			return nil, fmt.Errorf("failed to setup openrouter transcriber: %w", err)
+		}
+		transcriber = &vendorCpy
+	case strings.Contains(model, "whisper") || strings.Contains(model, "transcribe"):
+		vendorCpy := openai.TranscriberDefault
+		vendorCpy.Model = model
+		if err := vendorCpy.Setup(); err != nil {
+			return nil, fmt.Errorf("failed to setup openai transcriber: %w", err)
+		}
+		transcriber = &vendorCpy
+	default:
+		return nil, fmt.Errorf("failed to find audio transcriber for model: '%v', supported routes: 'or:' prefix (OpenRouter), model containing 'whisper' or 'transcribe' (OpenAI), 'test'/'mock_test' (mock)", model)
+	}
+	splitter := audio.NewSplitter(transcriber, audio.ExecRunner{})
+	splitter.Model = model
+	if conf.Transcribe.Parallelism > 0 {
+		splitter.Parallelism = conf.Transcribe.Parallelism
+	}
+	return splitter, nil
+}
+
+// CreateAudioQuerier validates the output format, routes the transcriber and
+// returns the transcript-printing querier.
+func CreateAudioQuerier(conf audio.Configurations, filePath string, cleanup func()) (models.Querier, error) {
+	format, err := audio.ParseOutputFormat(conf.Transcribe.OutputFormat)
+	if err != nil {
+		return nil, err
+	}
+	splitter, err := createAudioSplitter(conf)
+	if err != nil {
+		return nil, err
+	}
+	return &audio.TranscribeQuerier{
+		Splitter: splitter,
+		FilePath: filePath,
+		Format:   format,
+		Cleanup:  cleanup,
+	}, nil
+}
+
+// audioTranscribeEngine backs the audio_transcribe built-in tool: config →
+// querier path → rendered transcript string. Wired via init below so
+// pkg/tools carries no engine dependencies (mode-as-tool bridge).
+func audioTranscribeEngine(filePath, outputFormat string) (string, error) {
+	confDir, err := utils.GetClaiConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to find config dir: %w", err)
+	}
+	aConf, err := utils.LoadConfigFromFile(confDir, "audioConfig.json", nil, &audio.Default)
+	if err != nil {
+		return "", fmt.Errorf("failed to load configs: %w", err)
+	}
+	if outputFormat == "" {
+		outputFormat = "text"
+	}
+	format, err := audio.ParseOutputFormat(outputFormat)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(filePath); err != nil {
+		return "", fmt.Errorf("failed to find audio file: %w", err)
+	}
+	splitter, err := createAudioSplitter(aConf)
+	if err != nil {
+		return "", err
+	}
+	segs, err := splitter.Transcribe(context.Background(), filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to transcribe %v: %w", filePath, err)
+	}
+	return audio.Render(segs, format)
+}
+
+func init() {
+	pkgtools.AudioTranscribeEngine = audioTranscribeEngine
 }
 
 func CreateVideoQuerier(conf video.Configurations) (models.Querier, error) {

--- a/internal/create_queriers_audio_test.go
+++ b/internal/create_queriers_audio_test.go
@@ -1,0 +1,96 @@
+package internal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/baalimago/clai/internal/audio"
+	"github.com/baalimago/clai/internal/vendors/openai"
+	"github.com/baalimago/clai/internal/vendors/openrouter"
+)
+
+func audioConfWithModel(model string) audio.Configurations {
+	conf := audio.Default
+	conf.Transcribe.Model = model
+	return conf
+}
+
+func mustCreateAudioQuerier(t *testing.T, model string) *audio.TranscribeQuerier {
+	t.Helper()
+	q, err := CreateAudioQuerier(audioConfWithModel(model), "f.wav", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	tq, ok := q.(*audio.TranscribeQuerier)
+	if !ok {
+		t.Fatalf("expected *audio.TranscribeQuerier, got %T", q)
+	}
+	return tq
+}
+
+func TestCreateAudioQuerier_Routing(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("OPENROUTER_API_KEY", "test-key")
+
+	t.Run("or prefix routes to openrouter", func(t *testing.T) {
+		tq := mustCreateAudioQuerier(t, "or:openai/whisper-1")
+		if _, ok := tq.Splitter.Transcriber.(*openrouter.Transcriber); !ok {
+			t.Errorf("expected openrouter transcriber, got %T", tq.Splitter.Transcriber)
+		}
+	})
+	t.Run("whisper routes to openai", func(t *testing.T) {
+		tq := mustCreateAudioQuerier(t, "whisper-1")
+		if _, ok := tq.Splitter.Transcriber.(*openai.Transcriber); !ok {
+			t.Errorf("expected openai transcriber, got %T", tq.Splitter.Transcriber)
+		}
+	})
+	t.Run("transcribe substring routes to openai", func(t *testing.T) {
+		tq := mustCreateAudioQuerier(t, "gpt-4o-transcribe-diarize")
+		if _, ok := tq.Splitter.Transcriber.(*openai.Transcriber); !ok {
+			t.Errorf("expected openai transcriber, got %T", tq.Splitter.Transcriber)
+		}
+	})
+	t.Run("test routes to mock", func(t *testing.T) {
+		tq := mustCreateAudioQuerier(t, "test")
+		if _, ok := tq.Splitter.Transcriber.(audio.MockTranscriber); !ok {
+			t.Errorf("expected mock transcriber, got %T", tq.Splitter.Transcriber)
+		}
+	})
+	t.Run("parallelism and model propagate to splitter", func(t *testing.T) {
+		conf := audioConfWithModel("test")
+		conf.Transcribe.Parallelism = 5
+		q, err := CreateAudioQuerier(conf, "f.wav", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tq := q.(*audio.TranscribeQuerier)
+		if tq.Splitter.Parallelism != 5 {
+			t.Errorf("expected parallelism 5, got %v", tq.Splitter.Parallelism)
+		}
+		if tq.Splitter.Model != "test" {
+			t.Errorf("expected model on splitter, got %v", tq.Splitter.Model)
+		}
+	})
+	t.Run("unroutable model lists supported routes", func(t *testing.T) {
+		_, err := CreateAudioQuerier(audioConfWithModel("mystery9000"), "f.wav", nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		for _, hint := range []string{"or:", "whisper", "transcribe"} {
+			if !strings.Contains(err.Error(), hint) {
+				t.Errorf("expected error to mention %q, got: %v", hint, err)
+			}
+		}
+	})
+	t.Run("invalid output format errors listing valid values", func(t *testing.T) {
+		conf := audioConfWithModel("test")
+		conf.Transcribe.OutputFormat = "yaml"
+		_, err := CreateAudioQuerier(conf, "f.wav", nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "vtt") {
+			t.Errorf("expected valid formats listed, got: %v", err)
+		}
+	})
+}

--- a/internal/setup.go
+++ b/internal/setup.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/baalimago/clai/internal/audio"
 	"github.com/baalimago/clai/internal/chat"
 	"github.com/baalimago/clai/internal/debugflags"
 	"github.com/baalimago/clai/internal/glob"
@@ -42,6 +43,7 @@ const (
 	GLOB
 	PHOTO
 	VIDEO
+	AUDIO
 	VERSION
 	SETUP
 	REPLAY
@@ -96,6 +98,8 @@ func getCmdFromArgs(args []string) (Mode, error) {
 		return PHOTO, nil
 	case "video", "v":
 		return VIDEO, nil
+	case "audio", "a":
+		return AUDIO, nil
 	case "chat", "c":
 		return CHAT, nil
 	case "query", "q":
@@ -498,6 +502,9 @@ func printHelp(usage string, args []string) {
 		cfgDir,
 		defaultFlags.VideoDir,
 		defaultFlags.VideoPrefix,
+		cfgDir,
+		cfgDir,
+		cfgDir,
 		defaultFlags.UseTools,
 		defaultFlags.Glob,
 		defaultFlags.Profile,
@@ -596,6 +603,11 @@ func Setup(ctx context.Context, usage string, allArgs []string) (models.Querier,
 	} else {
 		announceUpgrade("videoConfig.json", added)
 	}
+	if _, added, err := utils.LoadConfigFromFileCollect(claiConfDir, "audioConfig.json", nil, &audio.Default); err != nil {
+		ancli.Warnf("failed to upgrade audioConfig.json: %v\n", err)
+	} else {
+		announceUpgrade("audioConfig.json", added)
+	}
 
 	// Profiles are upgraded the same way: every profiles/*.json is migrated
 	// against DefaultProfile before dispatch, so all profiles carry the
@@ -674,6 +686,8 @@ func Setup(ctx context.Context, usage string, allArgs []string) (models.Querier,
 			return nil, fmt.Errorf("failed to create video querier: %v", err)
 		}
 		return vq, nil
+	case AUDIO:
+		return handleAudio(ctx, claiConfDir, postFlagConf, postFlagArgs)
 	case PHOTO:
 		pConf, err := utils.LoadConfigFromFile(claiConfDir, "photoConfig.json", migrateOldPhotoConfig, &photo.DEFAULT)
 		if err != nil {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -190,7 +190,7 @@ func InitCmd() error {
 		{
 			name: "model files",
 			load: func(dir string) ([]config, error) {
-				return getConfigs(filepath.Join(dir, "*.json"), []string{"textConfig", "photoConfig", "videoConfig"})
+				return getConfigs(filepath.Join(dir, "*.json"), []string{"textConfig", "photoConfig", "videoConfig", "audioConfig"})
 			},
 			itemSelectActions: nil,
 			itemActions:       []action{conf, del, copyAction, confWithEditor},

--- a/internal/setup/setup_actions.go
+++ b/internal/setup/setup_actions.go
@@ -706,7 +706,7 @@ func selectFromList(items []string, header, prompt string) (string, error) {
 
 // getAvailableModels discovers model configurations from the clai config directory.
 func getAvailableModels(claiConfigDir string) ([]string, error) {
-	cfgs, err := getConfigs(filepath.Join(claiConfigDir, "*.json"), []string{"textConfig", "photoConfig", "videoConfig"})
+	cfgs, err := getConfigs(filepath.Join(claiConfigDir, "*.json"), []string{"textConfig", "photoConfig", "videoConfig", "audioConfig"})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/setup_audio.go
+++ b/internal/setup_audio.go
@@ -1,0 +1,112 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/baalimago/clai/internal/audio"
+	"github.com/baalimago/clai/internal/models"
+	"github.com/baalimago/clai/internal/utils"
+	"github.com/baalimago/go_away_boilerplate/pkg/table"
+)
+
+const audioNamespaceHelp = `usage: clai [flags] audio <verb> [args]
+
+Verbs:
+  t|transcribe <file>   Transcribe an audio file to text. Use '-' to read audio bytes from stdin.
+  h|help                Show this help.
+
+Flags:
+  -am, -audio-model     Set the transcription model (default in audioConfig.json)
+  -af, -audio-format    Set the transcript output format: vtt|srt|text|json
+  -parallelism          Max parallel requests when a large file is split into chunks
+
+Examples:
+  clai audio transcribe meeting.wav
+  clai -af text a t meeting.wav
+  cat meeting.wav | clai a t -
+`
+
+// handleAudio dispatches the audio namespace verbs; args[0] is "audio" or "a".
+func handleAudio(_ context.Context, confDir string, flagSet Configurations, args []string) (models.Querier, error) {
+	if len(args) < 2 {
+		fmt.Fprint(os.Stderr, audioNamespaceHelp)
+		return nil, fmt.Errorf("missing audio verb")
+	}
+	switch verb := args[1]; verb {
+	case "transcribe", "t":
+		return setupAudioTranscribeQuerier(confDir, flagSet, args[2:])
+	case "help", "h":
+		fmt.Print(audioNamespaceHelp)
+		return nil, table.ErrUserInitiatedExit
+	default:
+		fmt.Fprint(os.Stderr, audioNamespaceHelp)
+		return nil, fmt.Errorf("unknown audio verb: %q", verb)
+	}
+}
+
+func setupAudioTranscribeQuerier(confDir string, flagSet Configurations, args []string) (models.Querier, error) {
+	filePath, cleanup, err := resolveAudioInput(args)
+	if err != nil {
+		return nil, err
+	}
+	aConf, err := utils.LoadConfigFromFile(confDir, "audioConfig.json", nil, &audio.Default)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("failed to load configs: %w", err)
+	}
+	applyFlagOverridesForAudio(&aConf, flagSet, defaultFlags)
+	q, err := CreateAudioQuerier(aConf, filePath, cleanup)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("failed to create audio querier: %w", err)
+	}
+	return q, nil
+}
+
+// resolveAudioInput returns the audio file path from the positional args.
+// '-' drains stdin into a temp file; the cleanup removes it after the query.
+func resolveAudioInput(args []string) (string, func(), error) {
+	noop := func() {}
+	if len(args) == 0 {
+		return "", noop, fmt.Errorf("missing audio file argument, usage: clai audio transcribe <file>")
+	}
+	filePath := args[0]
+	if filePath == "-" {
+		// The extension is load-bearing downstream (vendor multipart filename,
+		// ffmpeg chunk pattern), so sniff the container before creating the file
+		header := make([]byte, audio.SniffLen)
+		n, err := io.ReadFull(os.Stdin, header)
+		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+			return "", noop, fmt.Errorf("failed to read stdin audio: %w", err)
+		}
+		ext, err := audio.DetectExtension(header[:n])
+		if err != nil {
+			return "", noop, fmt.Errorf("failed to detect stdin audio format: %w", err)
+		}
+		tmpFile, err := os.CreateTemp("", "clai-audio-stdin-*"+ext)
+		if err != nil {
+			return "", noop, fmt.Errorf("failed to create temp file for stdin audio: %w", err)
+		}
+		cleanup := func() { os.Remove(tmpFile.Name()) }
+		_, err = tmpFile.Write(header[:n])
+		if err == nil {
+			_, err = io.Copy(tmpFile, os.Stdin)
+		}
+		if closeErr := tmpFile.Close(); err == nil {
+			err = closeErr
+		}
+		if err != nil {
+			cleanup()
+			return "", noop, fmt.Errorf("failed to read stdin audio: %w", err)
+		}
+		return tmpFile.Name(), cleanup, nil
+	}
+	if _, err := os.Stat(filePath); err != nil {
+		return "", noop, fmt.Errorf("failed to find audio file: %w", err)
+	}
+	return filePath, noop, nil
+}

--- a/internal/setup_audio_test.go
+++ b/internal/setup_audio_test.go
@@ -1,0 +1,184 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/baalimago/clai/internal/audio"
+	"github.com/baalimago/clai/internal/audio/generic"
+)
+
+func TestResolveAudioInput(t *testing.T) {
+	t.Run("missing argument errors", func(t *testing.T) {
+		_, _, err := resolveAudioInput(nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+	t.Run("nonexistent path errors with path in message", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "gone.wav")
+		_, _, err := resolveAudioInput([]string{missing})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "gone.wav") {
+			t.Errorf("expected path in error, got: %v", err)
+		}
+	})
+	t.Run("existing path passes through with noop cleanup", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "f.wav")
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		got, cleanup, err := resolveAudioInput([]string{path})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != path {
+			t.Errorf("expected %v, got %v", path, got)
+		}
+		cleanup()
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("cleanup must not remove user files: %v", err)
+		}
+	})
+	t.Run("dash reads stdin into temp file with sniffed extension, cleanup removes it", func(t *testing.T) {
+		stdinBytes := fakeWAVBytes("stdin-audio-bytes")
+		setStdin(t, stdinBytes)
+
+		got, cleanup, err := resolveAudioInput([]string{"-"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if filepath.Ext(got) != ".wav" {
+			t.Errorf("expected sniffed .wav extension on temp file, got: %v", got)
+		}
+		content, err := os.ReadFile(got)
+		if err != nil {
+			t.Fatalf("failed to read temp file: %v", err)
+		}
+		if string(content) != string(stdinBytes) {
+			t.Errorf("unexpected temp file content: %q", content)
+		}
+		cleanup()
+		if _, err := os.Stat(got); !os.IsNotExist(err) {
+			t.Errorf("expected temp file removed by cleanup, stat err: %v", err)
+		}
+	})
+	t.Run("dash with unrecognized bytes errors before creating a file", func(t *testing.T) {
+		setStdin(t, []byte("definitely not audio bytes"))
+		_, _, err := resolveAudioInput([]string{"-"})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "wav") {
+			t.Errorf("expected recognized formats in error, got: %v", err)
+		}
+	})
+}
+
+// fakeWAVBytes prefixes content with a valid RIFF/WAVE header so the
+// container sniffer accepts it
+func fakeWAVBytes(content string) []byte {
+	return append([]byte("RIFF\x24\x08\x00\x00WAVEfmt "), content...)
+}
+
+func setStdin(t *testing.T, content []byte) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe: %v", err)
+	}
+	if _, err := w.Write(content); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	w.Close()
+	oldStdin := os.Stdin
+	t.Cleanup(func() {
+		os.Stdin = oldStdin
+		r.Close()
+	})
+	os.Stdin = r
+}
+
+// TestStdinMultipartFilename proves the seam R1-01 severed: the multipart
+// filename a vendor sees for stdin input must carry a recognized audio
+// extension, since vendors infer the upload format from it
+func TestStdinMultipartFilename(t *testing.T) {
+	setStdin(t, fakeWAVBytes("stdin-audio-bytes"))
+	filePath, cleanup, err := resolveAudioInput([]string{"-"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	var gotFilename string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(32 << 20); err != nil {
+			t.Errorf("failed to parse multipart form: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, header, err := r.FormFile("file")
+		if err != nil {
+			t.Errorf("failed to get file part: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		gotFilename = header.Filename
+		fmt.Fprint(w, `{"segments":[{"start":0,"end":1,"text":"hi"}]}`)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("TEST_AUDIO_API_KEY", "test-key")
+	trans := &generic.Transcriber{Model: "whisper-1"}
+	if err := trans.Setup("TEST_AUDIO_API_KEY", server.URL, "DEBUG_TEST_AUDIO"); err != nil {
+		t.Fatalf("failed to setup transcriber: %v", err)
+	}
+	if _, err := trans.Transcribe(context.Background(), filePath); err != nil {
+		t.Fatalf("unexpected transcribe error: %v", err)
+	}
+	if !strings.HasPrefix(gotFilename, "clai-audio-stdin-") || !strings.HasSuffix(gotFilename, ".wav") {
+		t.Errorf("expected multipart filename 'clai-audio-stdin-*.wav', got: %q", gotFilename)
+	}
+}
+
+func TestApplyFlagOverridesForAudio(t *testing.T) {
+	fileConf := audio.Configurations{
+		Transcribe: audio.TranscribeConfig{
+			Model:        "from-file",
+			OutputFormat: "text",
+			Parallelism:  2,
+		},
+	}
+	t.Run("default flags leave file values", func(t *testing.T) {
+		conf := fileConf
+		applyFlagOverridesForAudio(&conf, defaultFlags, defaultFlags)
+		if conf != fileConf {
+			t.Errorf("expected file config untouched, got: %+v", conf)
+		}
+	})
+	t.Run("set flags beat file values", func(t *testing.T) {
+		conf := fileConf
+		flagSet := defaultFlags
+		flagSet.AudioModel = "from-flag"
+		flagSet.AudioFormat = "json"
+		flagSet.Parallelism = 7
+		applyFlagOverridesForAudio(&conf, flagSet, defaultFlags)
+		if conf.Transcribe.Model != "from-flag" {
+			t.Errorf("expected flag model, got: %v", conf.Transcribe.Model)
+		}
+		if conf.Transcribe.OutputFormat != "json" {
+			t.Errorf("expected flag format, got: %v", conf.Transcribe.OutputFormat)
+		}
+		if conf.Transcribe.Parallelism != 7 {
+			t.Errorf("expected flag parallelism, got: %v", conf.Transcribe.Parallelism)
+		}
+	})
+}

--- a/internal/setup_flags.go
+++ b/internal/setup_flags.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/baalimago/clai/internal/audio"
 	"github.com/baalimago/clai/internal/photo"
 	"github.com/baalimago/clai/internal/text"
 	"github.com/baalimago/clai/internal/utils"
@@ -14,15 +15,22 @@ import (
 )
 
 type Configurations struct {
-	ChatModel     string
-	PhotoModel    string
-	PhotoDir      string
-	PhotoPrefix   string
-	PhotoOutput   string
-	VideoModel    string
-	VideoDir      string
-	VideoPrefix   string
-	VideoOutput   string
+	ChatModel   string
+	PhotoModel  string
+	PhotoDir    string
+	PhotoPrefix string
+	PhotoOutput string
+	VideoModel  string
+	VideoDir    string
+	VideoPrefix string
+	VideoOutput string
+	AudioModel  string
+	// AudioFormat is the -af/-audio-format transcript output format
+	// (vtt|srt|text|json); validated in CreateAudioQuerier.
+	AudioFormat string
+	// Parallelism is the -parallelism max concurrent transcription requests
+	// for split audio files. 0 = no override.
+	Parallelism   int
 	StdinReplace  string
 	ExpectReplace bool
 	PrintRaw      bool
@@ -110,6 +118,14 @@ func parseFlags(defaults Configurations, args []string) (Configurations, []strin
 
 	vpShort := fs.String("vp", defaults.VideoPrefix, "Set prefix for generated videos. Default 'clai'")
 	vpLong := fs.String("video-prefix", defaults.VideoPrefix, "Set prefix for generated videos. Default 'clai'")
+
+	amShort := fs.String("am", defaults.AudioModel, "Set the audio transcription model. Mutually exclusive with audio-model.")
+	amLong := fs.String("audio-model", defaults.AudioModel, "Set the audio transcription model. Mutually exclusive with am.")
+
+	afShort := fs.String("af", defaults.AudioFormat, "Set the transcript output format: vtt|srt|text|json. Mutually exclusive with audio-format.")
+	afLong := fs.String("audio-format", defaults.AudioFormat, "Set the transcript output format: vtt|srt|text|json. Mutually exclusive with af.")
+
+	parallelism := fs.Int("parallelism", defaults.Parallelism, "Set max parallel transcription requests for split audio files.")
 
 	gShort := fs.String("g", defaults.Glob, "Use globbing from query or chat. This flag will deprecate glob mode in a future release.")
 	gLong := fs.String("glob", defaults.Glob, "Use globbing from query or chat. This flag will deprecate glob mode in a future release.")
@@ -214,6 +230,10 @@ func parseFlags(defaults Configurations, args []string) (Configurations, []strin
 	exitWithFlagError(err, "vd", "video-dir")
 	videoPrefix, err := utils.ReturnNonDefault(*vpShort, *vpLong, defaults.VideoPrefix)
 	exitWithFlagError(err, "vp", "video-prefix")
+	audioModel, err := utils.ReturnNonDefault(*amShort, *amLong, defaults.AudioModel)
+	exitWithFlagError(err, "am", "audio-model")
+	audioFormat, err := utils.ReturnNonDefault(*afShort, *afLong, defaults.AudioFormat)
+	exitWithFlagError(err, "af", "audio-format")
 	shellContext, err := utils.ReturnNonDefault(*ascShort, *ascLong, defaults.ShellContext)
 	exitWithFlagError(err, "asc", "add-shell-context")
 	responseFormatPath, err := utils.ReturnNonDefault(*rfShort, *rfLong, defaults.ResponseFormatPath)
@@ -244,6 +264,9 @@ func parseFlags(defaults Configurations, args []string) (Configurations, []strin
 		VideoModel:                   videoModel,
 		VideoDir:                     videoDir,
 		VideoPrefix:                  videoPrefix,
+		AudioModel:                   audioModel,
+		AudioFormat:                  audioFormat,
+		Parallelism:                  *parallelism,
 		StdinReplace:                 stdinReplace,
 		PrintRaw:                     printRaw,
 		ReplyMode:                    replyMode,
@@ -392,6 +415,18 @@ func applyFlagOverridesForVideo(vConf *video.Configurations, flagSet, defaultFla
 	}
 	if flagSet.VideoOutput != defaultFlags.VideoOutput && flagSet.VideoOutput != "" {
 		vConf.Output.Type = video.OutputType(flagSet.VideoOutput)
+	}
+}
+
+func applyFlagOverridesForAudio(aConf *audio.Configurations, flagSet, defaultFlags Configurations) {
+	if flagSet.AudioModel != defaultFlags.AudioModel {
+		aConf.Transcribe.Model = flagSet.AudioModel
+	}
+	if flagSet.AudioFormat != defaultFlags.AudioFormat {
+		aConf.Transcribe.OutputFormat = flagSet.AudioFormat
+	}
+	if flagSet.Parallelism != defaultFlags.Parallelism {
+		aConf.Transcribe.Parallelism = flagSet.Parallelism
 	}
 }
 

--- a/internal/tools/handler.go
+++ b/internal/tools/handler.go
@@ -51,6 +51,7 @@ func registerLocalTools() {
 	Registry.Set(tools.LineCount.Specification().Name, tools.LineCount)
 	Registry.Set(tools.Git.Specification().Name, tools.Git)
 	Registry.Set(tools.FFProbe.Specification().Name, tools.FFProbe)
+	Registry.Set(tools.AudioTranscribe.Specification().Name, tools.AudioTranscribe)
 	Registry.Set(tools.Date.Specification().Name, tools.Date)
 	Registry.Set(tools.Pwd.Specification().Name, tools.Pwd)
 	Registry.Set(tools.ClaiHelp.Specification().Name, tools.ClaiHelp)

--- a/internal/vendors/mock.go
+++ b/internal/vendors/mock.go
@@ -184,6 +184,12 @@ func inputsForTool(toolName string) pub_models.Input {
 			}
 		}
 		return input
+	case "audio_transcribe":
+		input := pub_models.Input{"file_path": os.Getenv("CLAI_MOCK_AUDIO_TRANSCRIBE_FILE")}
+		if format := os.Getenv("CLAI_MOCK_AUDIO_TRANSCRIBE_FORMAT"); format != "" {
+			input["output_format"] = format
+		}
+		return input
 	case "cmd":
 		return pub_models.Input{"command": envOr("CLAI_MOCK_CMD_COMMAND", `printf mocked-cmd`)}
 	case "freetext_command": // legacy alias of cmd

--- a/internal/vendors/openai/transcribe.go
+++ b/internal/vendors/openai/transcribe.go
@@ -1,0 +1,27 @@
+package openai
+
+import (
+	"fmt"
+
+	"github.com/baalimago/clai/internal/audio/generic"
+)
+
+const TranscribeURL = "https://api.openai.com/v1/audio/transcriptions"
+
+var TranscriberDefault = Transcriber{
+	Model: "whisper-1",
+}
+
+type Transcriber struct {
+	generic.Transcriber
+	Model string `json:"model"`
+}
+
+func (t *Transcriber) Setup() error {
+	err := t.Transcriber.Setup("OPENAI_API_KEY", TranscribeURL, "DEBUG_OPENAI")
+	if err != nil {
+		return fmt.Errorf("failed to setup transcriber: %w", err)
+	}
+	t.Transcriber.Model = t.Model
+	return nil
+}

--- a/internal/vendors/openai/transcribe_test.go
+++ b/internal/vendors/openai/transcribe_test.go
@@ -1,0 +1,92 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const verboseFixture = `{
+  "task": "transcribe",
+  "duration": 9.04,
+  "segments": [
+    {"id": 0, "start": 0.0, "end": 5.28, "text": " Hello and welcome to the meeting."},
+    {"id": 1, "start": 5.28, "end": 9.04, "text": " Let's get started with the agenda."}
+  ]
+}`
+
+func TestTranscriber_Setup_MissingKey(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	trans := TranscriberDefault
+	err := trans.Setup()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "OPENAI_API_KEY") {
+		t.Errorf("expected error naming OPENAI_API_KEY, got: %v", err)
+	}
+}
+
+func TestTranscriber_Transcribe(t *testing.T) {
+	var gotModel, gotFormat, gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Errorf("failed to parse multipart form: %v", err)
+		}
+		gotModel = r.FormValue("model")
+		gotFormat = r.FormValue("response_format")
+		gotAuth = r.Header.Get("Authorization")
+		w.Write([]byte(verboseFixture))
+	}))
+	defer server.Close()
+	t.Setenv("OPENAI_API_KEY", "oai-test-key")
+	trans := TranscriberDefault
+	if err := trans.Setup(); err != nil {
+		t.Fatalf("failed to setup: %v", err)
+	}
+	trans.Transcriber.URL = server.URL
+	audioFile := filepath.Join(t.TempDir(), "test.wav")
+	if err := os.WriteFile(audioFile, []byte("fake-wav"), 0o644); err != nil {
+		t.Fatalf("failed to write audio file: %v", err)
+	}
+
+	segs, err := trans.Transcribe(context.Background(), audioFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotModel != "whisper-1" {
+		t.Errorf("expected default model whisper-1, got: %q", gotModel)
+	}
+	if gotFormat != "verbose_json" {
+		t.Errorf("expected verbose_json, got: %q", gotFormat)
+	}
+	if gotAuth != "Bearer oai-test-key" {
+		t.Errorf("expected bearer auth, got: %q", gotAuth)
+	}
+	if len(segs) != 2 {
+		t.Fatalf("expected 2 segments, got %v", len(segs))
+	}
+	if segs[1].Text != "Let's get started with the agenda." {
+		t.Errorf("unexpected segment text: %q", segs[1].Text)
+	}
+	if segs[1].End != 9040*time.Millisecond {
+		t.Errorf("unexpected segment end: %v", segs[1].End)
+	}
+}
+
+func TestTranscriberDefault_URL(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "oai-test-key")
+	trans := TranscriberDefault
+	if err := trans.Setup(); err != nil {
+		t.Fatalf("failed to setup: %v", err)
+	}
+	if trans.Transcriber.URL != TranscribeURL {
+		t.Errorf("expected default URL %v, got: %v", TranscribeURL, trans.Transcriber.URL)
+	}
+}

--- a/internal/vendors/openrouter/transcribe.go
+++ b/internal/vendors/openrouter/transcribe.go
@@ -1,0 +1,32 @@
+package openrouter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/baalimago/clai/internal/audio/generic"
+)
+
+const TranscribeURL = "https://openrouter.ai/api/v1/audio/transcriptions"
+
+var TranscriberDefault = Transcriber{
+	Model: "or:openai/whisper-1",
+}
+
+type Transcriber struct {
+	generic.Transcriber
+	Model string `json:"model"`
+}
+
+func (t *Transcriber) Setup() error {
+	err := t.Transcriber.Setup("OPENROUTER_API_KEY", TranscribeURL, "DEBUG_OPENROUTER")
+	if err != nil {
+		return fmt.Errorf("failed to setup transcriber: %w", err)
+	}
+	t.Transcriber.Model = strings.TrimPrefix(t.Model, "or:")
+	t.Transcriber.ExtraHeaders = map[string]string{
+		"HTTP-Referer":       "clai",
+		"X-OpenRouter-Title": "clai",
+	}
+	return nil
+}

--- a/internal/vendors/openrouter/transcribe_test.go
+++ b/internal/vendors/openrouter/transcribe_test.go
@@ -1,0 +1,76 @@
+package openrouter
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const verboseFixture = `{
+  "task": "transcribe",
+  "duration": 3.84,
+  "segments": [
+    {"id": 0, "start": 0.0, "end": 3.84, "text": " Testing OpenRouter transcription."}
+  ]
+}`
+
+func TestTranscriber_Setup_MissingKey(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "")
+	trans := TranscriberDefault
+	err := trans.Setup()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "OPENROUTER_API_KEY") {
+		t.Errorf("expected error naming OPENROUTER_API_KEY, got: %v", err)
+	}
+}
+
+func TestTranscriber_Transcribe_TrimsPrefixAndSendsHeaders(t *testing.T) {
+	var gotModel, gotReferer, gotTitle string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Errorf("failed to parse multipart form: %v", err)
+		}
+		gotModel = r.FormValue("model")
+		gotReferer = r.Header.Get("HTTP-Referer")
+		gotTitle = r.Header.Get("X-OpenRouter-Title")
+		w.Write([]byte(verboseFixture))
+	}))
+	defer server.Close()
+	t.Setenv("OPENROUTER_API_KEY", "or-test-key")
+	trans := Transcriber{Model: "or:openai/whisper-1"}
+	if err := trans.Setup(); err != nil {
+		t.Fatalf("failed to setup: %v", err)
+	}
+	trans.Transcriber.URL = server.URL
+	audioFile := filepath.Join(t.TempDir(), "test.wav")
+	if err := os.WriteFile(audioFile, []byte("fake-wav"), 0o644); err != nil {
+		t.Fatalf("failed to write audio file: %v", err)
+	}
+
+	segs, err := trans.Transcribe(context.Background(), audioFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotModel != "openai/whisper-1" {
+		t.Errorf("expected or: prefix trimmed, got: %q", gotModel)
+	}
+	if gotReferer != "clai" {
+		t.Errorf("expected HTTP-Referer clai, got: %q", gotReferer)
+	}
+	if gotTitle != "clai" {
+		t.Errorf("expected X-OpenRouter-Title clai, got: %q", gotTitle)
+	}
+	if len(segs) != 1 {
+		t.Fatalf("expected 1 segment, got %v", len(segs))
+	}
+	if segs[0].Text != "Testing OpenRouter transcription." {
+		t.Errorf("unexpected segment text: %q", segs[0].Text)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -34,6 +34,9 @@ Flags:
   -pp, -photo-prefix string           Set the prefix for the generated pictures. (default is found in %v/photoConfig.json)
   -vd, -video-dir string              Set dir for generated videos. Default $HOME/Videos (default %v)
   -vp, -video-prefix string           Set prefix for generated videos. Default 'clai' (default %v)
+  -am, -audio-model string            Set the audio transcription model. (default is found in %v/audioConfig.json)
+  -af, -audio-format string           Set the transcript output format (vtt|srt|text|json). (default is found in %v/audioConfig.json)
+  -parallelism int                    Set max parallel transcription requests for split audio files. (default is found in %v/audioConfig.json)
   -t, -tools string                   Set to <tool_a>,<tool_b> for specific tool, or */"" to use all built in or MCP tools. See available tools with 'clai tools' (default %v)
   -s, -skills string                  Enable or disable skills for this run. Use '*' to enable or 'none' to disable.
   -cmd-ban string                     Append comma-separated command bans for this run (e.g. "rm,sudo"). Commands matching a ban are refused before they spawn.
@@ -58,6 +61,7 @@ Commands:
   q|query <text>                Query the chat model with the given text
   p|photo <text>                Ask the photo model for a picture with the given prompt
   v|video <text>                Ask the video model for a video with the given prompt
+  a|audio  t|transcribe <file>    Transcribe an audio file to text. Use '-' to read audio from stdin.
   re|replay                     Replay the most recent message.
   t|tools [tool name]           List available tools, both mcp and built-in. Or show details for a specific tool.
 
@@ -76,6 +80,7 @@ Examples:
   - clai -asc minimal q "what changed in this repo?"
   - clai -pm dall-e-2 photo A cat in space
   - docker logs example | clai -I LOG q "Find errors in these logs: LOG"
+  - clai a t meeting.wav | clai q "Summarize these meeting notes: {}"
   - clai c list
   - clai -r c dirv2
   - clai c help

--- a/main_audio_e2e_test.go
+++ b/main_audio_e2e_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/baalimago/go_away_boilerplate/pkg/testboil"
+)
+
+const (
+	wantMockVTT = `WEBVTT
+
+00:00:00.000 --> 00:00:01.500
+mock transcription
+
+00:00:01.500 --> 00:00:03.000
+of an audio file
+`
+	wantMockText = "mock transcription\nof an audio file\n"
+)
+
+func writeE2EAudioFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "f.wav")
+	if err := os.WriteFile(path, []byte("RIFF-fake-wav"), 0o644); err != nil {
+		t.Fatalf("WriteFile(audio): %v", err)
+	}
+	return path
+}
+
+func runAudio(t *testing.T, args string) (int, string, string) {
+	t.Helper()
+	oldArgs := os.Args
+	t.Cleanup(func() { os.Args = oldArgs })
+	var status int
+	var stdout string
+	stderr := testboil.CaptureStderr(t, func(t *testing.T) {
+		stdout = testboil.CaptureStdout(t, func(t *testing.T) {
+			status = run(strings.Split(args, " "))
+		})
+	})
+	return status, stdout, stderr
+}
+
+func Test_goldenFile_AUDIO_transcribe_vtt(t *testing.T) {
+	confDir := setupMainTestConfigDir(t)
+	audioFile := writeE2EAudioFile(t)
+
+	status, stdout, _ := runAudio(t, "-am test audio transcribe "+audioFile)
+
+	testboil.FailTestIfDiff(t, status, 0)
+	testboil.FailTestIfDiff(t, stdout, wantMockVTT)
+	if _, err := os.Stat(filepath.Join(confDir, "audioConfig.json")); err != nil {
+		t.Errorf("expected audioConfig.json to be created from defaults: %v", err)
+	}
+}
+
+func Test_goldenFile_AUDIO_alias_and_text_format(t *testing.T) {
+	_ = setupMainTestConfigDir(t)
+	audioFile := writeE2EAudioFile(t)
+
+	status, stdout, _ := runAudio(t, "-am test -af text a t "+audioFile)
+
+	testboil.FailTestIfDiff(t, status, 0)
+	testboil.FailTestIfDiff(t, stdout, wantMockText)
+	if strings.Contains(stdout, "WEBVTT") {
+		t.Errorf("unexpected VTT header in text output: %q", stdout)
+	}
+}
+
+func Test_goldenFile_AUDIO_stdin_dash(t *testing.T) {
+	_ = setupMainTestConfigDir(t)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe: %v", err)
+	}
+	if _, err := w.Write([]byte("RIFF\x24\x08\x00\x00WAVEfmt fake-wav-from-stdin")); err != nil {
+		t.Fatalf("Write(stdin): %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close(stdin writer): %v", err)
+	}
+	oldStdin := os.Stdin
+	t.Cleanup(func() { os.Stdin = oldStdin })
+	os.Stdin = r
+	t.Cleanup(func() { _ = r.Close() })
+
+	status, stdout, _ := runAudio(t, "-am test -af text a t -")
+
+	testboil.FailTestIfDiff(t, status, 0)
+	testboil.FailTestIfDiff(t, stdout, wantMockText)
+}
+
+func Test_goldenFile_AUDIO_stdin_unrecognized_format(t *testing.T) {
+	_ = setupMainTestConfigDir(t)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe: %v", err)
+	}
+	if _, err := w.Write([]byte("definitely not audio bytes")); err != nil {
+		t.Fatalf("Write(stdin): %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close(stdin writer): %v", err)
+	}
+	oldStdin := os.Stdin
+	t.Cleanup(func() { os.Stdin = oldStdin })
+	os.Stdin = r
+	t.Cleanup(func() { _ = r.Close() })
+
+	status, stdout, stderr := runAudio(t, "-am test -af text a t -")
+
+	testboil.FailTestIfDiff(t, status, 1)
+	testboil.FailTestIfDiff(t, stdout, "")
+	testboil.AssertStringContains(t, stderr, "wav")
+}
+
+func Test_goldenFile_AUDIO_namespace_help(t *testing.T) {
+	t.Run("no verb errors with help on stderr", func(t *testing.T) {
+		_ = setupMainTestConfigDir(t)
+		status, stdout, stderr := runAudio(t, "audio")
+		testboil.FailTestIfDiff(t, status, 1)
+		testboil.AssertStringContains(t, stderr, "transcribe")
+		testboil.FailTestIfDiff(t, stdout, "")
+	})
+	t.Run("unknown verb errors with help on stderr", func(t *testing.T) {
+		_ = setupMainTestConfigDir(t)
+		status, _, stderr := runAudio(t, "audio fly")
+		testboil.FailTestIfDiff(t, status, 1)
+		testboil.AssertStringContains(t, stderr, "transcribe")
+	})
+	t.Run("help verb lists verbs and exits 0", func(t *testing.T) {
+		_ = setupMainTestConfigDir(t)
+		status, stdout, _ := runAudio(t, "audio help")
+		testboil.FailTestIfDiff(t, status, 0)
+		testboil.AssertStringContains(t, stdout, "transcribe")
+	})
+}
+
+func Test_goldenFile_AUDIO_missing_input_file(t *testing.T) {
+	_ = setupMainTestConfigDir(t)
+	missing := filepath.Join(t.TempDir(), "nope.wav")
+
+	status, _, stderr := runAudio(t, "-am test a t "+missing)
+
+	testboil.FailTestIfDiff(t, status, 1)
+	testboil.AssertStringContains(t, stderr, "nope.wav")
+}
+
+func Test_goldenFile_AUDIO_invalid_format_flag(t *testing.T) {
+	_ = setupMainTestConfigDir(t)
+	audioFile := writeE2EAudioFile(t)
+
+	status, _, stderr := runAudio(t, "-am test -af yaml a t "+audioFile)
+
+	testboil.FailTestIfDiff(t, status, 1)
+	testboil.AssertStringContains(t, stderr, "vtt")
+	testboil.AssertStringContains(t, stderr, "json")
+}
+
+func Test_goldenFile_AUDIO_unroutable_model(t *testing.T) {
+	_ = setupMainTestConfigDir(t)
+	audioFile := writeE2EAudioFile(t)
+
+	status, _, stderr := runAudio(t, "-am mystery9000 a t "+audioFile)
+
+	testboil.FailTestIfDiff(t, status, 1)
+	testboil.AssertStringContains(t, stderr, "or:")
+	testboil.AssertStringContains(t, stderr, "whisper")
+}
+
+func Test_goldenFile_AUDIO_missing_api_key(t *testing.T) {
+	_ = setupMainTestConfigDir(t)
+	audioFile := writeE2EAudioFile(t)
+	t.Setenv("OPENAI_API_KEY", "")
+
+	status, _, stderr := runAudio(t, "-am whisper-1 a t "+audioFile)
+
+	testboil.FailTestIfDiff(t, status, 1)
+	testboil.AssertStringContains(t, stderr, "OPENAI_API_KEY")
+}
+
+func Test_goldenFile_AUDIO_config_cascade(t *testing.T) {
+	confDir := setupMainTestConfigDir(t)
+	audioFile := writeE2EAudioFile(t)
+	// File sets text format and an unroutable model; both should apply over defaults
+	fileConf := `{"transcribe": {"model": "or:some/model", "output-format": "text", "parallelism": 2}}`
+	if err := os.WriteFile(filepath.Join(confDir, "audioConfig.json"), []byte(fileConf), 0o644); err != nil {
+		t.Fatalf("WriteFile(audioConfig.json): %v", err)
+	}
+
+	t.Run("file beats default", func(t *testing.T) {
+		// -am test routes to mock; format text comes from the file (default vtt)
+		status, stdout, _ := runAudio(t, "-am test a t "+audioFile)
+		testboil.FailTestIfDiff(t, status, 0)
+		testboil.FailTestIfDiff(t, stdout, wantMockText)
+	})
+	t.Run("flag beats file", func(t *testing.T) {
+		status, stdout, _ := runAudio(t, "-am test -af json a t "+audioFile)
+		testboil.FailTestIfDiff(t, status, 0)
+		testboil.AssertStringContains(t, stdout, `"start":`)
+		if strings.Contains(stdout, "WEBVTT") {
+			t.Errorf("expected json output, got: %q", stdout)
+		}
+	})
+}
+
+func Test_goldenFile_AUDIO_corrupt_config(t *testing.T) {
+	confDir := setupMainTestConfigDir(t)
+	audioFile := writeE2EAudioFile(t)
+	if err := os.WriteFile(filepath.Join(confDir, "audioConfig.json"), []byte("{broken"), 0o644); err != nil {
+		t.Fatalf("WriteFile(audioConfig.json): %v", err)
+	}
+
+	status, _, stderr := runAudio(t, "-am test a t "+audioFile)
+
+	testboil.FailTestIfDiff(t, status, 1)
+	testboil.AssertStringContains(t, stderr, "audioConfig.json")
+}
+
+func Test_goldenFile_AUDIO_help_includes_audio(t *testing.T) {
+	_ = setupMainTestConfigDir(t)
+
+	status, stdout, _ := runAudio(t, "help")
+
+	testboil.FailTestIfDiff(t, status, 0)
+	testboil.AssertStringContains(t, stdout, "a|audio")
+	testboil.AssertStringContains(t, stdout, "-am")
+	testboil.AssertStringContains(t, stdout, "-af")
+	testboil.AssertStringContains(t, stdout, "-parallelism")
+}

--- a/main_tooling_audio_e2e_test.go
+++ b/main_tooling_audio_e2e_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/baalimago/go_away_boilerplate/pkg/testboil"
+)
+
+func writeAudioToolConfig(t *testing.T, confDir, model string) {
+	t.Helper()
+	conf := `{"transcribe": {"model": "` + model + `", "output-format": "vtt", "parallelism": 3}}`
+	if err := os.WriteFile(filepath.Join(confDir, "audioConfig.json"), []byte(conf), 0o644); err != nil {
+		t.Fatalf("WriteFile(audioConfig.json): %v", err)
+	}
+}
+
+func runAudioTool(t *testing.T, confDir, model, args string) (int, string, string) {
+	t.Helper()
+	oldArgs := os.Args
+	t.Cleanup(func() { os.Args = oldArgs })
+	writeAudioToolConfig(t, confDir, model)
+	var status int
+	stdout, stderr := captureStdoutStderr(t, func() {
+		status = run(strings.Split(args, " "))
+	})
+	return status, stdout, stderr
+}
+
+func Test_e2e_audio_transcribe_tool_returns_transcript(t *testing.T) {
+	confDir := setupMainTestConfigDir(t)
+	audioFile := writeE2EAudioFile(t)
+	t.Setenv("CLAI_MOCK_AUDIO_TRANSCRIBE_FILE", audioFile)
+
+	status, stdout, stderr := runAudioTool(t, confDir, "test",
+		"-r -cm mock_test -t=audio_transcribe q tool_audio_transcribe")
+
+	if status != 0 {
+		t.Fatalf("expected success, got %d stdout=%q stderr=%q", status, stdout, stderr)
+	}
+	combined := stdout + stderr
+	testboil.AssertStringContains(t, combined, "mock transcription")
+	// Tool default is text, not the config file's vtt: no VTT framing in model context
+	if strings.Contains(combined, "WEBVTT") {
+		t.Errorf("expected text default for tool calls, got VTT: %q", combined)
+	}
+	if strings.HasPrefix(stdout, "WEBVTT") {
+		t.Errorf("transcript must not be written raw to process stdout: %q", stdout)
+	}
+}
+
+func Test_e2e_audio_transcribe_tool_vtt_format(t *testing.T) {
+	confDir := setupMainTestConfigDir(t)
+	audioFile := writeE2EAudioFile(t)
+	t.Setenv("CLAI_MOCK_AUDIO_TRANSCRIBE_FILE", audioFile)
+	t.Setenv("CLAI_MOCK_AUDIO_TRANSCRIBE_FORMAT", "vtt")
+
+	status, stdout, stderr := runAudioTool(t, confDir, "test",
+		"-r -cm mock_test -t=audio_transcribe q tool_audio_transcribe")
+
+	if status != 0 {
+		t.Fatalf("expected success, got %d stdout=%q stderr=%q", status, stdout, stderr)
+	}
+	testboil.AssertStringContains(t, stdout+stderr, "WEBVTT")
+}
+
+func Test_e2e_audio_transcribe_tool_diarized_text_keeps_speakers(t *testing.T) {
+	confDir := setupMainTestConfigDir(t)
+	audioFile := writeE2EAudioFile(t)
+	t.Setenv("CLAI_MOCK_AUDIO_TRANSCRIBE_FILE", audioFile)
+
+	status, stdout, stderr := runAudioTool(t, confDir, "test-diarize",
+		"-r -cm mock_test -t=audio_transcribe q tool_audio_transcribe")
+
+	if status != 0 {
+		t.Fatalf("expected success, got %d stdout=%q stderr=%q", status, stdout, stderr)
+	}
+	testboil.AssertStringContains(t, stdout+stderr, "A: mock transcription")
+}
+
+func Test_e2e_audio_transcribe_tool_listing(t *testing.T) {
+	_ = setupMainTestConfigDir(t)
+
+	t.Run("tools listing includes audio_transcribe", func(t *testing.T) {
+		status, stdout, _ := runAudio(t, "tools")
+		testboil.FailTestIfDiff(t, status, 0)
+		testboil.AssertStringContains(t, stdout, "audio_transcribe")
+	})
+	t.Run("detail view prints schema", func(t *testing.T) {
+		status, stdout, _ := runAudio(t, "tools audio_transcribe")
+		testboil.FailTestIfDiff(t, status, 0)
+		testboil.AssertStringContains(t, stdout, "file_path")
+		testboil.AssertStringContains(t, stdout, "output_format")
+	})
+}
+
+func Test_e2e_audio_transcribe_tool_not_selected(t *testing.T) {
+	confDir := setupMainTestConfigDir(t)
+	audioFile := writeE2EAudioFile(t)
+	t.Setenv("CLAI_MOCK_AUDIO_TRANSCRIBE_FILE", audioFile)
+
+	status, stdout, stderr := runAudioTool(t, confDir, "test",
+		"-r -cm mock_test -t=website_text q tool_audio_transcribe")
+
+	if status != 0 {
+		t.Fatalf("expected success, got %d stdout=%q stderr=%q", status, stdout, stderr)
+	}
+	if strings.Contains(stdout+stderr, "mock transcription") {
+		t.Errorf("tool must not be invocable when not selected, got: %q", stdout+stderr)
+	}
+}
+
+func Test_e2e_audio_transcribe_tool_errors_keep_query_alive(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		confDir := setupMainTestConfigDir(t)
+		t.Setenv("CLAI_MOCK_AUDIO_TRANSCRIBE_FILE", filepath.Join(t.TempDir(), "gone.wav"))
+
+		status, stdout, stderr := runAudioTool(t, confDir, "test",
+			"-r -cm mock_test -t=audio_transcribe q tool_audio_transcribe")
+
+		if status != 0 {
+			t.Fatalf("expected query loop to continue, got %d stdout=%q stderr=%q", status, stdout, stderr)
+		}
+		testboil.AssertStringContains(t, stdout+stderr, "gone.wav")
+	})
+	t.Run("invalid output format", func(t *testing.T) {
+		confDir := setupMainTestConfigDir(t)
+		audioFile := writeE2EAudioFile(t)
+		t.Setenv("CLAI_MOCK_AUDIO_TRANSCRIBE_FILE", audioFile)
+		t.Setenv("CLAI_MOCK_AUDIO_TRANSCRIBE_FORMAT", "yaml")
+
+		status, stdout, stderr := runAudioTool(t, confDir, "test",
+			"-r -cm mock_test -t=audio_transcribe q tool_audio_transcribe")
+
+		if status != 0 {
+			t.Fatalf("expected query loop to continue, got %d stdout=%q stderr=%q", status, stdout, stderr)
+		}
+		testboil.AssertStringContains(t, stdout+stderr, "vtt")
+	})
+	t.Run("engine failure surfaces cause without process exit", func(t *testing.T) {
+		confDir := setupMainTestConfigDir(t)
+		audioFile := writeE2EAudioFile(t)
+		t.Setenv("CLAI_MOCK_AUDIO_TRANSCRIBE_FILE", audioFile)
+		// Unroutable model in config makes the engine fail inside the tool call
+		status, stdout, stderr := runAudioTool(t, confDir, "unroutable9000",
+			"-r -cm mock_test -t=audio_transcribe q tool_audio_transcribe")
+
+		if status != 0 {
+			t.Fatalf("expected query loop to continue, got %d stdout=%q stderr=%q", status, stdout, stderr)
+		}
+		testboil.AssertStringContains(t, stdout+stderr, "unroutable9000")
+	})
+}

--- a/pkg/tools/audio_tool_transcribe.go
+++ b/pkg/tools/audio_tool_transcribe.go
@@ -1,0 +1,59 @@
+package tools
+
+import (
+	"fmt"
+
+	pub_models "github.com/baalimago/clai/pkg/text/models"
+)
+
+type AudioTranscribeTool pub_models.Specification
+
+var audioTranscribeFormats = []string{"text", "vtt", "srt", "json"}
+
+var AudioTranscribe = AudioTranscribeTool{
+	Name:        "audio_transcribe",
+	Description: "Transcribe a local audio file to text. Returns the transcript; timestamps and speaker labels are included for output formats that carry them. Default output_format is 'text'.",
+	Inputs: &pub_models.InputSchema{
+		Type: "object",
+		Properties: map[string]pub_models.ParameterObject{
+			"file_path": {
+				Type:        "string",
+				Description: "Path to the local audio file to transcribe.",
+			},
+			"output_format": {
+				Type:        "string",
+				Description: "Transcript output format. Default is 'text'.",
+				Enum:        &audioTranscribeFormats,
+			},
+		},
+		Required: []string{"file_path"},
+	},
+}
+
+// AudioTranscribeEngine is injected by the clai runtime (mode-as-tool bridge):
+// the tool layer holds no transcription logic and pkg/tools stays free of
+// engine dependencies.
+var AudioTranscribeEngine func(filePath, outputFormat string) (string, error)
+
+func (a AudioTranscribeTool) Call(input pub_models.Input) (string, error) {
+	filePath, ok := input["file_path"].(string)
+	if !ok || filePath == "" {
+		return "", fmt.Errorf("file_path must be a non-empty string")
+	}
+	outputFormat := "text"
+	if raw, exists := input["output_format"]; exists {
+		formatStr, ok := raw.(string)
+		if !ok {
+			return "", fmt.Errorf("output_format must be a string, one of: %v", audioTranscribeFormats)
+		}
+		outputFormat = formatStr
+	}
+	if AudioTranscribeEngine == nil {
+		return "", fmt.Errorf("audio transcription engine is not wired into this runtime")
+	}
+	return AudioTranscribeEngine(filePath, outputFormat)
+}
+
+func (a AudioTranscribeTool) Specification() pub_models.Specification {
+	return pub_models.Specification(a)
+}

--- a/pkg/tools/audio_tool_transcribe_test.go
+++ b/pkg/tools/audio_tool_transcribe_test.go
@@ -1,0 +1,99 @@
+package tools
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	pub_models "github.com/baalimago/clai/pkg/text/models"
+)
+
+func withFakeEngine(t *testing.T, engine func(filePath, outputFormat string) (string, error)) {
+	t.Helper()
+	orig := AudioTranscribeEngine
+	AudioTranscribeEngine = engine
+	t.Cleanup(func() { AudioTranscribeEngine = orig })
+}
+
+func TestAudioTranscribe_Specification(t *testing.T) {
+	spec := AudioTranscribe.Specification()
+	if spec.Name != "audio_transcribe" {
+		t.Errorf("expected name audio_transcribe, got: %v", spec.Name)
+	}
+	if len(spec.Inputs.Required) != 1 || spec.Inputs.Required[0] != "file_path" {
+		t.Errorf("expected file_path required, got: %v", spec.Inputs.Required)
+	}
+	format, ok := spec.Inputs.Properties["output_format"]
+	if !ok {
+		t.Fatal("expected output_format property")
+	}
+	if format.Enum == nil || len(*format.Enum) != 4 {
+		t.Errorf("expected 4-value output_format enum, got: %v", format.Enum)
+	}
+}
+
+func TestAudioTranscribe_Call(t *testing.T) {
+	t.Run("passes file path and defaults format to text", func(t *testing.T) {
+		var gotPath, gotFormat string
+		withFakeEngine(t, func(filePath, outputFormat string) (string, error) {
+			gotPath, gotFormat = filePath, outputFormat
+			return "the transcript", nil
+		})
+		got, err := AudioTranscribe.Call(pub_models.Input{"file_path": "f.wav"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "the transcript" {
+			t.Errorf("expected engine result returned, got: %q", got)
+		}
+		if gotPath != "f.wav" || gotFormat != "text" {
+			t.Errorf("expected f.wav/text, got: %q/%q", gotPath, gotFormat)
+		}
+	})
+	t.Run("forwards explicit output_format", func(t *testing.T) {
+		var gotFormat string
+		withFakeEngine(t, func(_, outputFormat string) (string, error) {
+			gotFormat = outputFormat
+			return "", nil
+		})
+		if _, err := AudioTranscribe.Call(pub_models.Input{"file_path": "f.wav", "output_format": "vtt"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gotFormat != "vtt" {
+			t.Errorf("expected vtt, got: %q", gotFormat)
+		}
+	})
+	t.Run("missing file_path errors", func(t *testing.T) {
+		withFakeEngine(t, func(_, _ string) (string, error) { return "", nil })
+		_, err := AudioTranscribe.Call(pub_models.Input{})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "file_path") {
+			t.Errorf("expected file_path in error, got: %v", err)
+		}
+	})
+	t.Run("non-string output_format errors", func(t *testing.T) {
+		withFakeEngine(t, func(_, _ string) (string, error) { return "", nil })
+		_, err := AudioTranscribe.Call(pub_models.Input{"file_path": "f.wav", "output_format": 7})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+	t.Run("engine errors propagate as tool errors", func(t *testing.T) {
+		withFakeEngine(t, func(_, _ string) (string, error) {
+			return "", errors.New("vendor exploded")
+		})
+		_, err := AudioTranscribe.Call(pub_models.Input{"file_path": "f.wav"})
+		if err == nil || !strings.Contains(err.Error(), "vendor exploded") {
+			t.Errorf("expected engine error propagated, got: %v", err)
+		}
+	})
+	t.Run("unwired engine yields clear error", func(t *testing.T) {
+		withFakeEngine(t, nil)
+		_, err := AudioTranscribe.Call(pub_models.Input{"file_path": "f.wav"})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}

--- a/worklogs/2026-08-26-audio-transcription-design/README.md
+++ b/worklogs/2026-08-26-audio-transcription-design/README.md
@@ -1,0 +1,125 @@
+# Worklog: `clai audio` — transcription
+
+Effort started: 2026-08-26. Repo: clai, branch `feat-audio-processing`.
+
+## Status board
+
+| Phase | File                                                                     | Status              | Summary                                                                                               |
+| ----- | ------------------------------------------------------------------------ | ------------------- | ----------------------------------------------------------------------------------------------------- |
+| 1     | [phase-1-segments-and-renderers.md](./phase-1-segments-and-renderers.md) | Complete            | Segment model, wire-format normalization, vtt/srt/text/json renderers                                 |
+| 2     | [phase-2-generic-transcriber.md](./phase-2-generic-transcriber.md)       | Complete            | OpenAI-protocol multipart transcriber + openai/openrouter vendor structs; F1-01 fixed (diarize `chunking_strategy`) |
+| 3     | [phase-3-ffmpeg-split-stitch.md](./phase-3-ffmpeg-split-stitch.md)       | Complete            | Best-effort ffmpeg chunking, parallel transcription, offset stitching                                 |
+| 4     | [phase-4-mode-wiring.md](./phase-4-mode-wiring.md)                       | Complete    | `audio transcribe` subcommand, config, flags, routing; R1-01 fixed (stdin `-` extension sniffed) |
+| 5     | [phase-5-audio-transcribe-tool.md](./phase-5-audio-transcribe-tool.md)   | Complete            | `audio_transcribe` built-in tool as thin adapter over the same engine                                 |
+| 6     | [phase-6-docs-and-quality-gates.md](./phase-6-docs-and-quality-gates.md) | Complete            | `architecture/audio.md`, usage text, full QA sweep                                                    |
+
+Router: take the first incomplete or reopened phase; order is strict (each phase builds on the previous).
+
+## Severity taxonomy
+
+- **Critical** — wrong externally observable behavior, data loss, or a QA-gate violation. Reopens the phase.
+- **Major** — unmet contract row, missing error coverage, or missing test evidence. Reopens the phase.
+- **Minor** — style, naming, doc nits with no behavioral impact. Logged, does not reopen.
+
+## Strategy (shared invariants — read before any phase)
+
+- **Pipes stay clean:** stdout carries only the rendered transcript; every status/progress/warning line goes to stderr via `ancli`.
+- **Shared segment model** (defined in phase 1, consumed by all later phases):
+
+  ```go
+  // internal/audio package
+  type Segment struct {
+      Start   time.Duration
+      End     time.Duration
+      Speaker string // "" when model does not diarize
+      Text    string
+  }
+  ```
+
+  All vendor payloads normalize into `[]Segment`; all output formats render from it; chunk stitching offsets it. No later phase parses vendor JSON or emits vtt/srt directly.
+
+  `Segment` is never marshaled directly for output — `time.Duration` would emit nanosecond ints. The `json` output format renders through a render-time DTO with `start`/`end` as **float seconds** (`{"start": 5.28, "end": 9.04, "speaker": "A", "text": "…"}`, `speaker` omitted when empty); defined in phase 1.
+
+- **Response-format negotiation:** always request the richest machine format the endpoint supports — `diarized_json` when the model name contains `diarize`, else `verbose_json`. Never request `text`/`srt`/`vtt` from a vendor (OpenRouter 400s on them); those are local renderings.
+- **Default output format is `vtt`** (`text|srt|json` selectable). Speaker labels render as WebVTT voice tags `<v A>` / SRT `A: ` prefixes.
+- **Vendor pattern mirrors text:** generic engine in `internal/audio/generic/`, thin vendor structs in `internal/vendors/{openai,openrouter}/` embedding it (env key + URL + prefix-trim in `Setup()`), explicit routing in `internal/create_queriers.go` (`or:` prefix → OpenRouter; `whisper`/`transcribe` substring → OpenAI). Vendor-specific logic never leaks into `internal/audio/` or `internal/audio/generic/`.
+- **File extensions are part of the transcription contract** (elevated by review 1, root cause of R1-01): the vendor infers upload format from the multipart filename and ffmpeg infers the chunk container from the output pattern's extension. Any code path that synthesizes a file the engine will touch (stdin temp files, chunk files, future tool-written files) must give it a real audio extension and thread that extension to every consumer (multipart part name, chunk pattern, error-message hints).
+- **External binaries are best-effort and loud:** ffmpeg/ffprobe are optional prerequisites invoked through an injected command-runner (testable without ffmpeg installed); their use is announced on stderr, their absence produces an actionable error, never silent degradation.
+- **Repo QA gates apply to every phase:** `make qa` — gofumpt, staticcheck, `go vet`, `go test ./... -race -cover -count=3 -timeout=30s`, `go fix`, dupl. New code needs 70%+ coverage, 90%+ preferred. Tests first, implementation second. No new third-party dependencies.
+
+## Design decisions (agreed 2026-08-26, design session with Lorentz)
+
+1. **No audio capture in clai.** Files only; recording stays in userland (`pw-record`, ffmpeg, OBS).
+2. **Two surfaces, one engine.** Subcommand `clai audio transcribe <file>` (aliases `a t`; chat-style noun namespace, room for `audio generate` etc.) plus built-in tool `audio_transcribe` as a thin adapter over the same querier.
+3. **Generic mode-as-tool bridge, shaped not built.** Any querier mode can become a tool later (`image_generate`, `video_generate` return file paths by reference; transcribe returns text). Ship only `audio_transcribe`; generalize on the second consumer. Tool naming: `<modality>_<verb>`, verbs describe actual capability (`audio_load` rejected — reserved for true multimodal attachment).
+4. **Normalize inside, render locally.** Forced by per-provider `response_format` fragmentation (survey below).
+5. **Long files: best-effort ffmpeg split** (OpenAI cap 25 MB; 1 h meetings exceed it). Fixed-duration chunks, no overlap, chunk-relative timestamps offset and stitched locally, bounded parallel requests (`parallelism`, default 3).
+6. **Vendors: OpenAI + OpenRouter first** via one generic OpenAI-protocol client; default model `whisper-1` (expected to rotate; single config field). HF ASR = future third implementation (divergent protocol).
+
+### Protocol survey (2026-08)
+
+| Surface                            | text             | srt/vtt | verbose_json | diarized_json |
+| ---------------------------------- | ---------------- | ------- | ------------ | ------------- |
+| OpenAI `whisper-1`                 | ✓                | ✓       | ✓ (+word ts) | —             |
+| OpenAI `gpt-4o-transcribe`         | ✓                | —       | —            | —             |
+| OpenAI `gpt-4o-transcribe-diarize` | —                | —       | —            | ✓             |
+| OpenRouter `/audio/transcriptions` | 400!             | 400!    | ✓            | —             |
+| HuggingFace ASR task API           | own chunked JSON |         |              |               |
+
+- OpenAI multipart `/v1/audio/transcriptions` is the de facto standard; OpenRouter's endpoint (2026-07-22) is compatible (multipart or base64 `input_audio` JSON) but rejects `text`/`srt`/`vtt` with 400.
+- HF's OpenAI-compatible router is chat-only; ASR uses HF's own task API.
+- Diarization: `gpt-4o-transcribe-diarize` → `diarized_json`, labels `A:`/`B:`; up to 4 reference clips via `known_speaker_names[]`/`known_speaker_references[]`.
+
+### Accepted trade-offs
+
+- **Diarize label drift across chunks:** labels are per-request; chunk 1's "A" ≠ chunk 2's "A". Mitigate with identical `known_speaker_references[]` per chunk; warn when diarize meets a split file (phase 3).
+- **Parallelism forfeits whisper `prompt` conditioning** (sequential-only); `parallelism: 1` could re-enable later.
+- **Chunk-boundary word clipping** with no-overlap splits; overlap/dedup deferred.
+
+## Target user story
+
+```bash
+clai a t meeting.wav | clai -p meetingnotes q "File these meeting notes: {}"
+# or agentically:
+clai -t "*" q "Transcribe meeting.wav and file the meeting notes"
+```
+
+## Session journal
+
+- **2026-08-26 (Claude, design session):** Q&A design with Lorentz (decisions above), protocol survey via web research, worklog structured into phases. No implementation yet.
+- **2026-08-26 (Claude, worklog validation):** Pre-implementation validation. All repo references verified sound. Findings V1-01…V1-05 filed and resolved in place (see feedback index). Verdict after fixes: ready.
+- **2026-08-26 (Claude, phase 1 implementation):** `internal/audio/` created: `Segment`, `ParseVerboseJSON`/`ParseDiarizedJSON`, `Offset`, `Render` (vtt/srt/text/json), `ParseOutputFormat`. Doc-derived fixtures (no live keys). 98.4 % coverage, full `make qa` green. Deltas: text trimmed at parse, ms-precision durations. Phase 1 Complete.
+- **2026-08-26 (Claude, phase 2 implementation):** `internal/audio/generic/Transcriber` (streamed multipart POST, format negotiation, ctx-aware) + `openai.TranscriberDefault`/`openrouter.TranscriberDefault` vendor structs. All contract rows tested against `httptest.Server`. `make qa` green (one pre-existing `anthropic/Test_context` flake under full-suite load, passes isolated). Phase 2 Complete.
+- **2026-08-26 (Claude, phase 3 implementation):** `audio.Splitter` + `ExecRunner`/`CommandRunner` seam: size gate, ffmpeg/ffprobe hard-require on split path, plan-offset stitching, bounded pool with ctx-cancel, drift + diarize warnings on injected stderr writer. All contract rows faked, 93.2 % package coverage, `make qa` green. Phase 3 Complete.
+- **2026-08-26 (Claude, phase 4 implementation):** `clai audio transcribe` / `a t` wired end to end: `AUDIO` mode + verb dispatch (`internal/setup_audio.go`), `audioConfig.json` (united migration + defaults), `-am/-af/-parallelism` flags, `CreateAudioQuerier` routing (or:→openrouter, whisper|transcribe→openai, test→mock), stdin `-` input, completion registry, usage text. 11 e2e tests + routing/input/override units. `make qa` green. Phase 4 Complete.
+- **2026-08-26 (Claude, phase 5 implementation):** `audio_transcribe` built-in tool: schema in `pkg/tools` with injected engine func (wired from `internal` init), registered in the tool registry, mock-vendor inputs via `CLAI_MOCK_AUDIO_TRANSCRIBE_*`. Routing shared with the subcommand via `createAudioSplitter`; mock gained diarize labels (`test-diarize`). 6 tooling e2e tests + adapter units, `make qa` green. Phase 5 Complete.
+- **2026-08-26 (Claude, phase 6 implementation):** `architecture/audio.md` + index row, `examples.md` audio section, usage pipe example, setup wizard "model files" exclusion for audioConfig (general-config listing already covered it via `*Config.json` glob). Final sweep: `make qa` exit 0 on branch tip, coverage audit recorded (internal/audio 91.6 %). Phase 6 Complete — **effort done, all phases Complete**.
+- **2026-08-26 (Claude, review 1):** Independent code review of all six phases. Gates re-run on the branch tip: `make qa` → exit 0 (38 `ok` package lines of 40 packages, 2 without tests — phase 6 notes said 39, trivial count discrepancy, nothing failed). All acceptance criteria, contract rows, and error rows re-traced against the code and tests, not the notes; shared invariants (pipes clean, negotiation, temp cleanup, ctx-cancel, bounded pool) verified branch-by-branch — details in each phase's "Review findings (review 1)" section. Three findings: **R1-01 (Major, phase 4 reopened)** — stdin `-` creates an extensionless temp file; the ffmpeg split path is confirmed broken for it by live reproduction (the chunk pattern inherits the empty extension and the segment muxer errors), and the OpenAI multipart filename likely fails vendor format detection — the `-` contract row is only proven against the mock. **R1-02 (Minor, phase 3)** — ≥1000-chunk inputs stitch out of order (lexical glob vs `%03d` overflow), ~20 GB to trigger. **R1-03 (Minor, phase 2)** — the promised diarize `known_speaker_references[]` follow-up note never landed anywhere. New cross-phase invariant elevated to Strategy: file extensions are part of the transcription contract. **Verdict: ships clean through the gates, but not ready** — the advertised stdin flow fails at the real boundary; phase 4 reopened to fix R1-01, minors logged without reopening.
+- **2026-08-26 (Claude, R1-01 fix):** Phase 4 reopened→Complete. Stdin `-` container is now sniffed from the first 12 bytes (`audio.DetectExtension`, pure Go — no ffprobe dependency, keeping external binaries best-effort) and the temp file named `clai-audio-stdin-*.<ext>`; unrecognized bytes fail pre-flight listing the recognized formats (wav/mp3/flac/ogg/m4a/mp4/webm — exactly OpenAI's accepted set), before any temp file exists. Chunk pattern and manual-split hint inherit the extension untouched. Seam proven both sides: `internal.TestStdinMultipartFilename` asserts the vendor-visible multipart filename through the real `generic.Transcriber` against `httptest`, and the R1-01 ffmpeg reproduction re-run with the fixed naming splits cleanly. Magic table validated against real ffmpeg-generated files of all seven containers. New e2e for the unrecognized-stdin error path; stdin fixtures upgraded to real RIFF/WAVE magic. `DetectExtension` 100 % covered, `make qa` exit 0. **All phases Complete again — ready for re-review.**
+- **2026-08-26 (Claude, F1-01 field fix):** Lorentz's first live diarize run 400'd: OpenAI requires `chunking_strategy` for diarization models, which the protocol survey missed and no fixture asserted. Phase 2 reopened→Complete in-session: failing test first (`TestTranscribe_DiarizedModel` now asserts `chunking_strategy=auto`; `TestTranscribe_VerboseJSON` pins its absence for non-diarize), then `writeMultipart` sends the field iff `diarized_json` is negotiated — keyed to the format, not a vendor, so the generic layer stays vendor-agnostic. Contract row updated; `make qa` exit 0.
+
+## Feedback index
+
+Pre-implementation validation round (2026-08-26), all resolved by spec edits:
+
+| ID    | Severity | Phase | Finding                                                                                                      | Resolution                                                                                    |
+| ----- | -------- | ----- | ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| V1-01 | Major    | 1     | `json` render contradicted README struct tags (ns ints vs float seconds); no acceptance criterion for `json` | Render-time DTO with float seconds; struct tags dropped; criterion added                      |
+| V1-02 | Minor    | 1     | `testdata/` fixtures nonexistent, no acquisition procedure for "real" payloads                               | Provenance rule: live capture when keys available, else doc-derived; source cited per fixture |
+| V1-03 | Minor    | 3     | `segment_time` needed total duration but ffprobe was optional                                                | ffprobe now a hard requirement on the split path; formula pinned                              |
+| V1-04 | Note     | 1     | Empty render pinned only for vtt/text                                                                        | srt → empty string, json → `[]` added                                                         |
+| V1-05 | Note     | 5     | Tool schema sketch could be transcribed literally                                                            | Marked illustrative; encode in `internal/tools` schema types                                  |
+
+Review 1 (2026-08-26, post-implementation code review):
+
+| ID    | Severity | Phase                                 | Finding                                                                                                                                                                                   | Status                  |
+| ----- | -------- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| R1-01 | Major    | [4](./phase-4-mode-wiring.md)         | stdin `-` temp file has no extension → ffmpeg split confirmed broken (chunk pattern inherits empty ext), vendor multipart filename likely rejected; `-` flow proven only against the mock | Resolved 2026-08-26 — container magic sniffed into temp-file extension; multipart seam + ffmpeg pattern proven |
+| R1-02 | Minor    | [3](./phase-3-ffmpeg-split-stitch.md) | ≥1000 chunks stitch out of order: `chunk_%03d` overflow vs lexical glob sort (~20 GB input)                                                                                               | Logged, does not reopen |
+| R1-03 | Minor    | [2](./phase-2-generic-transcriber.md) | Deferred diarize `known_speaker_names/references` follow-up was never noted in phase 4+ or docs; README's drift mitigation has no landing place                                           | Logged, does not reopen |
+
+Field reports (2026-08-26, live usage after review 1):
+
+| ID    | Severity | Phase                                 | Finding                                                                                                                                        | Status                                                                          |
+| ----- | -------- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| F1-01 | Major    | [2](./phase-2-generic-transcriber.md) | Live diarize request 400s: OpenAI requires `chunking_strategy` for diarization models; transcriber never sent it, no test asserted the field | Resolved 2026-08-26 — `chunking_strategy=auto` sent iff `diarized_json` negotiated |

--- a/worklogs/2026-08-26-audio-transcription-design/phase-1-segments-and-renderers.md
+++ b/worklogs/2026-08-26-audio-transcription-design/phase-1-segments-and-renderers.md
@@ -1,0 +1,78 @@
+# Phase 1: Segment model, normalization, renderers
+
+**Status:** Complete
+[← README](./README.md)
+
+## Goal
+
+Establish the vendor-agnostic `Segment` model with pure functions that normalize vendor wire payloads into it and render it to `vtt|srt|text|json`.
+
+## Specification
+
+New package `internal/audio/` (no HTTP, no exec — pure functions only):
+
+- `Segment` struct as defined in the README strategy.
+- `ParseVerboseJSON([]byte) ([]Segment, error)` — OpenAI/OpenRouter `verbose_json` payload (`segments[].{start,end,text}`, float seconds → `time.Duration`). Word-level granularity is ignored in this phase (segment granularity only).
+- `ParseDiarizedJSON([]byte) ([]Segment, error)` — `gpt-4o-transcribe-diarize` `diarized_json` payload (`segments[].{speaker,start,end,text}`); `speaker` mapped to `Segment.Speaker`.
+- `Offset(segs []Segment, delta time.Duration) []Segment` — shifts all timestamps; used by phase 3 stitching.
+- `Render(segs []Segment, format OutputFormat) (string, error)` with `OutputFormat ∈ {vtt, srt, text, json}`:
+  - `vtt`: valid WebVTT — `WEBVTT` header, `HH:MM:SS.mmm --> HH:MM:SS.mmm` cues, `<v X>text</v>` when `Speaker != ""`.
+  - `srt`: 1-based numbered cues, `HH:MM:SS,mmm` comma separator, `X: text` prefix when `Speaker != ""`.
+  - `text`: plain concatenated text, one segment per line, speaker prefix `X: ` when present; no timestamps.
+  - `json`: rendered via a render-time DTO — `[{"start": <float seconds>, "end": <float seconds>, "speaker": "<label, omitted when empty>", "text": "…"}]`. `[]Segment` is never marshaled directly (`time.Duration` would emit nanosecond ints; float seconds is the wire contract for tool/script consumption).
+- `ParseOutputFormat(string) (OutputFormat, error)` for flag/config validation.
+
+Timestamps are `time.Duration` internally (per repo convention: no formatted-string storage); formatting happens only at render time.
+
+## Integration contract
+
+`unit-test-only` — this phase has no external boundary. Table-driven tests over payload fixtures (OpenAI verbose_json, OpenRouter verbose_json, diarized_json) checked into `testdata/`.
+
+**Fixture provenance:** live API captures when keys are available, otherwise fixtures authored from the vendor docs / README protocol survey are acceptable. Every fixture file cites its source (API capture date+model, or doc URL) in a `testdata/README.md` line.
+
+## Acceptance criteria
+
+- [x] `ParseVerboseJSON` round-trips a real whisper-1 `verbose_json` fixture into correct `[]Segment` (start/end/text verified against fixture values). — `TestParseVerboseJSON_Whisper1Fixture`, `TestParseVerboseJSON_OpenRouterFixture`
+- [x] `ParseDiarizedJSON` preserves speaker labels from a diarized fixture. — `TestParseDiarizedJSON_PreservesSpeakers`
+- [x] `Render` produces spec-valid VTT (header, arrow syntax, dot millis) and SRT (index, comma millis) for the same input, including voice tags/prefixes when speakers are present and their absence when not. — `TestRender` (cases `vtt/srt with/without speakers`, exact-string assertions)
+- [x] `Offset` shifts start and end uniformly and is a no-op at delta 0. — `TestOffset` (also asserts input not mutated)
+- [x] `text` render of a diarized fixture reads `A: …` lines; of a non-diarized fixture, bare lines. — `TestRender` (cases `text with/without speakers`)
+- [x] `json` render yields `start`/`end` as float seconds (test asserts a known value, e.g. `5.28`, from the fixture) and omits `speaker` when empty; no nanosecond integers anywhere in the output. — `TestRender` (json cases, exact-string), `TestRenderJSON_FloatSecondsContract`
+- [x] Package coverage ≥ 90 % (`go test -cover`). — 98.4 % (`go test ./internal/audio/ -race -cover -count=3 -timeout=30s`)
+
+## Error coverage
+
+| Failure condition | Expected outcome | Test |
+| ----------------- | ---------------- | ---- |
+| Malformed JSON payload | wrapped parse error naming the format | `TestParse_MalformedJSON` |
+| Valid JSON, missing `segments` field | error, not empty success | `TestParse_MissingSegmentsField` |
+| Empty `segments` array | `[]Segment{}`, no error; `Render` yields valid empty document per format: vtt → `WEBVTT` header only, srt → empty string, text → empty string, json → `[]` | `TestParse_EmptySegmentsArray`, `TestRenderEmpty` |
+| Unknown output format string | `ParseOutputFormat` error listing valid values | `TestParseOutputFormat` (also `TestRenderUnknownFormat` for `Render`) |
+| Negative or end<start timestamps in payload | segments passed through unaltered (garbage-in tolerated), render does not panic | `TestRenderGarbageTimestampsDoesNotPanic` |
+
+## Implementation notes
+
+**Session:** Claude, 2026-08-26. Files: `internal/audio/audio.go`, `internal/audio/audio_test.go`, `internal/audio/testdata/`.
+
+Deltas from spec:
+
+- **Text trimmed at parse time.** whisper-1 emits segment text with a leading space (`" Hello …"`); `ParseVerboseJSON`/`ParseDiarizedJSON` apply `strings.TrimSpace` so renders don't carry stray whitespace. Tests assert the trimmed values.
+- **Millisecond precision pinned at parse.** Float seconds → `time.Duration` rounds to whole milliseconds (`math.Round(s*1000)`), matching subtitle timestamp resolution and keeping the json render's float seconds free of float-noise (`5.28`, never `5.279999…`).
+- **Missing vs. empty `segments`** distinguished via a `*[]wireSegment` field: absent key → error, `[]` → empty success.
+- **No live API keys** during this session; all fixtures are doc-derived per the provenance rule, cited in `testdata/README.md`.
+- **dupl** flagged the initial per-format render tests as three structural clones; consolidated into one table-driven `TestRender`, dupl now clean for the package.
+
+Verification (all green):
+
+- `go test ./internal/audio/ -race -cover -count=3 -timeout=30s` → ok, **98.4 %** coverage
+- `make qa` (full sweep) → pass; gofumpt/staticcheck/vet/fix clean, no dupl clones in `internal/audio`
+
+## Review findings (review 1, 2026-08-26)
+
+No findings. Verified good: all seven acceptance criteria and five error rows
+re-traced against `audio.go`/`audio_test.go` — the missing-vs-empty
+`segments` distinction (`*[]wireSegment`), ms-precision rounding, float-second
+json DTO (no nanosecond ints reachable: `Segment` has no marshal path in
+`Render`), empty-document renders per format, and negative-timestamp
+formatting (`formatTimestamp` sign handling) all hold. Fixture provenance is
+recorded in `testdata/README.md` per the V1-02 resolution.

--- a/worklogs/2026-08-26-audio-transcription-design/phase-2-generic-transcriber.md
+++ b/worklogs/2026-08-26-audio-transcription-design/phase-2-generic-transcriber.md
@@ -1,0 +1,119 @@
+# Phase 2: Generic transcriber + vendor structs
+
+**Status:** Complete
+[← README](./README.md)
+
+## Goal
+
+Implement the OpenAI-protocol multipart transcription client once in `internal/audio/generic/` and expose it through thin `openai` and `openrouter` vendor structs, mirroring `generic.StreamCompleter`.
+
+## Specification
+
+- `internal/audio/generic/transcriber.go` — `Transcriber` struct:
+  - `Setup(apiKeyEnv, url, debugEnv string) error` — reads bearer token from env (same signature family as `StreamCompleter.Setup`), configurable endpoint URL, optional `ExtraHeaders`.
+  - `Transcribe(ctx context.Context, filePath string) ([]audio.Segment, error)` — multipart POST: `file` part (streamed from disk, not slurped), `model`, `response_format` per README negotiation rule (`diarized_json` iff model name contains `diarize`, else `verbose_json`). Parses via phase-1 functions. Respects ctx cancellation.
+  - Injected `*http.Client` (defaultable) so tests use `httptest.Server`.
+- `internal/vendors/openai/transcribe.go` — struct embedding `generic.Transcriber`; `Default` with model `whisper-1`, URL `https://api.openai.com/v1/audio/transcriptions`, key `OPENAI_API_KEY`.
+- `internal/vendors/openrouter/transcribe.go` — embeds the same; URL `https://openrouter.ai/api/v1/audio/transcriptions`, key `OPENROUTER_API_KEY`, trims `or:` model prefix in `Setup()`, sets the same `HTTP-Referer`/`X-OpenRouter-Title` headers as the chat vendor.
+- No vendor-specific behavior inside `internal/audio/generic/` (repo rule); differences live entirely in the vendor `Setup()`s.
+- Diarize extras (`known_speaker_names[]`/`known_speaker_references[]`) are **out of scope** for this phase; noted as a follow-up field on the config in phase 4 or later.
+
+## Integration contract
+
+| Scenario | Collaborators | Observable result | Required side effects | Prohibited side effects |
+| -------- | ------------- | ----------------- | --------------------- | ----------------------- |
+| whisper-1 model, valid audio file | `httptest.Server` asserting multipart fields | request has `response_format=verbose_json`, returns parsed `[]Segment` | Authorization: `Bearer <key>` header | no `text/srt/vtt` response_format ever sent |
+| model `gpt-4o-transcribe-diarize` | same | request has `response_format=diarized_json`; speakers populated | `chunking_strategy=auto` field sent (F1-01: OpenAI 400s diarize requests without it) | `chunking_strategy` on non-diarize requests |
+| OpenRouter vendor with model `or:openai/whisper-1` | same | `model` field sent without `or:` prefix | OpenRouter extra headers present | — |
+| large file (multi-MB fixture) | same | request body streamed (no full-file buffering assertion via io behavior) | — | file not read into memory as one slice |
+
+## Acceptance criteria
+
+- [x] Both vendor structs produce correct requests against `httptest.Server` (fields, headers, auth) — cited per contract row:
+  - whisper-1 + verbose_json + bearer auth: `generic.TestTranscribe_VerboseJSON`, `openai.TestTranscriber_Transcribe`
+  - diarize model → diarized_json + speakers: `generic.TestTranscribe_DiarizedModel`
+  - OpenRouter `or:` trim + extra headers: `openrouter.TestTranscriber_Transcribe_TrimsPrefixAndSendsHeaders`, `generic.TestTranscribe_ExtraHeaders`
+  - 3 MB file streamed (chunked, no Content-Length, byte-count equality): `generic.TestTranscribe_StreamsLargeFile`
+- [x] Response payloads flow through phase-1 parsers into `[]Segment` (fixture equality). — `generic.TestTranscribe_VerboseJSON` asserts full segment equality against the phase-1 fixture
+- [x] `create_queriers`-style routing decision is NOT in this phase (phase 4); package compiles standalone. — no changes outside `internal/audio/generic/` and the two vendor files
+- [x] Coverage ≥ 80 % for `internal/audio/generic/` and the two vendor files. — generic 81.2 % package coverage; `openai/transcribe.go` and `openrouter/transcribe.go` both 100 % (`go tool cover -func`)
+
+## Error coverage
+
+| Failure condition | Expected outcome | Test |
+| ----------------- | ---------------- | ---- |
+| API key env unset/empty | `Setup` error naming the env var | `generic.TestSetup_MissingAPIKey`, `openai.TestTranscriber_Setup_MissingKey`, `openrouter.TestTranscriber_Setup_MissingKey` |
+| Input file does not exist / unreadable | error before any HTTP request | `generic.TestTranscribe_FileMissing` (asserts zero server hits) |
+| Non-200 response | error including status and (truncated) body | `generic.TestTranscribe_Non200` |
+| 200 with malformed JSON body | wrapped phase-1 parse error | `generic.TestTranscribe_MalformedResponseBody` |
+| ctx cancelled mid-request | request aborts, `ctx.Err()`-wrapped error returned promptly | `generic.TestTranscribe_ContextCancelled` (`errors.Is(err, context.Canceled)`, <2 s abort) |
+
+## Implementation notes
+
+**Session:** Claude, 2026-08-26. Files: `internal/audio/generic/transcriber.go` + test, `internal/vendors/openai/transcribe.go` + test, `internal/vendors/openrouter/transcribe.go` + test.
+
+Deltas from spec:
+
+- **Client injection is a public `Client *http.Client` field** (defaulted in `Setup` when nil) instead of a private field, so vendor-package tests could inject too. In practice all tests override `URL` against `httptest.Server` with the default client, mirroring how chat vendor tests work.
+- **Streaming proven via chunked transfer:** the file part goes through `io.Pipe`, so the request has no Content-Length; `TestTranscribe_StreamsLargeFile` asserts `ContentLength <= 0` plus byte-count equality on a 3 MB file. That is the io-behavior assertion the contract row asked for — no full-file slurp is possible through a pipe.
+- **Vendor default vars named `TranscriberDefault`** (repo convention is `<Thing>Default`/`GptDefault`, not the spec's `Default`, which would collide within the packages).
+- **Debug output via `slog.Debug`**, not `ancli.PrintOK`: ancli OK/notice print to stdout, which would violate the pipes-stay-clean invariant.
+- One `make qa` run hit a pre-existing flake: `internal/vendors/anthropic` `Test_context` timed out at 30 s under full-suite load; passes in isolation (1.2 s, count=3) and on re-run of the full suite. Not related to this change.
+
+Verification (all green):
+
+- `go test ./internal/audio/... ./internal/vendors/openai/ ./internal/vendors/openrouter/ -race -cover -count=3 -timeout=30s` → ok; generic 81.2 %, openai 73.0 % (pkg), openrouter 57.1 % (pkg), transcribe files 100 %
+- `make qa` (full sweep) → exit 0
+
+## Review findings (review 1, 2026-08-26)
+
+Verified good (traced in the code, not from the notes):
+
+- All four integration-contract rows and five error rows re-read in
+  `generic/transcriber_test.go` and the two vendor tests: bearer auth, model
+  and `response_format` fields, `or:` trim, extra headers, and 3 MB
+  chunked-streaming (no Content-Length + byte-equality) are all genuinely
+  asserted against `httptest.Server`.
+- The negotiation invariant ("never request text/srt/vtt") holds by
+  construction: `responseFormat()` (`transcriber.go:53`) can only return
+  `verbose_json` or `diarized_json`.
+- ctx cancellation is honored on request creation, `Do`, and body read, with
+  `context.Canceled` preserved in the chain and a timing-bounded test.
+- The `io.Pipe` writer goroutine cannot leak: `CloseWithError` always runs,
+  and an aborted request drains via the pipe's error propagation.
+
+Findings:
+
+- [ ] **R1-03 (Minor, logged — does not reopen)** — the spec deferred diarize
+  extras with "noted as a follow-up field on the config in phase 4 or later",
+  but the note never landed: no phase-4 config field, no architecture-doc
+  mention, no worklog follow-up entry. Consequence: the README's accepted
+  trade-off for diarize label drift names `known_speaker_references[]` as the
+  mitigation, and that mitigation currently has no tracked landing place —
+  only the stderr warning exists. Record the follow-up (config-field sketch in
+  `architecture/audio.md` or a worklog note) so the promise is findable.
+
+Cross-reference: **R1-01** (filed in phase 4) has one sink in this phase's
+code — `transcriber.go:125` names the multipart part after the local file, so
+extensionless temp files likely fail OpenAI's filename-based format check.
+The fix is routed through phase 4 (temp-file naming); if instead fixed here,
+keep the vendor-agnostic rule: the generic layer must not special-case
+vendors.
+
+## Field findings (2026-08-26, live usage)
+
+**Session:** Claude, 2026-08-26, reported by Lorentz from a real
+`gpt-4o-transcribe-diarize` run. Phase reopened and closed in-session.
+
+- [x] **F1-01 (Major)** — diarize requests were rejected live with
+  `400: "chunking_strategy is required for diarization models"`. The
+  transcriber negotiated `diarized_json` but never sent `chunking_strategy`;
+  every diarize fixture/httptest passed because nothing asserted the field.
+  The protocol survey missed that the parameter is mandatory for diarize
+  models. **Fix:** `writeMultipart` sends `chunking_strategy=auto` iff the
+  response format is `diarized_json` (keyed to the negotiation, not to a
+  vendor name — generic layer stays vendor-agnostic; OpenRouter never
+  receives it since it has no diarize models). Validated test-first:
+  `generic.TestTranscribe_DiarizedModel` asserts the field (failed before the
+  fix, passes after) and `TestTranscribe_VerboseJSON` pins its absence for
+  non-diarize requests. Contract row updated. `make qa` → exit 0.

--- a/worklogs/2026-08-26-audio-transcription-design/phase-3-ffmpeg-split-stitch.md
+++ b/worklogs/2026-08-26-audio-transcription-design/phase-3-ffmpeg-split-stitch.md
@@ -1,0 +1,102 @@
+# Phase 3: ffmpeg split, parallel transcription, stitch
+
+**Status:** Complete
+[← README](./README.md)
+
+## Goal
+
+Transparently handle files over the 25 MB request cap by best-effort ffmpeg chunking, bounded-parallel transcription of chunks, and local timestamp-offset stitching.
+
+## Specification
+
+`internal/audio/split.go` (+ tests), orchestration layer above the phase-2 transcriber:
+
+- Size gate: files ≤ 25 MB (constant, config-overridable later) transcribe as a single request — the split path must be provably skipped.
+- Over the cap: locate `ffmpeg` **and** `ffprobe` on `PATH` through an **injected command-runner interface** (pattern: constructor takes a `runner` func/interface; production wires `exec.CommandContext`). Both are hard requirements for the split path — either missing yields the same actionable error; sub-cap files need neither.
+- Total duration comes from `ffprobe` on the input file; `segment_time = duration / ceil(size / 20 MB)` (fixed-duration chunks targeting ~20 MB each). Split via `-f segment -segment_time <s> -c copy` into a temp dir under `os.MkdirTemp`.
+- Chunk start offsets derive from the split plan (`i × segment_time`); optionally verified against `ffprobe` per-chunk durations, with a stderr warning on drift > 1 s.
+- Chunks transcribe via a bounded worker pool: `parallelism` from config (default 3), results indexed by chunk, `Offset()` applied, concatenated in order. First error cancels the rest through the existing ctx-cancel machinery.
+- stderr UX (via `ancli`): pre-flight notice `<file> is <size> (> 25 MB limit) → splitting via ffmpeg: N chunks × ~M min`; per-chunk completion lines; all on stderr only.
+- Diarize + split ⇒ stderr warning about speaker-label drift across chunks (README trade-off).
+- Temp chunk files removed on completion and on error/cancel (defer-based).
+
+## Integration contract
+
+| Scenario | Collaborators | Observable result | Required side effects | Prohibited side effects |
+| -------- | ------------- | ----------------- | --------------------- | ----------------------- |
+| 10 MB file | fake runner (must not be called), fake transcriber | single transcription call, unmodified timestamps | — | no ffmpeg/ffprobe invocation, no temp dir |
+| 60 MB file, ffmpeg+ffprobe present | fake runner serving ffprobe duration and producing 3 chunk files, fake transcriber returning per-chunk segments | stitched `[]Segment` with offsets 0 / T / 2T, in order | stderr split notice; temp dir removed | chunk results out of order; anything on stdout |
+| 60 MB file, parallelism 2 | fake transcriber recording concurrency | max 2 in-flight transcriptions observed | — | unbounded concurrency |
+| chunk 2 of 3 fails | fake transcriber erroring on index 1 | error returned; ctx cancelled for remaining chunks | temp dir removed | partial transcript returned as success |
+| diarize model + oversized file | fakes as above | stitched result | stderr drift warning | — |
+
+## Acceptance criteria
+
+- [x] All five contract rows proven with the fake runner/transcriber (no real ffmpeg in tests) — race-clean under `-race -count=3`:
+  - 10 MB bypass: `TestSplitter_SubCapBypassesSplit`
+  - 60 MB split/stitch (offsets 0/600 s/1200 s, in order, stderr notice, temp dir removed, stdout empty via pipe capture): `TestSplitter_OversizedSplitsAndStitches`
+  - parallelism 2 bound: `TestSplitter_ParallelismBounded` (atomic max-in-flight ≤ 2)
+  - chunk 2 of 3 fails: `TestSplitter_ChunkFailureCancelsSiblings` (first error propagated, siblings observe ctx cancel, temp dir removed)
+  - diarize + split warning: `TestSplitter_DiarizeWarning` (+ `TestSplitter_NoDiarizeWarningForPlainModel` negative)
+- [x] Offset math: a segment at chunk-local 00:00:05 in chunk 3 (600 s chunks) renders at 00:20:05 in final VTT. — `TestSplitter_OversizedSplitsAndStitches` asserts `00:20:05.000` in rendered VTT
+- [x] Sub-cap files bypass splitting entirely (fake runner asserts zero calls). — `TestSplitter_SubCapBypassesSplit`
+- [x] Coverage ≥ 80 %. — package `internal/audio` at 93.2 % with the splitter included
+
+## Error coverage
+
+| Failure condition | Expected outcome | Test |
+| ----------------- | ---------------- | ---- |
+| Oversized file, ffmpeg or ffprobe not on PATH | actionable error naming the missing binary and a manual split command; no request sent | `TestSplitter_MissingBinary` (both binaries, asserts `ffmpeg -i` hint + zero transcriber calls) |
+| ffmpeg/ffprobe exits non-zero | error including stderr tail; temp dir cleaned | `TestSplitter_FfmpegFails` |
+| ffmpeg produces zero chunks | explicit error (not empty-success) | `TestSplitter_ZeroChunks` |
+| transcription error mid-pool | first error propagated, siblings cancelled, cleanup ran | `TestSplitter_ChunkFailureCancelsSiblings` |
+| ctx cancelled during split | prompt abort, cleanup ran | `TestSplitter_CtxCancelledDuringSplit` (`errors.Is(err, context.Canceled)`, <2 s) |
+
+## Implementation notes
+
+**Session:** Claude, 2026-08-26. Files: `internal/audio/split.go`, split tests appended in `internal/audio/split_test.go`.
+
+Deltas from spec:
+
+- **Status output goes to an injected `io.Writer` (default `os.Stderr`), not through ancli print functions.** ancli's notice/warn/ok printers write to *stdout* (and under `SetupSlog` everything below error level routes to stdout via the slog handler), which would break the pipes-stay-clean invariant. The splitter uses `ancli.ColoredMessage` for formatting (gated on `ancli.UseColor`) but writes lines itself. The injected writer also makes stderr UX assertable in tests.
+- **`NewSplitter(transcriber, runner)` constructor** with exported tuning fields (`Parallelism`, `MaxBytes`, `Model`, `StatusOut`); `ExecRunner` is the production `CommandRunner` (covered by `TestExecRunner` against real `sh`).
+- **Drift verification warns once** (first chunk over 1 s drift) rather than per chunk, and skips silently if a chunk probe fails — verification is best-effort per spec. `TestSplitter_ChunkDriftWarning` proves the warning path.
+- **Sparse files** (`f.Truncate(60<<20)`) provide oversized inputs in tests without writing real megabytes.
+- Phase-1 package doc ("pure functions only") updated: the split orchestration now lives in `internal/audio` per this phase's spec; HTTP remains excluded.
+
+Verification (all green):
+
+- `go test ./internal/audio/ -race -cover -count=3 -timeout=30s` → ok, **93.2 %** coverage
+- `make qa` → exit 0; dupl reports zero clones in `internal/audio`
+
+## Review findings (review 1, 2026-08-26)
+
+Verified good (traced through every branch, not from the notes):
+
+- All five integration-contract rows and five error rows re-read in
+  `split_test.go`; the fakes are honest (atomic max-in-flight for the
+  parallelism bound, timing-bounded sibling-cancel proof, stdout captured via
+  `os.Pipe` and asserted empty, temp-dir removal stat-asserted on success,
+  chunk-failure, and ffmpeg-failure paths).
+- Temp-dir invariant holds on every path: `defer os.RemoveAll(tempDir)` is
+  installed immediately after `MkdirTemp` at `split.go:147`, before any branch
+  can return.
+- ctx-cancel machinery holds: `Run` gets the pool/parent ctx everywhere,
+  workers blocked on the semaphore observe `poolCtx.Done()`, first error wins
+  under `errMu`, and external cancellation with no chunk error is still
+  surfaced via the `ctx.Err()` check at `split.go:267`.
+- Offset math verified: `i × segmentTime` through `secondsToDuration` (ms
+  rounding) matches the phase-1 fixture precision; in-order stitch guaranteed
+  by index-addressed `results[i]`.
+
+Findings:
+
+- [ ] **R1-02 (Minor, logged — does not reopen)** — inputs needing ≥1000
+  chunks stitch out of order silently. The pattern `chunk_%03d`
+  (`split.go:176`) grows to 4 digits at chunk 1000 and `filepath.Glob`'s
+  lexical sort (`split.go:190`) orders `chunk_1000` before `chunk_999`; both
+  segment order and the `i × segmentTime` offsets then misalign. Requires a
+  ~20 GB input at the 20 MB chunk target, so practically unreachable for the
+  meeting-recording use case — but the failure would be silent. Cheap
+  hardening if ever touched: widen the pattern (`%06d`) or sort numerically
+  after globbing.

--- a/worklogs/2026-08-26-audio-transcription-design/phase-4-mode-wiring.md
+++ b/worklogs/2026-08-26-audio-transcription-design/phase-4-mode-wiring.md
@@ -1,0 +1,168 @@
+# Phase 4: Mode wiring — subcommand, config, flags, routing
+
+**Status:** Complete
+[← README](./README.md)
+
+## Goal
+
+Make `clai audio transcribe <file>` (alias `a t`) a first-class mode: config file, flag overrides, querier creation, and usage text.
+
+## Specification
+
+- **Command parsing** (`internal/setup.go` / `getCmdFromArgs`): new mode `AUDIO` with verb subcommands, chat-style — `audio transcribe <file>` and aliases `a t`. Unknown verb under `audio` prints namespace help and errs. `audio help` lists verbs.
+- **Config**: `audioConfig.json` in the config dir, loaded via `LoadConfigFromFile`, registered so `clai confdir`/setup discover it:
+
+  ```json
+  {
+    "transcribe": {
+      "model": "whisper-1",
+      "output-format": "vtt",
+      "parallelism": 3
+    }
+  }
+  ```
+
+- **Flag overrides** (photo/video style, applied in `applyFlagOverridesForAudio`): `-am/-audio-model`, `-af/-audio-format` (validated via phase-1 `ParseOutputFormat`), `-parallelism`. `-r/-raw` continues to mean no glow/animation (transcript printing is already raw by nature; flag accepted, no-op beyond suppressing any stderr animation).
+- **Input resolution**: positional file path required; `-` reads audio bytes from stdin into a temp file (scriptability) whose extension is sniffed from the container magic bytes (extensions are part of the transcription contract — README strategy, R1-01); unrecognized container errs pre-flight listing recognized formats. Missing/nonexistent path errs before querier creation.
+- **Querier routing** (`internal/create_queriers.go`, `CreateAudioQuerier`): explicit prefix routing per README strategy — `or:` → openrouter transcriber; model containing `whisper` or `transcribe` → openai; model `test`/`mock_test` → mock transcriber (mirrors text mock path) enabling e2e tests without network. Unmatched model → error listing supported routes.
+- **Querier** implements `models.Querier` (`Query(ctx) error`): resolves size gate → phase-3 orchestration or phase-2 direct call → phase-1 render → stdout write.
+- **Usage text** in `main.go` gains the `a|audio t|transcribe <file>` command row and the new flags (final wording pass happens in phase 6).
+- **E2E**: `main_audio_e2e_test.go` following existing `main_*_e2e_test.go` conventions, using the mock model.
+
+## Integration contract
+
+| Scenario | Collaborators | Observable result | Required side effects | Prohibited side effects |
+| -------- | ------------- | ----------------- | --------------------- | ----------------------- |
+| `clai audio transcribe f.wav` (mock model) | mock transcriber, temp config dir | rendered VTT on stdout, exit 0 | — | status text on stdout |
+| `clai a t f.wav -af text` | same | plain text on stdout | — | VTT header present |
+| `clai a t f.wav -am or:openai/whisper-1` | routing unit test | openrouter transcriber selected | — | openai selected |
+| `clai audio` (no verb) / unknown verb | — | namespace help on stderr, non-zero exit | — | panic |
+| `cat f.wav \| clai a t -` | mock transcriber | transcript on stdout | temp file cleaned | — |
+| missing `audioConfig.json` | defaults | works with `Default` config; file created per repo convention for mode configs | — | crash |
+
+## Acceptance criteria
+
+- [x] All contract rows covered by e2e or focused unit tests (cited per row), passing `-race -count=3 -timeout=30s`:
+  - mock VTT on stdout + audioConfig.json created from defaults: `Test_goldenFile_AUDIO_transcribe_vtt`
+  - `a t -af text` alias, no VTT header: `Test_goldenFile_AUDIO_alias_and_text_format`
+  - `or:` → openrouter routing (plus openai/mock/diarize routes): `internal.TestCreateAudioQuerier_Routing`
+  - no verb / unknown verb → help on stderr, exit 1, stdout empty: `Test_goldenFile_AUDIO_namespace_help`
+  - `cat f.wav | clai a t -` transcript on stdout: `Test_goldenFile_AUDIO_stdin_dash`; temp file cleanup proven in `internal.TestResolveAudioInput` (dash subtest)
+  - missing audioConfig.json → defaults + file created: `Test_goldenFile_AUDIO_transcribe_vtt`
+- [x] Flag overrides demonstrably beat config file values (defaults → file → flags). — `Test_goldenFile_AUDIO_config_cascade` (file beats default vtt; `-af json` beats file's text) and `internal.TestApplyFlagOverridesForAudio`
+- [x] `clai help` output includes the audio command and flags. — `Test_goldenFile_AUDIO_help_includes_audio` (`a|audio`, `-am`, `-af`, `-parallelism`)
+- [x] Coverage ≥ 70 % on new wiring code. — `go tool cover -func`: `handleAudio` 100 %, `setupAudioTranscribeQuerier` 100 %, `resolveAudioInput` 85 %, `CreateAudioQuerier` 95.7 %, `TranscribeQuerier.Query` 81.2 %
+
+## Error coverage
+
+| Failure condition | Expected outcome | Test |
+| ----------------- | ---------------- | ---- |
+| Nonexistent input file | pre-flight error naming the path, non-zero exit, no querier created | `Test_goldenFile_AUDIO_missing_input_file`, `internal.TestResolveAudioInput` |
+| Invalid `-af` value | error listing valid formats | `Test_goldenFile_AUDIO_invalid_format_flag`, `internal.TestCreateAudioQuerier_Routing` (invalid format subtest) |
+| Unroutable model name | error listing supported routes/prefixes | `Test_goldenFile_AUDIO_unroutable_model`, `internal.TestCreateAudioQuerier_Routing` (unroutable subtest) |
+| Missing vendor API key | phase-2 `Setup` error surfaced with env-var name, non-zero exit | `Test_goldenFile_AUDIO_missing_api_key` |
+| Corrupt `audioConfig.json` | load error naming the file path | `Test_goldenFile_AUDIO_corrupt_config` |
+
+## Implementation notes
+
+**Session:** Claude, 2026-08-26. Files: `internal/audio/querier.go` (+test), `internal/setup_audio.go` (+test), `internal/create_queriers.go` (`CreateAudioQuerier`, +test), `internal/setup.go`, `internal/setup_flags.go`, `internal/completion.go` (+golden updates), `main.go`, `main_audio_e2e_test.go`.
+
+Deltas from spec:
+
+- **Mock transcriber returns a fixed transcript** ("mock transcription" / "of an audio file") instead of echoing the file name — the stdin `-` path uses a random temp name, so echoing would make e2e output nondeterministic. The mock still stats the file so missing inputs fail.
+- **`TranscribeQuerier` implements `SuppressCompletionNotification()`** — main.go rings the completion bell as `\a` on stdout, which would corrupt piped transcripts; the audio querier suppresses it (pipes-stay-clean invariant, not in the phase spec).
+- **Mode config schema lives in `internal/audio/querier.go`** (`Configurations`/`Default`) beside the querier, matching photo/video convention of conf-in-mode-package.
+- **`json` render gets a trailing newline appended at write time** (render itself stays newline-free per phase 1 contract).
+- **Completion registry updated** (`a`/`audio` commands, `-am/-af/-audio-model/-audio-format/-parallelism` flags) and the completion golden tests' expected lists/counts updated accordingly — repo maintenance contract, not a test cheat: the lists are the feature.
+- **`-r/-raw` needed no code**: transcript printing has no glow/animation path.
+- `audioConfig.json` added to the united config migration block in `Setup()` (created/upgraded before dispatch like the other mode configs).
+
+Verification (all green):
+
+- `go test ./internal/ ./internal/audio/ . -race -count=3 -timeout=30s` via full suite → ok
+- `make qa` → exit 0
+
+**Session:** Claude, 2026-08-26 (R1-01 fix). Files: `internal/audio/sniff.go` (+test),
+`internal/setup_audio.go`, `internal/setup_audio_test.go`, `main_audio_e2e_test.go`.
+
+- Fix implemented as pure-Go magic-byte sniffing (`audio.DetectExtension`, first
+  12 bytes) rather than the ffprobe route the finding suggested: external
+  binaries are best-effort per Strategy, and requiring ffprobe for every piped
+  sub-cap input would have violated that. All formats OpenAI accepts (wav, mp3,
+  flac, ogg, m4a, mp4, webm) are magic-sniffable; magic table validated against
+  real ffmpeg-generated files of all seven containers.
+- Unrecognized stdin bytes now fail pre-flight with the recognized-format list,
+  before any temp file exists — strictly better than the prior vendor 400,
+  since an unsniffable container was headed for rejection anyway.
+- The stdin header is sniffed before `os.CreateTemp`, so the sniff-error path
+  creates nothing to clean up; the chunk pattern and manual-split hint inherit
+  the extension with no change to `split.go`.
+- E2E stdin fixture upgraded to real RIFF/WAVE magic (the old
+  `RIFF-fake-wav-from-stdin` bytes were not a valid WAV header); new e2e
+  `Test_goldenFile_AUDIO_stdin_unrecognized_format` pins the error path.
+- New seam test `internal.TestStdinMultipartFilename` drives the resolved
+  stdin path through the real `generic.Transcriber` multipart encoder against
+  an `httptest` server and asserts the vendor-visible filename matches
+  `clai-audio-stdin-*.wav` — the boundary review 1 found untested.
+- Live reproduction of the R1-01 ffmpeg failure re-run with the fixed naming:
+  `ffmpeg -i clai-audio-stdin-12345.wav -f segment -segment_time 2.000 -c copy
+  chunk_%03d.wav` → two valid RIFF chunks (previously errored extensionless).
+- Coverage: `DetectExtension` 100 %, `resolveAudioInput` 86.2 %. `make qa` →
+  exit 0.
+
+## Review findings (review 1, 2026-08-26)
+
+Verified good (traced in the code, independently of the notes):
+
+- All six integration-contract rows and five error rows re-traced against
+  `main_audio_e2e_test.go`, `internal/setup_audio_test.go`,
+  `internal/create_queriers_audio_test.go`. The e2e stdout assertions are
+  exact-match (`FailTestIfDiff` against full golden strings), not
+  substring-lenient; the config cascade is proven in both directions
+  (file-beats-default and flag-beats-file).
+- Pipes stay clean on every path: transcript → `Out` (stdout), splitter status
+  → injected writer defaulting to stderr, completion bell suppressed via
+  `SuppressCompletionNotification`, namespace help on error → stderr with
+  empty stdout asserted.
+- The stdin temp-file cleanup runs on every branch: config-load error and
+  querier-creation error in `setupAudioTranscribeQuerier`, plus the deferred
+  call in `Query`; unit-proven for both the dash and the
+  must-not-delete-user-files cases.
+- `printHelp` format-verb count re-audited against the three new `%v`s in the
+  usage string — argument order is correct.
+
+Findings:
+
+- [x] **R1-01 (Major)** — *resolved 2026-08-26, see implementation notes
+  (R1-01 fix session): container sniffed from magic bytes, temp file named
+  `clai-audio-stdin-*.<ext>`, multipart-filename seam and ffmpeg pattern both
+  proven.* — stdin `-` input resolves to an extensionless temp
+  file (`internal/setup_audio.go:78`,
+  `os.CreateTemp("", "clai-audio-stdin-*")`), and the file extension is
+  load-bearing on both downstream sinks:
+  1. **Split path — CONFIRMED by reproduction.** `internal/audio/split.go:176`
+     builds the chunk pattern as `chunk_%03d` + `filepath.Ext(filePath)`; for
+     the stdin temp file the extension is empty and ffmpeg's segment muxer
+     cannot infer the per-chunk container. Reproduced (ffmpeg 7.x): the exact
+     command the splitter issues, `ffmpeg -v error -i clai-audio-stdin-12345
+     -f segment -segment_time 2.000 -c copy chunks/chunk_%03d`, fails with
+     `Output file does not contain any stream` / `Error opening output file`;
+     the identical command with `.wav` appended to the pattern succeeds. So
+     any piped input over 25 MB hard-fails. The manual-split hint at
+     `split.go:127` also renders with an empty extension in this mode.
+  2. **Vendor request — PLAUSIBLE, boundary untested.**
+     `internal/audio/generic/transcriber.go:125` names the multipart file part
+     `filepath.Base(file.Name())`. OpenAI validates upload format from that
+     filename's extension, so `clai-audio-stdin-123456` is expected to be
+     rejected (400, invalid/unsupported file format) even under the size cap.
+     Every `-` test runs against the mock, which stats the file and ignores
+     its name — the mock passes on both sides of this severed seam.
+
+  **Failure scenario:** `cat meeting.wav | clai a t -` with a real API key →
+  vendor 400 (sub-cap) or ffmpeg split error (over-cap), despite the
+  integration-contract row and the usage text advertising exactly this flow.
+
+  **Fix:** give the stdin temp file a real extension (sniff the container via
+  ffprobe when available, or accept a format hint), ensure the chunk pattern
+  and the manual-split hint inherit it, and add a test asserting the multipart
+  filename sent for stdin input carries a recognized audio extension.

--- a/worklogs/2026-08-26-audio-transcription-design/phase-5-audio-transcribe-tool.md
+++ b/worklogs/2026-08-26-audio-transcription-design/phase-5-audio-transcribe-tool.md
@@ -1,0 +1,89 @@
+# Phase 5: `audio_transcribe` built-in tool
+
+**Status:** Complete
+[← README](./README.md)
+
+## Goal
+
+Expose the transcription engine as the built-in tool `audio_transcribe` so a model can transcribe files mid-query — the first consumer of the mode-as-tool bridge.
+
+## Specification
+
+- Register `audio_transcribe` in the built-in tool registry (`internal/tools/`, following the existing built-in tool pattern; see `tooling.md`). Listed by `clai tools`, detail view prints its JSON schema, selectable via `-t audio_transcribe` and included in `-t "*"`.
+- Tool schema (illustrative sketch — encode it in the actual `internal/tools` schema types, matching how existing built-ins declare required fields and enums):
+
+  ```json
+  {
+    "name": "audio_transcribe",
+    "description": "Transcribe a local audio file to text. Returns the transcript; timestamps and speaker labels included for formats that carry them.",
+    "input": {
+      "file_path": {"type": "string", "required": true},
+      "output_format": {"type": "string", "enum": ["text", "vtt", "srt", "json"], "default": "text"}
+    }
+  }
+  ```
+
+  Tool default is `text` (model context rarely wants VTT framing), unlike the subcommand's `vtt` default — deliberate divergence, documented in the description.
+- Executor is a **thin adapter**: loads `audioConfig.json` (model/parallelism from user config), builds the same querier path as phase 4 (size gate → split → transcribe → render), returns the rendered string as the tool result. No transcription logic in the tool layer — the bridge principle from README decision 3.
+- stderr progress lines from phase 3 still go to stderr during tool execution (visible to the user, not injected into model context).
+- Errors return as tool-result errors (standard tool error surface), not process exits.
+- Respects existing tool-call budget flags (`-mtc`); nothing special-cased.
+
+## Integration contract
+
+| Scenario | Collaborators | Observable result | Required side effects | Prohibited side effects |
+| -------- | ------------- | ----------------- | --------------------- | ----------------------- |
+| tool call `{file_path: f.wav}` (mock transcriber via test model config) | tool executor, mock engine | tool result contains transcript text | — | transcript on process stdout |
+| `{file_path: f.wav, output_format: "vtt"}` | same | result begins `WEBVTT` | — | — |
+| `clai tools` listing | registry | `audio_transcribe` row present; detail prints schema | — | — |
+| `-t website_text` (tool not selected) | allow-list | `audio_transcribe` not offered to model | — | tool invocable anyway |
+
+## Acceptance criteria
+
+- [x] Contract rows proven via the existing tooling test harness (cf. `main_tooling_*_e2e_test.go` patterns), race-clean:
+  - transcript in tool result, not raw on stdout; tool default `text` beats config `vtt`: `Test_e2e_audio_transcribe_tool_returns_transcript`
+  - `output_format: vtt` → `WEBVTT`: `Test_e2e_audio_transcribe_tool_vtt_format`
+  - `clai tools` row + detail schema: `Test_e2e_audio_transcribe_tool_listing`
+  - `-t website_text` → tool not offered/invoked: `Test_e2e_audio_transcribe_tool_not_selected`
+- [x] Adapter contains no parsing/rendering/splitting logic. — `pkg/tools/audio_tool_transcribe.go` only validates input types and delegates to the injected `AudioTranscribeEngine`; the engine (`internal/create_queriers.go audioTranscribeEngine`) wires config → `createAudioSplitter` → `Render`, all logic in phases 1–3 code.
+- [x] Tool result for a diarized fixture retains speaker prefixes in `text` format. — `Test_e2e_audio_transcribe_tool_diarized_text_keeps_speakers` (`A: mock transcription` via `test-diarize` mock model)
+- [x] Coverage ≥ 70 % on the adapter. — `AudioTranscribeTool.Call`/`Specification` 100 % (`pkg/tools` unit tests); engine 80 % via e2e
+
+## Error coverage
+
+| Failure condition | Expected outcome | Test |
+| ----------------- | ---------------- | ---- |
+| `file_path` missing from input | schema/validation error returned to model | `pkg/tools TestAudioTranscribe_Call` (missing/non-string subtests) |
+| File does not exist | tool-result error naming the path; query loop continues | `Test_e2e_audio_transcribe_tool_errors_keep_query_alive` (missing file: exit 0, path in output) |
+| Invalid `output_format` | tool-result error listing valid values | `Test_e2e_audio_transcribe_tool_errors_keep_query_alive` (yaml → valid formats listed, exit 0) |
+| Engine failure (vendor 500 via mock) | tool-result error with cause; no process exit | `Test_e2e_audio_transcribe_tool_errors_keep_query_alive` (unroutable model → cause in output, exit 0); `TestAudioTranscribe_Call` (engine error propagation) |
+
+## Implementation notes
+
+**Session:** Claude, 2026-08-26. Files: `pkg/tools/audio_tool_transcribe.go` (+test), `internal/tools/handler.go` (registration), `internal/create_queriers.go` (`createAudioSplitter` extraction + `audioTranscribeEngine` + `init` wiring), `internal/audio/querier.go` (mock diarize), `internal/vendors/mock.go` (`audio_transcribe` inputs), `main_tooling_audio_e2e_test.go`.
+
+Deltas from spec:
+
+- **Injected engine seam:** `pkg/tools` deliberately imports nothing outside `pkg/text/models` (repo layering), so the tool declares `var AudioTranscribeEngine func(filePath, outputFormat string) (string, error)` and package `internal` wires it in an `init()` in `create_queriers.go`. Unwired (e.g. external `pkg/tools` consumers) yields a clear tool error, never a panic.
+- **Routing extracted, not duplicated:** phase 4's `CreateAudioQuerier` was refactored to share `createAudioSplitter` with the engine, keeping the phase-4 spec's "routing in create_queriers.go" true for both consumers.
+- **Mock extended for diarization:** routing now mock-matches on `test`/`mock_test` *prefixes*; a model containing `diarize` (e.g. `test-diarize`) sets `MockTranscriber.Diarized`, which adds `A`/`B` speakers — needed to prove the speaker-prefix acceptance criterion without live keys.
+- **No ctx in the tool interface** (`LLMTool.Call(Input)`): the engine uses `context.Background()`, same as other exec-backed built-ins.
+- Mock vendor gained an `audio_transcribe` case in `inputsForTool` driven by `CLAI_MOCK_AUDIO_TRANSCRIBE_FILE`/`_FORMAT`, following the existing `CLAI_MOCK_*` convention.
+
+Verification (all green):
+
+- `go test ./pkg/tools/ . ./internal/... -race -count=3 -timeout=30s` via full suite → ok
+- `make qa` → exit 0; adapter functions 100 % covered, engine 80 %
+
+## Review findings (review 1, 2026-08-26)
+
+No findings in this phase's own code. Verified good: the adapter
+(`pkg/tools/audio_tool_transcribe.go`) truly contains no engine logic — input
+type checks and delegation only, with a clear error when the engine is
+unwired; the injected-seam wiring (`init` in `create_queriers.go`) keeps
+`pkg/tools` free of internal imports; all four contract rows and four error
+rows are honestly proven in `main_tooling_audio_e2e_test.go` (including
+tool-default-`text`-beats-config-`vtt` and errors-keep-query-alive with exit
+0 asserted). Note: the tool inherits **R1-01** (phase 4) only through the
+engine for extensionless paths a model might pass; no separate fix needed
+here.

--- a/worklogs/2026-08-26-audio-transcription-design/phase-6-docs-and-quality-gates.md
+++ b/worklogs/2026-08-26-audio-transcription-design/phase-6-docs-and-quality-gates.md
@@ -1,0 +1,95 @@
+# Phase 6: Documentation and quality-gate sweep
+
+**Status:** Complete
+[← README](./README.md)
+
+## Goal
+
+Complete the repository's maintenance contracts (architecture doc, usage text, examples) and prove the whole change passes every QA gate.
+
+## Specification
+
+- **`architecture/audio.md`** in the style of `photo.md`/`video.md`: entry flow, key-files table, `audioConfig.json` reference, flag-override table, response-format negotiation, split/stitch behavior, tool bridge note. Add row to `architecture/README.md` index (Command docs section).
+- **`main.go` usage**: final wording for the `a|audio t|transcribe` command row and `-am/-af/-parallelism` flags; add one example line (piped meeting-notes flow).
+- **`examples.md` / README.md**: add the transcription pipe example if the files' conventions call for it (check both; additive only).
+- **Setup wizard**: verify `clai setup` lists/edits `audioConfig.json`; wire it if phase 4 did not.
+- **Docs accuracy check**: every path and flag named in `architecture/audio.md` must exist in the code (reviewer-checkable).
+- **Quality-gate sweep** (record exact commands + outcomes in implementation notes):
+
+  ```bash
+  go run mvdan.cc/gofumpt@latest -w -l .
+  go run honnef.co/go/tools/cmd/staticcheck@latest ./...
+  go vet ./...
+  go test ./... -race -cover -count=3 -timeout=30s
+  go fix ./...
+  go run github.com/mibk/dupl@latest -t 80 .
+  # or: make qa
+  ```
+
+  Dupl findings triaged per repo duplication policy (signal, not verdict) — each accepted clone justified in the notes.
+- **Coverage audit**: per-package coverage for all new packages recorded; every package ≥ 70 %, target 90 % for `internal/audio/`.
+
+## Integration contract
+
+`unit-test-only` — this phase adds documentation and runs gates; its "tests" are the gate commands themselves plus doc-accuracy review.
+
+## Acceptance criteria
+
+- [x] `make qa` passes clean, unedited, on the branch tip (command output cited). — exit 0, 39 `ok` package lines, no FAIL (see implementation notes)
+- [x] `architecture/audio.md` exists, indexed in `architecture/README.md`, and names only real paths/flags. — every file in the key-files table exists on disk; flags match `parseFlags`
+- [x] `clai help` (usage string) and the architecture doc agree on flags and command spelling. — both say `a|audio t|transcribe <file>`, `-am/-audio-model`, `-af/-audio-format`, `-parallelism`; asserted by `Test_goldenFile_AUDIO_help_includes_audio`
+- [x] Coverage table recorded in implementation notes; all new packages ≥ 70 %. — `internal/audio` 91.6 %, `internal/audio/generic` 81.2 %
+- [x] Worklog status board fully `Complete` (phases 1–5) before this phase closes. — board shows phases 1–5 Complete
+
+## Error coverage
+
+| Failure condition | Expected outcome | Test |
+| ----------------- | ---------------- | ---- |
+| Any QA gate fails | phase stays incomplete; failure recorded in notes and the owning phase reopened | `make qa` exit 0 — no gate failed |
+| Coverage below 70 % on a new package | owning phase reopened with a Major finding | all new packages ≥ 81 % — not triggered |
+
+## Implementation notes
+
+**Session:** Claude, 2026-08-26. Files: `architecture/audio.md` (new), `architecture/README.md` (index row), `examples.md` (audio section), `main.go` (piped meeting-notes example line), `internal/setup/setup.go` + `internal/setup/setup_actions.go` (audioConfig excluded from the wizard's "model files" glob).
+
+Deltas / findings:
+
+- **Setup wizard was half-wired by phase 4:** the "general config" category globs `*Config.json`, so `audioConfig.json` was already listed and editable via `clai setup` with no change. But the "model files" category globs `*.json` with an exclude-contains list — without adding `"audioConfig"` there, the wizard would have mislisted `audioConfig.json` as a vendor model-price file. Both exclusion lists updated (`setup.go:193`, `setup_actions.go:709`).
+- Usage command row and flags were already added in phase 4; this phase added only the pipe example line.
+- README.md needed no change: its conventions cover vendors/API keys, not per-command examples — the audio vendors (OpenAI, OpenRouter) are already in its table.
+
+Quality-gate sweep (branch tip, 2026-08-26):
+
+| Command | Outcome |
+| --- | --- |
+| `make qa` (gofumpt -w -l, staticcheck, go vet, `go test ./... -race -cover -count=3 -timeout=30s`, go fix, dupl -t 80) | exit 0; 39 packages `ok`, no FAIL |
+| `go run github.com/mibk/dupl@latest -t 80 .` | zero clones in any audio-related file; remaining clones are pre-existing (pi/gemini/berget/novita test scaffolds, setup_actions) and untouched by this effort |
+
+Coverage audit (new code):
+
+| Package / unit | Coverage |
+| --- | --- |
+| `internal/audio` | 91.6 % (target 90 % met) |
+| `internal/audio/generic` | 81.2 % |
+| `internal/vendors/openai/transcribe.go`, `openrouter/transcribe.go` | 100 % per `go tool cover -func` |
+| `pkg/tools/audio_tool_transcribe.go` (`Call`/`Specification`) | 100 % |
+| phase-4 wiring (`handleAudio`, `setupAudioTranscribeQuerier`, `resolveAudioInput`, `CreateAudioQuerier`) | 81–100 % per function |
+| `audioTranscribeEngine` | 80 % |
+
+## Review findings (review 1, 2026-08-26)
+
+No findings against this phase's contract. Verified good: `make qa` re-run
+independently on the branch tip → exit 0 (review 1; 38 `ok` package lines of
+40 packages, 2 with no test files — the notes above say 39, a trivial
+counting discrepancy, no package failed); `architecture/audio.md` re-audited
+against the code — every key-file path exists, the flag table matches
+`parseFlags`, and the routing/negotiation sections match
+`create_queriers.go`/`transcriber.go`; coverage figures reproduced
+(internal/audio 91.6 %, generic 81.2 %).
+
+One doc consequence of **R1-01** (phase 4): `architecture/audio.md` and the
+usage text advertise `-` stdin input without noting it currently breaks real
+transcription for extensionless temp input — update the doc when R1-01 is
+fixed. The board's "all phases Complete" claim is superseded: phase 4 is
+Reopened (review 1), so this phase's final acceptance box ("status board fully
+Complete") no longer holds until R1-01 closes.


### PR DESCRIPTION
I'm setting up an automatic meeting notes system. So first step is recording the audio, then I use clai to pass the audio into some transcriber, then I use clai chat functionality to potentially append context + summarize + look at details, lastly the same agent persists the meeting into durable storage via slivnigdoc.

Pretty neat system, if I may say so myself! And I never need to type again.

This transcribation system can ofc also be used like:
```
record-voice | clai audio transcribe | clai query
```

(and a few tweaks and profiles, ofc) to get voice to command functionality